### PR TITLE
(clawpack/disk,filament) Remove references to clawpatch and fclaw options

### DIFF
--- a/applications/clawpack/acoustics/2d/radial/fclaw_options.ini
+++ b/applications/clawpack/acoustics/2d/radial/fclaw_options.ini
@@ -1,5 +1,10 @@
 [user]
-     example = 0
+     # 0 : unit square
+     # 1 : 5 patch square + pillowdisk
+     # 2 : Pillowdisk
+
+     example = 1
+
      claw-version = 4
 
      rho = 1

--- a/applications/clawpack/acoustics/2d/radial/radial.cpp
+++ b/applications/clawpack/acoustics/2d/radial/radial.cpp
@@ -25,7 +25,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "radial_user.h"
 
+#include <fclaw2d_clawpatch.h>
+
 /* ------------------------- Start of program ---------------------------- */
+
 
 static
 fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm, 
@@ -51,11 +54,6 @@ fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm,
         cont = fclaw2d_map_new_nomap();
         break;
     case 1:
-        if (clawpatch_opt->mx*pow_int(2,fclaw_opt->minlevel) < 32)
-        {
-            fclaw_global_essentialf("The five patch mapping requires mx*2^minlevel >= 32\n");
-            exit(0);
-        }
         conn = p4est_connectivity_new_disk (0, 0);
         cont = fclaw2d_map_new_pillowdisk5 (fclaw_opt->scale,fclaw_opt->shift,
                                             rotate,user->alpha);
@@ -148,8 +146,12 @@ main (int argc, char **argv)
     retval = fclaw_options_read_from_file(options);
     vexit =  fclaw_app_options_parse (app, &first_arg,"fclaw_options.ini.used");
 
+    radial_global_post_process(fclaw_opt, clawpatch_opt, user_opt);
+    fclaw_app_print_options(app);
+
+
     /* Run the program */
-    if (!retval & !vexit)
+    if (!retval & (vexit < 2))
     {
         /* Options have been checked and are valid */
 

--- a/applications/clawpack/acoustics/2d/radial/radial.cpp
+++ b/applications/clawpack/acoustics/2d/radial/radial.cpp
@@ -51,6 +51,11 @@ fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm,
         cont = fclaw2d_map_new_nomap();
         break;
     case 1:
+        if (clawpatch_opt->mx*pow_int(2,fclaw_opt->minlevel) < 32)
+        {
+            fclaw_global_essentialf("The five patch mapping requires mx*2^minlevel >= 32\n");
+            exit(0);
+        }
         conn = p4est_connectivity_new_disk (0, 0);
         cont = fclaw2d_map_new_pillowdisk5 (fclaw_opt->scale,fclaw_opt->shift,
                                             rotate,user->alpha);

--- a/applications/clawpack/acoustics/2d/radial/radial_options.c
+++ b/applications/clawpack/acoustics/2d/radial/radial_options.c
@@ -58,21 +58,12 @@ radial_postprocess (user_options_t *user)
 }
 
 static fclaw_exit_type_t
-radial_check (user_options_t *user,
-             fclaw_options_t *fclaw_opt,
-             fclaw2d_clawpatch_options_t *clawpatch_opt)
+radial_check (user_options_t *user)
 {
     if (user->example < 0 || user->example > 2) {
         fclaw_global_essentialf ("Option --user:example must be 0 or 1\n");
         return FCLAW_EXIT_QUIET;
     }
-    if (user->example > 0)
-        if (clawpatch_opt->mx*pow_int(2,fclaw_opt->minlevel) < 32)
-        {
-            fclaw_global_essentialf("The five patch mapping requires mx*2^minlevel >= 32\n");
-            return FCLAW_EXIT_QUIET;
-        }
-    return FCLAW_NOEXIT;
 }
 
 static void
@@ -125,13 +116,7 @@ options_check(fclaw_app_t *app, void *package,void *registered)
     FCLAW_ASSERT(registered == NULL);
 
     user = (user_options_t*) package;
