### PR TITLE
Cuda fixes for cmake and automake

### DIFF
--- a/.github/workflows/ci_automake.yml
+++ b/.github/workflows/ci_automake.yml
@@ -27,10 +27,15 @@ jobs:
         - name: "Serial With GeoClaw"
           configure_flags: "--enable-geoclaw"
           ubuntu_packages: ""
-        - name: "Serial With CudaClaw"
+        - name: "Serial With CudaClaw (CUDA 10.1)"
           configure_flags: "CUDA_CFLAGS=\"-arch=sm_61\" LIBS=\"-lcuda -lcudart -lnvToolsExt\" --enable-cudaclaw --disable-shared"
           ubuntu_packages: "nvidia-cuda-toolkit"
           cuda: true
+        - name: "Serial With CudaClaw (CUDA 11.3)"
+          configure_flags: "NVCC=/usr/local/cuda-11.3/bin/nvcc CUDA_CFLAGS=\"-arch=sm_61\" LIBS=\"-L/usr/local/cuda-11.3/lib64 -lcudart -lnvToolsExt\" --enable-cudaclaw --disable-shared"
+          ubuntu_packages: ""
+          cuda: true
+          cuda_11_3: true
         - name: "MPI Minimal"
           configure_flags: "--enable-mpi"
           ubuntu_packages: "libopenmpi-dev openmpi-bin"
@@ -40,10 +45,15 @@ jobs:
         - name: "MPI With GeoClaw"
           configure_flags: "--enable-geoclaw --enable-mpi"
           ubuntu_packages: "libopenmpi-dev openmpi-bin"
-        - name: "MPI With CudaClaw"
+        - name: "MPI With CudaClaw (CUDA 10.1)"
           configure_flags: "CUDA_CFLAGS=\"-arch=sm_61 -I/usr/lib/x86_64-linux-gnu/openmpi/include\" LIBS=\"-lcuda -lcudart -lnvToolsExt\" --enable-cudaclaw --enable-mpi --disable-shared"
           ubuntu_packages: "libopenmpi-dev openmpi-bin nvidia-cuda-toolkit"
           cuda: true
+        - name: "MPI With CudaClaw (CUDA 11.3)"
+          configure_flags: "NVCC=/usr/local/cuda-11.3/bin/nvcc CUDA_CFLAGS=\"-arch=sm_61 -I/usr/lib/x86_64-linux-gnu/openmpi/include\" LIBS=\"-L/usr/local/cuda-11.3/lib64 -lcudart -lnvToolsExt\" --enable-cudaclaw --enable-mpi --disable-shared"
+          ubuntu_packages: "libopenmpi-dev openmpi-bin"
+          cuda: true
+          cuda_11_3: true
         - name: "MPI With ThunderEgg"
           configure_flags: "--enable-mpi --enable-thunderegg --with-thunderegg=$GITHUB_WORKSPACE/ThunderEgg"
           ubuntu_packages: "cmake libopenmpi-dev openmpi-bin libfftw3-dev"
@@ -67,6 +77,16 @@ jobs:
         sudo apt-get update
         sudo apt-get install ${{ matrix.ubuntu_packages }}
 
+    - name: Install Cuda Toolkit 11.3
+      if: ${{ matrix.cuda_11_3 }}
+      run: |
+        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin
+        sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
+        sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub
+        sudo add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /"
+        sudo apt-get update
+        sudo apt-get -y install cuda-toolkit-11-3
+
     - name: Install ThunderEgg
       if: ${{ matrix.thunderegg }}
       run: |
@@ -84,6 +104,10 @@ jobs:
 
     - name: Configure
       run: ./configure ${{ matrix.configure_flags }}
+
+    - name: Print Configure log
+      if: ${{ failure() }}
+      run: cat config.log
 
     - name: Build
       run: make

--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -28,10 +28,16 @@ jobs:
         - name: "Serial With GeoClaw"
           configure_flags: "-Dgeoclaw=ON"
           ubuntu_packages: ""
-        - name: "Serial With CudaClaw"
+        - name: "Serial With CudaClaw (CUDA 10.1)"
           configure_flags: "-Dcudaclaw=ON"
