### PR TITLE
Fix CMakeLists to remove cyclic dependency for geoclaw

### DIFF
--- a/src/solvers/fc2d_geoclaw/CMakeLists.txt
+++ b/src/solvers/fc2d_geoclaw/CMakeLists.txt
@@ -50,7 +50,6 @@ add_library(geoclaw_f OBJECT
 )
 
 target_link_Libraries(geoclaw_f PRIVATE 
-    FORESTCLAW::GEOCLAW
     clawpatch
 )
 


### PR DESCRIPTION
Removed a cyclic dependency in one of the CMakeLists.txt