-    fclaw_options_t *fclaw_opt = 
-                 (fclaw_options_t*) fclaw_app_get_attribute(app,"Options",NULL);
-
-    fclaw2d_clawpatch_options_t *clawpatch_opt = 
-                 (fclaw2d_clawpatch_options_t*)  fclaw_app_get_attribute(app,"clawpatch",NULL);
-
-    return radial_check(user,fclaw_opt, clawpatch_opt);
+    return radial_check(user);
 }
 
 static void

--- a/applications/clawpack/acoustics/2d/radial/radial_options.c
+++ b/applications/clawpack/acoustics/2d/radial/radial_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012 Carsten Burstedde, Donna Calhoun
+Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/applications/clawpack/acoustics/2d/radial/radial_options.c
+++ b/applications/clawpack/acoustics/2d/radial/radial_options.c
@@ -64,6 +64,9 @@ radial_check (user_options_t *user)
         fclaw_global_essentialf ("Option --user:example must be 0 or 1\n");
         return FCLAW_EXIT_QUIET;
     }
+    /* Don't print output values yet.  Wait until we have done a global options
+       checking */
+    return FCLAW_EXIT_QUIET;
 }
 
 static void
@@ -173,4 +176,17 @@ user_options_t* radial_get_options(fclaw2d_global_t* glob)
     int id = s_user_options_package_id;
     return (user_options_t*) fclaw_package_get_options(glob, id);    
 }
+
+void radial_global_post_process(fclaw_options_t *fclaw_opt,
+                                fclaw2d_clawpatch_options_t *clawpatch_opt,
+                                user_options_t *user_opt)
+{
+    if (user_opt->example == 1)
+        if (clawpatch_opt->mx*pow_int(2,fclaw_opt->minlevel) < 32)
+        {
+            fclaw_global_essentialf("The five patch mapping requires mx*2^minlevel >= 32\n");
+            exit(0);
+        }
+}
+
 