+          ubuntu_packages: "nvidia-cuda-toolkit"
+          cuda: true
+        - name: "Serial With CudaClaw (CUDA 11.3)"
+          configure_flags: "-Dcudaclaw=ON"
+          configure_environment: "CUDACXX=/usr/local/cuda/bin/nvcc"
           ubuntu_packages: ""
           cuda: true
+          cuda_11_3: true
         - name: "MPI Minimal"
           configure_flags: "-Dmpi=ON"
           ubuntu_packages: "libopenmpi-dev openmpi-bin"
@@ -41,10 +47,16 @@ jobs:
         - name: "MPI With GeoClaw"
           configure_flags: "-Dmpi=ON -Dgeoclaw=ON"
           ubuntu_packages: "libopenmpi-dev openmpi-bin"
-        - name: "MPI With CudaClaw"
+        - name: "MPI With CudaClaw (CUDA 10.1)"
           configure_flags: "-Dmpi=ON -Dcudaclaw=ON"
+          ubuntu_packages: "libopenmpi-dev openmpi-bin nvidia-cuda-toolkit"
+          cuda: true
+        - name: "MPI With CudaClaw (CUDA 11.3)"
+          configure_flags: "-Dmpi=ON -Dcudaclaw=ON"
+          configure_environment: "CUDACXX=/usr/local/cuda/bin/nvcc"
           ubuntu_packages: "libopenmpi-dev openmpi-bin"
           cuda: true
+          cuda_11_3: true
         - name: "MPI With ThunderEgg"
           configure_flags: "-Dmpi=ON -Dthunderegg=ON"
           ubuntu_packages: "libopenmpi-dev openmpi-bin libfftw3-dev"
@@ -60,8 +72,8 @@ jobs:
         sudo apt-get install -yq --no-install-recommends \
             ninja-build ${{ matrix.ubuntu_packages }}
 
-    - name: Install Cuda Toolkit
-      if: ${{ matrix.cuda }}
+    - name: Install Cuda Toolkit 11.3
+      if: ${{ matrix.cuda_11_3 }}
       run: |
         wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin
         sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
@@ -71,7 +83,7 @@ jobs:
         sudo apt-get -y install cuda-toolkit-11-3
 
     - name: CMake configure
-      run: cmake --preset ci -DCMAKE_INSTALL_PREFIX=~ ${{ matrix.configure_flags }}
+      run: ${{ matrix.configure_environment }} cmake --preset ci -DCMAKE_INSTALL_PREFIX=~ ${{ matrix.configure_flags }}
 
     - name: CMake build
       run: cmake --build --preset ci
@@ -85,7 +97,7 @@ jobs:
       run: cmake --install build
 
     - name: CMake configure examples
-      run: cmake -B applications/build -S applications --preset ci -DFORESTCLAW_ROOT=~
+      run: ${{ matrix.configure_environment }} cmake -B applications/build -S applications --preset ci -DFORESTCLAW_ROOT=~
 
     - name: CMake build examples
       run: cmake --build applications/build

--- a/.github/workflows/ci_external_project.yml
+++ b/.github/workflows/ci_external_project.yml
@@ -33,7 +33,7 @@ jobs:
 
         - name:            "Serial With CudaClaw"
           components:      "cudaclaw"
-          ubuntu_packages: ""
+          ubuntu_packages: "nvidia-cuda-toolkit"
           cuda:            true
 
         - name:            "MPI Minimal"
@@ -50,7 +50,7 @@ jobs:
 
         - name:            "MPI With CudaClaw"
           components:      "mpi cudaclaw"
-          ubuntu_packages: "libopenmpi-dev openmpi-bin"
+          ubuntu_packages: "libopenmpi-dev openmpi-bin nvidia-cuda-toolkit"
           cuda:            true
 
         - name:            "MPI With ThunderEgg"
@@ -67,16 +67,6 @@ jobs:
         sudo apt-get update -yq
         sudo apt-get install -yq --no-install-recommends \
             ninja-build ${{ matrix.ubuntu_packages }}
