### PR TITLE
(clawpack/apps) Fix common blocks so all declarations are consistent

### DIFF
--- a/applications/clawpack/acoustics/2d/radial/setprob.f
+++ b/applications/clawpack/acoustics/2d/radial/setprob.f
@@ -4,10 +4,11 @@
       double precision rho, bulk, cc, zz
       common /cparam/ rho,bulk,cc,zz
 
-      double precision pi
-      common /compi/ pi
+      double precision pi, pi2
+      common /compi/ pi, pi2
 
       pi = 4.d0*atan(1.d0)
+      pi2 = 2*pi
 
       open(10,file='setprob.data')
       read(10,*) rho

--- a/applications/clawpack/advection/2d/annulus/fdisc.f
+++ b/applications/clawpack/advection/2d/annulus/fdisc.f
@@ -4,14 +4,17 @@
       double precision xc,yc
       integer blockno
 
-      double precision pi
-      common /compi/ pi
+      double precision pi, pi2
+      common /compi/ pi, pi2
 
       integer*8 cont, get_context
       double precision xp, yp, zp
       double precision th, tp
 
       cont = get_context()
+
+      pi = 4.0*atan(1.0)
+      pi2 = 2*pi
 
       call fclaw2d_map_c2m(cont,
      &      blockno,xc,yc,xp,yp,zp)

--- a/applications/clawpack/advection/2d/annulus/regression.ini
+++ b/applications/clawpack/advection/2d/annulus/regression.ini
@@ -2,7 +2,7 @@
 # A periodic example that uses [ax,bx]x[ay,by]
 # -----------------------------------------------------------
 [user]
-     example = 0          # 0 = cubedsphere; 1 = pillowsphere
+     example = 0          
      revs-per-second = 0.5     # Rigid body rotation
      claw-version = 4
 

--- a/applications/clawpack/advection/2d/disk/psi.f
+++ b/applications/clawpack/advection/2d/disk/psi.f
@@ -1,8 +1,10 @@
       double precision function psi(x,y,z)
       implicit none
 
-      double precision x,y,z,pi,r
-      common /compi/ pi
+      double precision x,y,z,r
+
+      double precision pi, pi2
+      common /compi/ pi, pi2
 
 c      psi = ((sin(pi*x))**2 * (sin(pi*y))**2) / pi
 

--- a/applications/clawpack/advection/2d/disk/setprob.f
+++ b/applications/clawpack/advection/2d/disk/setprob.f
@@ -1,10 +1,11 @@
       subroutine setprob()
       implicit none
 
-      double precision pi
-      common /compi/ pi
+      double precision pi, pi2
+      common /compi/ pi, pi2
 
       pi = 4.d0*atan(1.d0)
+      pi2 = 2.0*pi
 
 
       end

--- a/applications/clawpack/advection/2d/filament/psi.f
+++ b/applications/clawpack/advection/2d/filament/psi.f
@@ -1,8 +1,10 @@
-      double precision function psi(x,y,z)
+      double precision function psi(x,y)
       implicit none
 
-      double precision x,y,z,pi,r
-      common /compi/ pi
+      double precision x,y,r
+
+      double precision pi, pi2
+      common /compi/ pi, pi2
 
 c      psi = ((sin(pi*x))**2 * (sin(pi*y))**2) / pi
 
@@ -24,7 +26,7 @@ c      psi = x + y
 
       double precision xd1(3),xd2(3), ds, vn, psi,t
 
-      vn = (psi(xd1(1),xd1(2),xd1(3)) -
-     &      psi(xd2(1),xd2(2),xd2(3)))/ds
+      vn = (psi(xd1(1),xd1(2)) -
+     &      psi(xd2(1),xd2(2)))/ds
 
       end

--- a/applications/clawpack/advection/2d/filament/setprob.f
+++ b/applications/clawpack/advection/2d/filament/setprob.f
@@ -1,10 +1,11 @@
       subroutine setprob
       implicit none
 
-      double precision pi
-      common /compi/ pi
+      double precision pi, pi2
+      common /compi/ pi, pi2
 
       pi = 4.d0*atan(1.d0)
+      pi2 = 2*pi
 
 
       end