--- a/applications/clawpack/acoustics/2d/radial/radial_user.h
+++ b/applications/clawpack/acoustics/2d/radial/radial_user.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012 Carsten Burstedde, Donna Calhoun
+Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -75,6 +75,11 @@ user_options_t* radial_options_register (fclaw_app_t * app, const char *configfi
 void radial_options_store (fclaw2d_global_t* glob, user_options_t* user);
 
 user_options_t* radial_get_options(fclaw2d_global_t* glob);
+
+void radial_global_post_process(fclaw_options_t *fclaw_opt,
+                                fclaw2d_clawpatch_options_t *clawpatch_opt,
+                                user_options_t *user_opt);
+
 
 /* --------------------------------- Fortran ------------------------------------- */
 

--- a/applications/clawpack/acoustics/2d/radial/regression_map.ini
+++ b/applications/clawpack/acoustics/2d/radial/regression_map.ini
@@ -1,5 +1,5 @@
 [user]
-     example = 0
+     example = 1
      claw-version = 4
 
      rho = 1

--- a/applications/clawpack/advection/2d/disk/disk.cpp
+++ b/applications/clawpack/advection/2d/disk/disk.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2021 Carsten Burstedde, Donna Calhoun
+Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -30,7 +30,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 static
 fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm, 
                                 fclaw_options_t* fclaw_opt, 
-                                user_options_t* user_opt)
+                                user_options_t* user_opt,
+                                fclaw2d_clawpatch_options_t *clawpatch_opt)
 {
     /* Mapped, multi-block domain */
     p4est_connectivity_t     *conn = NULL;
@@ -44,7 +45,8 @@ fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm,
     rotate[0] = pi*fclaw_opt->theta/180.0;
     rotate[1] = pi*fclaw_opt->phi/180.0;
 
-    switch (user_opt->example) {
+    switch (user_opt->example) 
+    {
     case 0:
         /* Map unit square to the pillow disk using mapc2m_pillowdisk.f */
         conn = p4est_connectivity_new_unitsquare();
@@ -52,6 +54,13 @@ fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm,
                                           rotate);
         break;
     case 1:
+        /* First check that the grid has the right dimensions.  A bit late to be checking options, 
+        but this is awkward to do in the options post-processing step */
+        if (clawpatch_opt->mx*pow_int(2,fclaw_opt->minlevel) < 32)
+        {
+            fclaw_global_essentialf("The five patch mapping requires mx*2^minlevel >= 32\n");
+            exit(0);
+        }
         /* Map five-patch square to pillow disk. */
         conn = p4est_connectivity_new_disk (0, 0);
         cont = fclaw2d_map_new_pillowdisk5 (fclaw_opt->scale,
@@ -145,7 +154,7 @@ main (int argc, char **argv)
     {
         /* Options have been checked and are valid */
         mpicomm = fclaw_app_get_mpi_size_rank (app, NULL, NULL);
-        domain = create_domain(mpicomm, fclaw_opt, user_opt);
+        domain = create_domain(mpicomm, fclaw_opt, user_opt,clawpatch_opt);
     
         /* Create global structure which stores the domain, timers, etc */
         glob = fclaw2d_global_new();

--- a/applications/clawpack/advection/2d/disk/disk_options.c
+++ b/applications/clawpack/advection/2d/disk/disk_options.c
@@ -61,9 +61,9 @@ disk_check (user_options_t *user_opt)
 
     if (user_opt->example < 0 || user_opt->example > 1) {
         fclaw_global_essentialf ("Option --user:example must be 0 or 1\n");
-        return FCLAW_EXIT_QUIET;
     }
-    return FCLAW_NOEXIT;
+    /* Print the summary after we have done a global option check */
+    return FCLAW_EXIT_QUIET;
 }
 
 static void
@@ -174,6 +174,19 @@ const user_options_t* disk_get_options(fclaw2d_global_t* glob)
     int id = s_user_options_package_id;
     return (user_options_t*) fclaw_package_get_options(glob, id);    
 }
+
+void disk_global_post_process(fclaw_options_t *fclaw_opt,
+                              fclaw2d_clawpatch_options_t *clawpatch_opt,
+                              user_options_t *user_opt)
+{
+    if (user_opt->example == 1)
+        if (clawpatch_opt->mx*pow_int(2,fclaw_opt->minlevel) < 32)
+        {
+            fclaw_global_essentialf("The five patch mapping requires mx*2^minlevel >= 32\n");
+            exit(0);
+        }
+}
+
 
 
 

--- a/applications/clawpack/advection/2d/disk/disk_options.c
+++ b/applications/clawpack/advection/2d/disk/disk_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012 Carsten Burstedde, Donna Calhoun
+Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -56,22 +56,12 @@ disk_postprocess(user_options_t *user)
 
 
 static fclaw_exit_type_t
-disk_check (user_options_t *user_opt, 
-            fclaw_options_t *fclaw_opt,
-            fclaw2d_clawpatch_options_t *clawpatch_opt)
+disk_check (user_options_t *user_opt)
 {
 
     if (user_opt->example < 0 || user_opt->example > 1) {
         fclaw_global_essentialf ("Option --user:example must be 0 or 1\n");
         return FCLAW_EXIT_QUIET;
-    }
-    else if (user_opt->example == 1)
-    {
-        if (clawpatch_opt->mx*pow_int(2,fclaw_opt->minlevel) < 32)
-        {
-            fclaw_global_essentialf("The five patch mapping requires mx*2^minlevel >= 32\n");
-            return FCLAW_EXIT_QUIET;
-        }
     }
     return FCLAW_NOEXIT;
 }
@@ -126,13 +116,7 @@ options_check(fclaw_app_t *app, void *package,void *registered)
     FCLAW_ASSERT(registered == NULL);
 
     user_opt = (user_options_t*) package;
-    fclaw_options_t *fclaw_opt = 
-                 (fclaw_options_t*) fclaw_app_get_attribute(app,"Options",NULL);
-
-    fclaw2d_clawpatch_options_t *clawpatch_opt = 
-                 (fclaw2d_clawpatch_options_t*)  fclaw_app_get_attribute(app,"clawpatch",NULL);
-
-    return disk_check(user_opt,fclaw_opt, clawpatch_opt);
+    return disk_check(user_opt);
 }
 
 static void

--- a/applications/clawpack/advection/2d/disk/disk_user.h
+++ b/applications/clawpack/advection/2d/disk/disk_user.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2021 Carsten Burstedde, Donna Calhoun
+Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -57,6 +57,11 @@ void disk_options_store (fclaw2d_global_t* glob, user_options_t* user_opt);
 const user_options_t* disk_get_options(fclaw2d_global_t* glob);
 
 void disk_link_solvers(fclaw2d_global_t *glob);
+
+void disk_global_post_process(fclaw_options_t *fclaw_opt,
+                              fclaw2d_clawpatch_options_t *clawpatch_opt,
+                              user_options_t *user_opt);
+
 
 #ifdef __cplusplus
 #if 0

--- a/applications/clawpack/advection/2d/filament/fclaw_options.ini
+++ b/applications/clawpack/advection/2d/filament/fclaw_options.ini
@@ -1,4 +1,8 @@
 [user]
+     # Mappings : 
+     # 0 : Use [ax,bx]x[ay,by]
+     # 1 : Use brick domain and parameters (mi,mj)
+     # 2 : Five-patch square
      example = 0        # no mapping
 
      claw-version = 4

--- a/applications/clawpack/advection/2d/filament/filament_options.c
+++ b/applications/clawpack/advection/2d/filament/filament_options.c
@@ -47,20 +47,11 @@ filament_register (user_options_t *user, sc_options_t * opt)
 }
 
 static fclaw_exit_type_t