-
-    - name: Install Cuda Toolkit
-      if: ${{ matrix.cuda }}
-      run: |
-        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin
-        sudo mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
-        sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub
-        sudo add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /"
-        sudo apt-get update
-        sudo apt-get -y install cuda-toolkit-11-3
 
     - name: CMake configure examples
       run: cmake -B applications/build -S applications --preset ci -DTEST_EXTERNAL_PROJECT=true -DTEST_EXTERNAL_PROJECT_COMPONENTS="${{ matrix.components }}" -DTEST_EXTERNAL_PROJECT_TAG="`git rev-parse HEAD`" -DTEST_EXTERNAL_PROJECT_REPO="`pwd`"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -14,9 +14,6 @@
   "cacheVariables": {
     "CMAKE_BUILD_TYPE": "Release",
     "CMAKE_CUDA_ARCHITECTURES": "72"
-  },
-  "environment": {
-    "CUDACXX": "/usr/local/cuda/bin/nvcc"
   }
 },
 {

--- a/applications/CMakePresets.json
+++ b/applications/CMakePresets.json
@@ -14,9 +14,6 @@
   "cacheVariables": {
     "CMAKE_BUILD_TYPE": "Release",
     "CMAKE_CUDA_ARCHITECTURES": "72"
-  },
-  "environment": {
-    "CUDACXX": "/usr/local/cuda/bin/nvcc"
   }
 },
 {

--- a/config/ax_get_cuda_version.m4
+++ b/config/ax_get_cuda_version.m4
@@ -1,0 +1,38 @@
+# ===========================================================================
+#     https://www.gnu.org/software/autoconf-archive/ax_split_version.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_GET_CUDA_VERSION
+#
+# DESCRIPTION
+#
+#   Gets the CUDA version.
+#   Sets the variables.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Tom Howard <tomhoward@users.sf.net> AX_SPLIT_VERSION
+#   Copyright (c) 2022 Scott Aiton - modified to check for cuda version
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 10
+
+AC_DEFUN([AX_GET_CUDA_VERSION],[
+    AC_REQUIRE([AC_PROG_SED])
+    AC_REQUIRE([AC_PROG_GREP])
+    CUDA_VERSION=`$NVCC --version | $GREP release | $SED 's/^.*V//'`
+    CUDA_MAJOR_VERSION=`echo "$CUDA_VERSION" | $SED 's/\([[^.]][[^.]]*\).*/\1/'`
+    CUDA_MINOR_VERSION=`echo "$CUDA_VERSION" | $SED 's/[[^.]][[^.]]*.\([[^.]][[^.]]*\).*/\1/'`
+    AC_MSG_CHECKING([CUDA version])
+    AC_MSG_RESULT([$CUDA_VERSION])
+    AC_MSG_CHECKING([CUDA Major version])
+    AC_MSG_RESULT([$CUDA_MAJOR_VERSION])
+    AC_MSG_CHECKING([CUDA Minor version])
+    AC_MSG_RESULT([$CUDA_MINOR_VERSION])
+])

--- a/configure.ac
+++ b/configure.ac
@@ -95,7 +95,14 @@ P4EST_AS_SUBPACKAGE([FCLAW])
 AM_CONDITIONAL([FCLAW_DIST_DENY], [test "x$FCLAW_DIST_DENY" != x])
 AC_SUBST([FCLAW_DISTCLEAN])
 
+echo "o---------------------------------------"
+echo "| Checking CUDA"
+echo "o---------------------------------------"
+
 AX_CHECK_CUDA()
+AX_GET_CUDA_VERSION()
+# Check version
+AM_CONDITIONAL(USE_LOCAL_CUB, [expr "$CUDA_MAJOR_VERSION" "<"  "11"])
 
 # Print summary.
 AC_DEFINE_UNQUOTED(CPP,         ["${CPP}"],         [C preprocessor])

--- a/configure.ac
+++ b/configure.ac
@@ -99,7 +99,7 @@ echo "o---------------------------------------"
 echo "| Checking CUDA"
 echo "o---------------------------------------"
 
-if [ "x$FCLAW_CUDACLAW" = "xyes" ]; then
+if [ test "x$FCLAW_CUDACLAW" = "xyes" ]; then
         # Check for CUDA
         AX_CHECK_CUDA()
         AX_GET_CUDA_VERSION()
@@ -108,7 +108,7 @@ else
         CUDA_MAJOR_VERSION="0"
 fi
 # Check version
-AC_MSG_CHECKING([Checking if local CUB library shoudl be used])
+AC_MSG_CHECKING([Checking if local CUB library should be used])
 AM_CONDITIONAL(USE_LOCAL_CUB, [expr "$CUDA_MAJOR_VERSION" "<"  "11"])
 
 # Print summary.

--- a/configure.ac
+++ b/configure.ac
@@ -99,9 +99,16 @@ echo "o---------------------------------------"
 echo "| Checking CUDA"
 echo "o---------------------------------------"
 
-AX_CHECK_CUDA()
-AX_GET_CUDA_VERSION()
+if [ "x$FCLAW_CUDACLAW" = "xyes" ]; then
+        # Check for CUDA
+        AX_CHECK_CUDA()
+        AX_GET_CUDA_VERSION()
+else
+        # Set version to 0 to avoid errors
+        CUDA_MAJOR_VERSION="0"
+fi
 # Check version
+AC_MSG_CHECKING([Checking if local CUB library shoudl be used])
 AM_CONDITIONAL(USE_LOCAL_CUB, [expr "$CUDA_MAJOR_VERSION" "<"  "11"])
 
 # Print summary.

--- a/configure.ac
+++ b/configure.ac
@@ -99,14 +99,17 @@ echo "o---------------------------------------"
 echo "| Checking CUDA"
 echo "o---------------------------------------"
 
-if [ test "x$FCLAW_CUDACLAW" = "xyes" ]; then
+AM_COND_IF([FCLAW_ENABLE_CUDACLAW],
+[
         # Check for CUDA
         AX_CHECK_CUDA()
         AX_GET_CUDA_VERSION()
-else
+
+],
+[
         # Set version to 0 to avoid errors
         CUDA_MAJOR_VERSION="0"
-fi
+])
 # Check version
 AC_MSG_CHECKING([Checking if local CUB library should be used])
 AM_CONDITIONAL(USE_LOCAL_CUB, [expr "$CUDA_MAJOR_VERSION" "<"  "11"])

--- a/src/solvers/fc2d_cudaclaw/CMakeLists.txt
+++ b/src/solvers/fc2d_cudaclaw/CMakeLists.txt
@@ -43,6 +43,10 @@ target_include_directories(cudaclaw
   $<INSTALL_INTERFACE:include>
 )
 
+if(CUDAToolkit_VERSION_MAJOR LESS 11)
+	target_include_directories(cudaclaw PRIVATE ${PROJECT_SOURCE_DIR}/cub)
+endif()
+
 # -- install
 install(FILES
 	fc2d_cudaclaw.h

--- a/src/solvers/fc2d_cudaclaw/Makefile.am
+++ b/src/solvers/fc2d_cudaclaw/Makefile.am
@@ -63,8 +63,11 @@ include_HEADERS += $(libcudaclaw_installed_headers)
 CUDACLAW_INCLUDE_DIRS = $(DEFS) $(DEFAULT_INCLUDES) \
 	$(INCLUDES) $(AM_CPPFLAGS) \
 	$(CPPFLAGS) $(AM_CFLAGS) \
-	$(MPI_INCLUDES) \
-	-I@top_srcdir@/cub/
+	$(MPI_INCLUDES)
+
+if USE_LOCAL_CUB
+CUDACLAW_INCLUDE_DIRS += -I@top_srcdir@/cub/
+endif
 
 .cu.o: 
 	$(NVCC) $(CUDA_CFLAGS) -dc $(CUDACLAW_INCLUDE_DIRS) -c -o $@ $<


### PR DESCRIPTION
CUB is included in the CUDA 11 standard library, so cmake and autoconf should check the CUDA version to avoid using the local CUB headers if the CUDA version is 11 or greater.

This pull request adds the checks to cmake and autoconf and also adds CI tests for both CUDA 10 and 11.
