### PR TITLE
Print out sc and p4est logs

### DIFF
--- a/.github/workflows/ci_automake.yml
+++ b/.github/workflows/ci_automake.yml
@@ -118,7 +118,10 @@ jobs:
 
     - name: Print Test log
       if: ${{ failure() }}
-      run: cat test-suite.log
+      run: |
+       cat sc/test-suite.log
+       cat p4est/test-suite.log
+       cat test-suite.log
 
     - name: Install
       run: sudo make install


### PR DESCRIPTION
Modify ci script to print out sc and p4est logs on test failure.