--- a/applications/clawpack/advection/2d/hemisphere/psi.f
+++ b/applications/clawpack/advection/2d/hemisphere/psi.f
@@ -2,14 +2,12 @@
       implicit none
 
       double precision xp,yp,zp,t
-      double precision pi2, revs_per_second
+      double precision revs_per_second
 
-      double precision pi
-      common /compi/ pi
+      double precision pi, pi2
+      common /compi/ pi, pi2
 
       common /spherecomm/ revs_per_second
-
-      pi2 = 2*pi
 
 c     # Solid body rotation
       psi = pi2*revs_per_second*zp

--- a/applications/clawpack/advection/2d/hemisphere/setprob.f
+++ b/applications/clawpack/advection/2d/hemisphere/setprob.f
@@ -1,13 +1,14 @@
       subroutine setprob()
       implicit none
 
-      double precision pi
-      common /compi/ pi
+      double precision pi, pi2
+      common /compi/ pi, pi2
 
       double precision revs_per_second
       common /spherecomm/ revs_per_second
 
       pi = 4.d0*atan(1.d0)
+      pi2 = 2*pi
 
       revs_per_second = 0.5d0
 

--- a/applications/clawpack/advection/2d/latlong/fdisc.f
+++ b/applications/clawpack/advection/2d/latlong/fdisc.f
@@ -6,8 +6,8 @@
       integer*8 cont, get_context
       double precision th, tp
 
-      double precision pi
-      common /compi/ pi
+      double precision pi, pi2
+      common /compi/ pi, pi2
 
       cont = get_context()
 

--- a/applications/clawpack/advection/2d/latlong/psi.f
+++ b/applications/clawpack/advection/2d/latlong/psi.f
@@ -2,14 +2,12 @@
       implicit none
 
       double precision xp,yp,zp,t
-      double precision pi2, revs_per_s
+      double precision revs_per_s
 
-      double precision pi
-      common /compi/ pi
+      double precision pi, pi2
+      common /compi/ pi, pi2
 
       revs_per_s = 0.5d0
-
-      pi2 = 2*pi
 
       psi = pi2*revs_per_s*zp
 

--- a/applications/clawpack/advection/2d/latlong/setprob.f
+++ b/applications/clawpack/advection/2d/latlong/setprob.f
@@ -1,9 +1,10 @@
       subroutine setprob()
       implicit none
 
-      double precision pi
-      common /compi/ pi
+      double precision pi, pi2
+      common /compi/ pi, pi2
 
       pi = 4.d0*atan(1.d0)
+      pi2 = 2.0*pi
 
       end

--- a/applications/clawpack/advection/2d/sphere/fdisc.f
+++ b/applications/clawpack/advection/2d/sphere/fdisc.f
@@ -5,8 +5,8 @@
       integer blockno
       integer*8 cont, get_context
 
-      double precision pi
-      common /compi/ pi
+      double precision pi, pi2
+      common /compi/ pi, pi2
 
       cont = get_context()
 

--- a/applications/clawpack/advection/2d/sphere/psi.f
+++ b/applications/clawpack/advection/2d/sphere/psi.f
@@ -2,14 +2,12 @@
       implicit none
 
       double precision xp,yp,zp,t
-      double precision pi2, revs_per_second
+      double precision revs_per_second
 
-      double precision pi
-      common /compi/ pi
+      double precision pi, pi2
+      common /compi/ pi, pi2
 
       common /spherecomm/ revs_per_second
-
-      pi2 = 2*pi
 
 c     # Solid body rotation
       psi = pi2*revs_per_second*zp

--- a/applications/clawpack/advection/2d/swirl/psi.f
+++ b/applications/clawpack/advection/2d/swirl/psi.f
@@ -1,8 +1,10 @@
       double precision function psi(xp,yp)
       implicit none
 
-      double precision xp,yp,pi
-      common /compi/ pi
+      double precision xp,yp
+
+      double precision pi, pi2
+      common /compi/ pi, pi2
 
       psi = ((sin(pi*xp))**2 * (sin(pi*yp))**2) / pi
 

--- a/applications/clawpack/shallow/2d/rp/clawpack46_rpt2.f
+++ b/applications/clawpack/shallow/2d/rp/clawpack46_rpt2.f
@@ -21,8 +21,8 @@ c
       common /cparam/  grav    !# gravitational parameter
       dimension waveb(3,3),sb(3)
       parameter (maxm2 = 603)  !# assumes at most 600x600 grid with mbc=3
