### PR TITLE
feature-p8est: add some 3D convenience functions

### DIFF
--- a/src/fclaw2d_convenience.c
+++ b/src/fclaw2d_convenience.c
@@ -731,10 +731,7 @@ fclaw2d_domain_write_vtk (fclaw2d_domain_t * domain, const char *basename)
     FCLAW_ASSERT (wrap != NULL);
     FCLAW_ASSERT (wrap->p4est != NULL);
 
-#ifndef P4_TO_P8
-    /* to be implemented in 3D */
     p4est_vtk_write_file (wrap->p4est, NULL, basename);
-#endif
 }
 
 static void

--- a/src/fclaw2d_convenience.c
+++ b/src/fclaw2d_convenience.c
@@ -570,6 +570,11 @@ fclaw2d_domain_adapt (fclaw2d_domain_t * domain)
                     }
                 }
 
+#ifdef P4_TO_P8
+                /* loop through edge neighbors of this patch */
+                /* to be implemented */
+#endif
+
                 /* loop through corner neighbors of this patch */
                 for (corner = 0; max_tlevel <= level &&
                      corner < wrap->p4est_children; ++corner)
@@ -718,8 +723,6 @@ fclaw2d_domain_complete (fclaw2d_domain_t * domain)
     p4est_wrap_complete (wrap);
 }
 
-#ifndef P4_TO_P8
-
 void
 fclaw2d_domain_write_vtk (fclaw2d_domain_t * domain, const char *basename)
 {
@@ -728,7 +731,10 @@ fclaw2d_domain_write_vtk (fclaw2d_domain_t * domain, const char *basename)
     FCLAW_ASSERT (wrap != NULL);
     FCLAW_ASSERT (wrap->p4est != NULL);
 
+#ifndef P4_TO_P8
+    /* to be implemented in 3D */
     p4est_vtk_write_file (wrap->p4est, NULL, basename);
+#endif
 }
 
 static void
@@ -799,6 +805,9 @@ fclaw2d_domain_list_neighbors_callback (fclaw2d_domain_t * domain,
         P4EST_LOGF (ln->lp, "Block %d patch %d face %d neighbor %d\n",
                     block_no, patch_no, faceno, (int) fnt);
     }