-filament_check (user_options_t *user, fclaw_options_t *fclaw_opt, 
-                fclaw2d_clawpatch_options_t* clawpatch_opt)
+filament_check (user_options_t *user)
 {
     if (user->example < 0 || user->example > 2) {
         fclaw_global_essentialf ("Option --user:example must be 0, 1, or 2\n");
         return FCLAW_EXIT_QUIET;
-    }
-    if (user->example == 2)
-    {
-        if (clawpatch_opt->mx*pow_int(2,fclaw_opt->minlevel) < 32)
-        {
-            fclaw_global_essentialf("The five patch mapping requires mx*2^minlevel > 32");
-            return FCLAW_EXIT_QUIET;
-        }
     }
     return FCLAW_NOEXIT;
 }
@@ -99,13 +90,7 @@ options_check(fclaw_app_t *app, void *package,void *registered)
     FCLAW_ASSERT(registered == NULL);
 
     user = (user_options_t*) package;
-    fclaw_options_t *fclaw_opt = 
-                 (fclaw_options_t*) fclaw_app_get_attribute(app,"Options",NULL);
-    fclaw2d_clawpatch_options_t *clawpatch_opt = 
-                 (fclaw2d_clawpatch_options_t*)  
-                 fclaw_app_get_attribute(app,"clawpatch",NULL);
-
-    return filament_check(user,fclaw_opt, clawpatch_opt);
+    return filament_check(user);
 }
 
 static void

--- a/applications/clawpack/advection/2d/replicated/fclaw_options.ini
+++ b/applications/clawpack/advection/2d/replicated/fclaw_options.ini
@@ -106,8 +106,8 @@
 
      # Dimensions of brick domain - mi x mj.  To override 'replicate_factor',
      # set replicate_factor=-1.
-     mi = 1
-     mj = 1
+     mi = 4
+     mj = 4
 
      #  (ax,bx,ay,by)=(0,mi,0,mj) are set in torus.cpp
 

--- a/applications/clawpack/advection/2d/replicated/regression.ini
+++ b/applications/clawpack/advection/2d/replicated/regression.ini
@@ -4,7 +4,7 @@
 [user]
      example = 1     # example=0 : 1x1 block;  example=1 : NxN block
 