-      common /comroe/ u(-2:maxm2),v(-2:maxm2),a(-2:maxm2),hl(-2:maxm2),
-     &                hr(-2:maxm2)
+      double precision, dimension(-2:maxm2) :: u,v,a,h
+      common /comroe/ u,v,a,h
 c
       if (-2.gt.1-mbc .or. maxm2 .lt. maxm+mbc) then
           write(6,*) 'need to increase maxm2 in rpB'

--- a/src/mappings/cubedsphere/mapc2m_cubedsphere.f
+++ b/src/mappings/cubedsphere/mapc2m_cubedsphere.f
@@ -28,9 +28,10 @@
 
       double precision xc,yc,xp,yp,zp
       double precision R, tan_xi, tan_eta
-      double precision pi
 
-      common /compi/ pi
+      
+      double precision pi, pi2
+      common /compi/ pi, pi2
 
       R = 1.d0
       tan_xi = tan(0.5d0*pi*(xc-0.5d0))

--- a/src/mappings/latlong/mapc2m_latlong.f
+++ b/src/mappings/latlong/mapc2m_latlong.f
@@ -4,9 +4,10 @@ c     # [xc,yc] are in [-180,180]x[0,360]
 
       integer blockno
       double precision xc,yc,xp,yp,zp
-      double precision pi, deg2rad,xc1,yc1
+      double precision deg2rad,xc1,yc1
 
-      common /compi/ pi
+      double precision pi, pi2
+      common /compi/ pi, pi2
 
 c     # blockno is not used here;  assume that [xc,yc] is
 c     # in a box [long0, long1]x[lat0,lat1], in

--- a/src/mappings/pillowsphere/mapc2m_pillowsphere.f
+++ b/src/mappings/pillowsphere/mapc2m_pillowsphere.f
@@ -10,6 +10,7 @@ c     # ------------------------------------------------------------------
       subroutine mapc2m_pillowsphere(blockno, xc1,yc1,xp,yp,zp)
       implicit none
 
+      external mapc2m_cart
       double precision xc1,yc1, xp, yp, zp
 
       double precision x1, y1, d, rp2, xc, yc, zc
@@ -75,8 +76,8 @@ c     #
       double precision xi,eta,x,y, minxy,maxxy
       double precision xit, etat, dd
 
-      double precision pi
-      common /compi/ pi
+      double precision pi, pi2
+      common /compi/ pi, pi2
 
       xc = x1
       yc = y1

--- a/src/mappings/squareddisk/mapc2m_squareddisk.f
+++ b/src/mappings/squareddisk/mapc2m_squareddisk.f
@@ -10,11 +10,9 @@ c     # -------------------------------------------------------
       double precision alpha
       integer blockno
       double precision xc1, yc1
-      double precision pi
 
-      common /compi/ pi
-
-      pi = 4.d0*atan(1.d0)
+      double precision pi, pi2
+      common /compi/ pi, pi2
 
       if (blockno .eq. 2) then
          xp = (2*xc - 1)*alpha/sqrt(2.d0);
@@ -54,9 +52,9 @@ c     # -------------------------------------------------------
       double precision alpha
       double precision R, tau, xi_prime
 
-      double precision pi
+      double precision pi, pi2
 
-      common /compi/ pi
+      common /compi/ pi, pi2
 
 c     # Original R - might be smoother
       R = alpha**(1-eta)

--- a/src/mappings/torus/mapc2m_twisted_torus.f
+++ b/src/mappings/torus/mapc2m_twisted_torus.f
@@ -6,10 +6,7 @@
       double precision alpha, r
 
       double precision pi, pi2
-
-      common /compi/ pi
-
-      pi2 = 2*pi
+      common /compi/ pi, pi2
 
       r = 1.d0 + alpha*cos(pi2*(yc + xc))
 


### PR DESCRIPTION
Fixed numerous places where  I defined 

```
double precision pi, pi2
common /compi/ pi, pi2
```

in one file, but then only referenced 

````
double precision pi
common /compi/ pi 
```
in another file, when `pi2` was not needed.   It seems that that latest versions of `gfortran` pick this up.  