+#ifdef P4_TO_P8
+    /* to be implemented: list edge neighbors as well */
+#endif
     for (cornerno = 0; cornerno < P4EST_CHILDREN; ++cornerno)
     {
         (void) fclaw2d_patch_corner_neighbors (domain, block_no, patch_no,
@@ -913,6 +922,9 @@ search_point_fn (p4est_t * p4est, p4est_topidx_t which_tree,
     int earlier, now;
     int *pentry;
     double x, y;
+#ifdef P4_TO_P8
+    double z;
+#endif
     double *xyentry;
     fclaw2d_block_t *block;
 #ifdef FCLAW_ENABLE_DEBUG
@@ -952,6 +964,14 @@ search_point_fn (p4est_t * p4est, p4est_topidx_t which_tree,
     {
         return 0;
     }
+#ifdef P4_TO_P8
+    z = xyentry[2];
+    if (z < quadrant->z * fclaw2d_smallest_h ||
+        z > (quadrant->z + qh) * fclaw2d_smallest_h)
+    {
+        return 0;
+    }
+#endif
     /* now we know that the point is contained in the search quadrant */
 
     if (local_num < 0)
@@ -975,6 +995,9 @@ search_point_fn (p4est_t * p4est, p4est_topidx_t which_tree,
     /* do the check a second time with the patch data */
     FCLAW_ASSERT (x >= patch->xlower && x <= patch->xupper);
     FCLAW_ASSERT (y >= patch->ylower && y <= patch->yupper);
+#ifdef P4_TO_P8
+    FCLAW_ASSERT (z >= patch->zlower && z <= patch->zupper);
+#endif
 
     /* remember the smallest local quadrant number as result */
     earlier = *(int *) sc_array_index_int (sd->results, ip);
@@ -1021,7 +1044,7 @@ fclaw2d_domain_search_points (fclaw2d_domain_t * domain,
     FCLAW_ASSERT (0 <= num_blocks);
 
     FCLAW_ASSERT (block_offsets->elem_size == sizeof (int));
-    FCLAW_ASSERT (coordinates->elem_size == 2 * sizeof (double));
+    FCLAW_ASSERT (coordinates->elem_size == P4EST_DIM * sizeof (double));
     FCLAW_ASSERT (results->elem_size == sizeof (int));
 
     FCLAW_ASSERT (num_blocks + 1 == (int) block_offsets->elem_count);
@@ -1037,7 +1060,7 @@ fclaw2d_domain_search_points (fclaw2d_domain_t * domain,
         *(int *) sc_array_index_int (results, ip) = -1;
     }
 
-    /* construct input set for p4est search */
+    /* construct input set for p4est search: block and point number */
     points = sc_array_new_size (2 * sizeof (int), num_points);
     pbegin = 0;
     for (jb = 0; jb < num_blocks; ++jb)
@@ -1071,7 +1094,7 @@ fclaw2d_domain_search_points (fclaw2d_domain_t * domain,
                   (p4est_topidx_t) num_blocks);
     user_save = p4est->user_pointer;
     p4est->user_pointer = sd;
-    p4est_search (p4est, NULL, search_point_fn, points);
+    p4est_search_local (p4est, 0, NULL, search_point_fn, points);
     p4est->user_pointer = user_save;
 
     /* synchronize results in parallel */
@@ -1079,5 +1102,3 @@ fclaw2d_domain_search_points (fclaw2d_domain_t * domain,
     /* tidy up memory */
     sc_array_destroy (points);
 }
-
-#endif /* !P4_TO_P8 */

--- a/src/fclaw2d_convenience.h
+++ b/src/fclaw2d_convenience.h
@@ -133,7 +133,7 @@ void fclaw2d_domain_complete (fclaw2d_domain_t * domain);
 
 /** Write VTK file(s) for a domain structure.
  *  Each patch is drawn as one rectangle.
- *  We ignore any geometric transformations
+ *  We ignore any geometric transformations.
  *  and use the vertex locations specified in the p4est's connectivity.
  * \param [in] domain           A valid domain structure.  Is not changed.
  * \param [in] basename         Filename prefix passed to p4est_vtk functions.
@@ -162,6 +162,10 @@ void fclaw2d_domain_list_adapted (fclaw2d_domain_t * old_domain,
  * We return the smallest patch number on the smallest processor touching it.
  * However, if a point is on a block boundary, it must be decided before
  * calling this function which tree shall be queried for it.
+ *
+ * \note Currently we do not find the smallest matching process, but instead
+ *       instead a point on a parallel boundary may be found on multiple processes.
+ *       This should be fixed in the near future.
  *
  * \param [in] domain           Must be valid domain structure.  Will not be changed.
  * \param [in] block_offsets    Array of (num_blocks + 1) int variables.

--- a/src/fclaw2d_to_3d.h
+++ b/src/fclaw2d_to_3d.h
@@ -128,6 +128,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define fclaw2d_domain_partition        fclaw3d_domain_partition
 #define fclaw2d_domain_partition_unchanged  fclaw3d_domain_partition_unchanged
 #define fclaw2d_domain_complete         fclaw3d_domain_complete
+#define fclaw2d_domain_write_vtk        fclaw3d_domain_write_vtk
+#define fclaw2d_domain_list_levels      fclaw3d_domain_list_levels
+#define fclaw2d_domain_list_neighbors   fclaw3d_domain_list_neighbors
+#define fclaw2d_domain_list_adapted     fclaw3d_domain_list_adapted
+#define fclaw2d_domain_search_points    fclaw3d_domain_search_points
 #define fclaw2d_domain_iterate_cb       fclaw3d_domain_iterate_cb
 #define fclaw_domain_new2d              fclaw_domain_new3d
 #define fclaw_domain_destroy2d          fclaw_domain_destroy3d

--- a/src/fclaw3d_convenience.h
+++ b/src/fclaw3d_convenience.h
@@ -43,6 +43,9 @@ extern "C"
 /* TODO: The unit cube is a special case of the brick.  Use that instead. */
 fclaw3d_domain_t *fclaw3d_domain_new_unitcube (sc_MPI_Comm mpicomm,
                                                int initial_level);
+
+#if 0
+
 /* TODO: The torus is a special case of the brick.  Use that instead. */
 fclaw3d_domain_t *fclaw3d_domain_new_torus (sc_MPI_Comm mpicomm,
                                             int initial_level);
@@ -50,8 +53,6 @@ fclaw3d_domain_t *fclaw3d_domain_new_twosphere (sc_MPI_Comm mpicomm,
                                                 int initial_level);
 fclaw3d_domain_t *fclaw3d_domain_new_cubedsphere (sc_MPI_Comm mpicomm,
                                                   int initial_level);
-
-#if 0
 
 /** Create a brick connectivity, that is, a rectangular grid of blocks.
  * The origin is in the lower-left corner of the brick.
@@ -137,13 +138,15 @@ void fclaw3d_domain_complete (fclaw3d_domain_t * domain);
 
 /** Write VTK file(s) for a domain structure.
  *  Each patch is drawn as one rectangle.
- *  We ignore any geometric transformations
+ *  We ignore any geometric transformations.
+ * \note Not yet doing anything in 3D.
  *  and use the vertex locations specified in the p4est's connectivity.
  * \param [in] domain           A valid domain structure.  Is not changed.
  * \param [in] basename         Filename prefix passed to p4est_vtk functions.
  */
 void fclaw3d_domain_write_vtk (fclaw3d_domain_t * domain,
                                const char *basename);
+
 
 /** Print patch number by level on all processors */
 void fclaw3d_domain_list_levels (fclaw3d_domain_t * domain, int log_priority);
@@ -166,6 +169,10 @@ void fclaw3d_domain_list_adapted (fclaw3d_domain_t * old_domain,
  * We return the smallest patch number on the smallest processor touching it.
  * However, if a point is on a block boundary, it must be decided before
  * calling this function which tree shall be queried for it.
+ *
+ * \note Currently we do not find the smallest matching process, but instead
+ *       instead a point on a parallel boundary may be found on multiple processes.
+ *       This should be fixed in the near future.
  *
  * \param [in] domain           Must be valid domain structure.  Will not be changed.
  * \param [in] block_offsets    Array of (num_blocks + 1) int variables.

--- a/src/fclaw3d_convenience.h
+++ b/src/fclaw3d_convenience.h
@@ -147,7 +147,6 @@ void fclaw3d_domain_complete (fclaw3d_domain_t * domain);
 void fclaw3d_domain_write_vtk (fclaw3d_domain_t * domain,
                                const char *basename);
 
-
 /** Print patch number by level on all processors */
 void fclaw3d_domain_list_levels (fclaw3d_domain_t * domain, int log_priority);
 


### PR DESCRIPTION
These are a couple translations to 3D, notably the point search.
The smooth refinement does not yet know about edges in 3D.
The neighbor list functions work but still ignore edge neighbors.

Note that the point search needs an update to eliminate multiple matches on different processes since the very beginning. Addressing this will solve it for both 2D and 3D at the same time.