-     replicate-factor = 2  
+     replicate-factor = 2  # Replicate the problem this many times.
      minlevel-base = 3     
      maxlevel-base = 6
 

--- a/applications/clawpack/advection/2d/replicated/replicated.cpp
+++ b/applications/clawpack/advection/2d/replicated/replicated.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2021 Carsten Burstedde, Donna Calhoun
+Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -27,23 +27,26 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "../all/advection_user.h"
 
+#include <fclaw2d_clawpatch.h>
+
 #include <math.h>
+
 
 static
 fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm, 
-                                fclaw_options_t* fclaw_opt,
-                                user_options_t* user_opt)
+                                fclaw_options_t* fclaw_opt)
 {
-    /* Mapped, multi-block domain */
-    p4est_connectivity_t     *conn = NULL;
-    fclaw2d_domain_t         *domain;
-    fclaw2d_map_context_t    *cont = NULL, *brick = NULL;
 
+    /* Set up domain */
     int mi = fclaw_opt->mi;
     int mj = fclaw_opt->mj;
     int a = fclaw_opt->periodic_x;
     int b = fclaw_opt->periodic_y;
 
+    /* Mapped, multi-block domain */
+    p4est_connectivity_t     *conn = NULL;
+    fclaw2d_domain_t         *domain;
+    fclaw2d_map_context_t    *cont = NULL, *brick = NULL;
 
     /* Duplicate initial conditions in each block */
     conn = p4est_connectivity_new_brick(mi,mj,a,b);
@@ -127,15 +130,22 @@ main (int argc, char **argv)
     retval = fclaw_options_read_from_file(options);
     vexit =  fclaw_app_options_parse (app, &first_arg,"fclaw_options.ini.used");
 
-    if (!retval & !vexit)
-    {
+    /* This might change some of the values from above. */
+    replicated_global_post_process(fclaw_opt, clawpatch_opt, user_opt);
 
+    fclaw_app_print_options(app);
+
+
+    if (!retval & (vexit < 2))
+    {
         /* Options have been checked and are valid */
         mpicomm = fclaw_app_get_mpi_size_rank (app, NULL, NULL);
-        domain = create_domain(mpicomm, fclaw_opt, user_opt);
-    
-        /* Create global structure which stores the domain, timers, etc */
+
+        domain = create_domain(mpicomm, fclaw_opt);
+
         glob = fclaw2d_global_new();
+
+        /* Create global structure which stores the domain, timers, etc */
         fclaw2d_global_store_domain(glob, domain);
 
         /* Store option packages in glob */

--- a/applications/clawpack/advection/2d/replicated/replicated_options.c
+++ b/applications/clawpack/advection/2d/replicated/replicated_options.c
@@ -63,52 +63,8 @@ static fclaw_exit_type_t
 replicated_postprocess(user_options_t *user, fclaw_options_t *fclaw_opt)
 {
 
-    /* Check to make sure replicate factor is power of 2. 
-       We do it here, since options_check only happens after post-process. */
-    int pos = 0;    
-    while (user->replicate_factor != (1 << pos))
-    {
-        pos++;
-        if (pos > 32)
-        {
-            fclaw_global_essentialf("Replicated_postprocess : Replicate " \
-                                    "factor should be a low power of 2 (< 2**32)\n");
-            return FCLAW_EXIT_QUIET;
-        }
-    }
-
-    fclaw_opt->ax = 0;
-    fclaw_opt->ay = 0;
-    fclaw_opt->bx = user->replicate_factor;
-    fclaw_opt->by = user->replicate_factor;
-
-    fclaw_opt->minlevel = user->minlevel_base;
-    fclaw_opt->maxlevel = user->maxlevel_base;
-
-
-
-    if (user->example == 0)
-    {
-        /* 1x1 block;  use replicate factor to dimension domain */
-        fclaw_opt->mi = 1;
-        fclaw_opt->mj = 1;
-
-        /* We need to increase the refinement level when we increase domain size. 
-           Code below computes pos=log2(replicate_factor) */
-        fclaw_opt->minlevel += pos;
-        fclaw_opt->maxlevel += pos;
-    }
-    else
-    {
-        /* NxN block */
-        fclaw_opt->mi = user->replicate_factor;
-        fclaw_opt->mj = user->replicate_factor;
-    }
-
-    fclaw_opt->periodic_x = 1;
-    fclaw_opt->periodic_y = 1;
-    fclaw_opt->smooth_level = fclaw_opt->maxlevel-1;
-    return FCLAW_NOEXIT;
+    /* Do post-processing before printing out summary */
+    return FCLAW_EXIT_QUIET;
 }
 
 static void
@@ -205,5 +161,63 @@ const user_options_t* replicated_get_options(fclaw2d_global_t* glob)
 {
     int id = s_user_options_package_id;
     return (user_options_t*) fclaw_package_get_options(glob, id);    
+}
+
+void replicated_global_post_process(fclaw_options_t *fclaw_opt, 
+                                    fclaw2d_clawpatch_options_t *clawpatch_opt,
+                                    user_options_t *user_opt)
+{
+    /* This routine will be called to do any more global  post-processing */
+    FCLAW_ASSERT(user_opt->replicate_factor >= 0);
+
+    fclaw_opt->ax = 0;
+    fclaw_opt->ay = 0;
+    fclaw_opt->bx = user_opt->replicate_factor;
+    fclaw_opt->by = user_opt->replicate_factor;
+
+    fclaw_opt->minlevel = user_opt->minlevel_base;
+    fclaw_opt->maxlevel = user_opt->maxlevel_base;
+
+    fclaw_opt->periodic_x = 1;
+    fclaw_opt->periodic_y = 1;
+    fclaw_opt->smooth_level = fclaw_opt->maxlevel;
+
+    switch (user_opt->example)
+    {
+        case 0:
+        {
+            /* In this case, we mimic the multiblock behavior in a single block */
+            /* Find p so that user_factor = 2**p.  Require p < 32 */
+            int p = 0;    
+            while (user_opt->replicate_factor != (1 << p))
+            {
+                p++;
+                if (p > 32)
+                {
+                    fclaw_global_essentialf("Replicated_postprocess : Replicate " \
+                                            "factor should be a low power of 2 (< 2**32)\n");
+                    return exit(1);
+                }
+            }
+
+            /* 1x1 block;  use replicate factor to dimension domain */
+            fclaw_opt->mi = 1;
+            fclaw_opt->mj = 1;
+
+            /* We need to increase the refinement level when we increase 
+               domain size.  */
+            fclaw_opt->minlevel += p;
+            fclaw_opt->maxlevel += p;
+        }
+        break;    
+    
+        default:
+        {
+            /* Multiblock case : NxN block */
+            fclaw_opt->mi = user_opt->replicate_factor;
+            fclaw_opt->mj = user_opt->replicate_factor;            
+        }
+        break;
+    }    
 }
 

--- a/applications/clawpack/advection/2d/replicated/replicated_user.h
+++ b/applications/clawpack/advection/2d/replicated/replicated_user.h
@@ -62,6 +62,10 @@ void replicated_options_store (fclaw2d_global_t* glob, user_options_t* user);
 
 const user_options_t* replicated_get_options(fclaw2d_global_t* glob);
 
+void replicated_global_post_process(fclaw_options_t *fclaw_opt, 
+                                    fclaw2d_clawpatch_options_t *clawpatch_opt,
+                                    user_options_t *user_opt);
+
 
 #ifdef __cplusplus
 #if 0

--- a/applications/clawpack/advection/3d/filament/filament_options.c
+++ b/applications/clawpack/advection/3d/filament/filament_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012 Carsten Burstedde, Donna Calhoun
+Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -47,8 +47,7 @@ filament_register (user_options_t *user, sc_options_t * opt)
 }
 
 static fclaw_exit_type_t
-filament_check (user_options_t *user, fclaw_options_t *fclaw_opt, 
-                fclaw2d_clawpatch_options_t* clawpatch_opt)
+filament_check (user_options_t *user)
 {
     if (user->example != 0) {
         fclaw_global_essentialf ("Option --user:example must be 0\n");
@@ -91,13 +90,7 @@ options_check(fclaw_app_t *app, void *package,void *registered)
     FCLAW_ASSERT(registered == NULL);
 
     user = (user_options_t*) package;
-    fclaw_options_t *fclaw_opt = 
-                 (fclaw_options_t*) fclaw_app_get_attribute(app,"Options",NULL);
-    fclaw2d_clawpatch_options_t *clawpatch_opt = 
-                 (fclaw2d_clawpatch_options_t*)  
-                 fclaw_app_get_attribute(app,"clawpatch",NULL);
-
-    return filament_check(user,fclaw_opt, clawpatch_opt);
+    return filament_check(user);
 }
 
 static void

--- a/applications/clawpack/shallow/2d/radialdam/radialdam.cpp
+++ b/applications/clawpack/shallow/2d/radialdam/radialdam.cpp
@@ -25,17 +25,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "radialdam_user.h"
 
-#include <fclaw2d_include_all.h>
-
-#include <fclaw2d_clawpatch_options.h>
-#include <fclaw2d_clawpatch.h>
-
-#include <fc2d_clawpack46_options.h>
-#include <fc2d_clawpack5_options.h>
-
-#include <fc2d_clawpack46.h>
-#include <fc2d_clawpack5.h>
-
 static
 fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm, 
                                 fclaw_options_t* fclaw_opt,

--- a/applications/clawpack/shallow/2d/radialdam/radialdam.cpp
+++ b/applications/clawpack/shallow/2d/radialdam/radialdam.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2021 Carsten Burstedde, Donna Calhoun
+Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -116,9 +116,11 @@ void run_program(fclaw2d_global_t* glob)
     /* ---------------------------------------------------------------
        Run
        --------------------------------------------------------------- */
+
     fclaw2d_initialize(glob);
     fclaw2d_run(glob);
     fclaw2d_finalize(glob);
+
 }
 
 
@@ -158,8 +160,11 @@ main (int argc, char **argv)
     retval = fclaw_options_read_from_file(options);
     vexit =  fclaw_app_options_parse (app, &first_arg,"fclaw_options.ini.used");
 
+    radialdam_global_post_process(fclaw_opt, clawpatch_opt, user_opt);
+    fclaw_app_print_options(app);
+
     /* Run the program */
-    if (!retval & !vexit)
+    if (!retval & (vexit < 2))
     {
         /* Options have been checked and are valid */
 

--- a/applications/clawpack/shallow/2d/radialdam/radialdam_options.c
+++ b/applications/clawpack/shallow/2d/radialdam/radialdam_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2021 Carsten Burstedde, Donna Calhoun
+Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -59,17 +59,8 @@ radialdam_check (user_options_t *user,
 {
     if (user->example < 0 || user->example > 3) {
         fclaw_global_essentialf ("Option --user:example must be 0 or 1\n");
-        return FCLAW_EXIT_QUIET;
     }
-    else if (user->example == 2)
-    {
-        if (clawpatch_opt->mx*pow_int(2,fclaw_opt->minlevel) < 32)
-        {
-            fclaw_global_essentialf("The five patch mapping requires mx*2^minlevel >= 32\n");
-            return FCLAW_EXIT_QUIET;
-        }
-    }
-    return FCLAW_NOEXIT;
+    return FCLAW_EXIT_QUIET;
 }
 
 static void
@@ -168,4 +159,17 @@ user_options_t* radialdam_get_options(fclaw2d_global_t* glob)
     int id = s_user_options_package_id;
     return (user_options_t*) fclaw_package_get_options(glob, id);    
 }
+
+void radialdam_global_post_process(fclaw_options_t *fclaw_opt,
+                                fclaw2d_clawpatch_options_t *clawpatch_opt,
+                                user_options_t *user_opt)
+{
+    if (user_opt->example == 2)
+        if (clawpatch_opt->mx*pow_int(2,fclaw_opt->minlevel) < 32)
+        {
+            fclaw_global_essentialf("The five patch mapping requires mx*2^minlevel >= 32\n");
+            exit(0);
+        }
+}
+
 

--- a/applications/clawpack/shallow/2d/radialdam/radialdam_user.h
+++ b/applications/clawpack/shallow/2d/radialdam/radialdam_user.h
@@ -28,6 +28,17 @@
 
 #include <fclaw2d_include_all.h>
 
+#include <fclaw2d_include_all.h>
+
+#include <fclaw2d_clawpatch_options.h>
+#include <fclaw2d_clawpatch.h>
+
+#include <fc2d_clawpack46_options.h>
+#include <fc2d_clawpack5_options.h>
+
+#include <fc2d_clawpack46.h>
+#include <fc2d_clawpack5.h>
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/applications/clawpack/shallow/2d/radialdam/radialdam_user.h
+++ b/applications/clawpack/shallow/2d/radialdam/radialdam_user.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2012-2021 Carsten Burstedde, Donna Calhoun
+  Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -64,6 +64,14 @@ void radialdam_options_store (fclaw2d_global_t* glob, user_options_t* user);
 
 user_options_t* radialdam_get_options(fclaw2d_global_t* glob);
 
+
+void radialdam_global_post_process(fclaw_options_t *fclaw_opt,
+                                   fclaw2d_clawpatch_options_t *clawpatch_opt,
+                                   user_options_t *user_opt);
+
+
+/* ------------------------------- Mapping functions ---------------------------------- */
+
 fclaw2d_map_context_t* fclaw2d_map_new_nomap();
 
 fclaw2d_map_context_t* fclaw2d_map_new_pillowdisk(const double scale[],
@@ -78,8 +86,6 @@ fclaw2d_map_context_t* fclaw2d_map_new_pillowdisk5(const double scale[],
 fclaw2d_map_context_t* fclaw2d_map_new_fivepatch(const double scale[],
                                                  const double shift[],
                                                  const double alpha);
-
-
 /* ----------------------------- Conservative update ---------------------------------- */
 
 #define RPN2_CONS_UPDATE FCLAW_F77_FUNC(rpn2_cons_update,RPN2_CONS_UPDATE)
@@ -131,8 +137,6 @@ void USER5_SETAUX_MANIFOLD(const int* mbc,
                            double ynormals[], double ytangents[],
                            double surfnormals[],
                            double area[]);
-
-
 
 #ifdef __cplusplus
 #if 0

--- a/src/fclaw_base.c
+++ b/src/fclaw_base.c
@@ -485,6 +485,13 @@ fclaw_app_options_register_core (fclaw_app_t * a, const char *configfile)
                                 core);
 }
 
+
+void fclaw_app_print_options(fclaw_app_t *app)
+{
+        sc_options_print_summary (fclaw_get_package_id (),
+                                  FCLAW_VERBOSITY_ESSENTIAL, app->opt);    
+}
+
 fclaw_exit_type_t
 fclaw_app_options_parse (fclaw_app_t * a, int *first_arg,
                          const char *savefile)

--- a/src/fclaw_base.h
+++ b/src/fclaw_base.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012 Carsten Burstedde, Donna Calhoun
+Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -484,6 +484,14 @@ void fclaw_app_options_register_core (fclaw_app_t * a,
  */
 fclaw_exit_type_t fclaw_app_options_parse (fclaw_app_t * a, int *first_arg,
                                            const char *savefile);
+
+
+/** Print out use options
+ * \param [in] a         Initialized forestclaw application.
+ * \return               This pointer is returned unchanged.
+ */
+void fclaw_app_print_options(fclaw_app_t *app);
+
 
 /** Return the user pointer passed on \ref fclaw_app_new.
  * \param [in] a         Initialized forestclaw application.


### PR DESCRIPTION
Remove hack that required reading option attributes and instead check in actual applications
Applications affected : 
* clawpack/advection/2d/disk
* clawpack/advection/2d/filament

Did I miss any? 