### PR TITLE
Move global option handling after vexit check

### DIFF
--- a/applications/clawpack/acoustics/2d/radial/radial.cpp
+++ b/applications/clawpack/acoustics/2d/radial/radial.cpp
@@ -146,13 +146,12 @@ main (int argc, char **argv)
     retval = fclaw_options_read_from_file(options);
     vexit =  fclaw_app_options_parse (app, &first_arg,"fclaw_options.ini.used");
 
-    radial_global_post_process(fclaw_opt, clawpatch_opt, user_opt);
-    fclaw_app_print_options(app);
-
-
     /* Run the program */
     if (!retval & (vexit < 2))
     {
+        radial_global_post_process(fclaw_opt, clawpatch_opt, user_opt);
+        fclaw_app_print_options(app);
+        
         /* Options have been checked and are valid */
 
         mpicomm = fclaw_app_get_mpi_size_rank (app, NULL, NULL);

--- a/applications/clawpack/advection/2d/disk/disk.cpp
+++ b/applications/clawpack/advection/2d/disk/disk.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun
+Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -142,12 +142,13 @@ main (int argc, char **argv)
     retval = fclaw_options_read_from_file(options);
     vexit =  fclaw_app_options_parse (app, &first_arg,"fclaw_options.ini.used");
 
-    disk_global_post_process(fclaw_opt,clawpatch_opt,user_opt);
-    fclaw_app_print_options(app);
-
 
     if (!retval & (vexit < 2))
     {
+        /* Move this here in case vexit >= 2 */
+        disk_global_post_process(fclaw_opt,clawpatch_opt,user_opt);
+        fclaw_app_print_options(app);
+
         /* Options have been checked and are valid */
         mpicomm = fclaw_app_get_mpi_size_rank (app, NULL, NULL);
         domain = create_domain(mpicomm, fclaw_opt, user_opt);

--- a/applications/clawpack/advection/2d/replicated/replicated.cpp
+++ b/applications/clawpack/advection/2d/replicated/replicated.cpp
@@ -130,14 +130,13 @@ main (int argc, char **argv)
     retval = fclaw_options_read_from_file(options);
     vexit =  fclaw_app_options_parse (app, &first_arg,"fclaw_options.ini.used");
 
-    /* This might change some of the values from above. */
-    replicated_global_post_process(fclaw_opt, clawpatch_opt, user_opt);
-
-    fclaw_app_print_options(app);
-
 
     if (!retval & (vexit < 2))
     {
+        /* This might change some of the values from above. */
+        replicated_global_post_process(fclaw_opt, clawpatch_opt, user_opt);
+        fclaw_app_print_options(app);
+
         /* Options have been checked and are valid */
         mpicomm = fclaw_app_get_mpi_size_rank (app, NULL, NULL);
 

--- a/applications/clawpack/shallow/2d/radialdam/radialdam.cpp
+++ b/applications/clawpack/shallow/2d/radialdam/radialdam.cpp
@@ -149,14 +149,13 @@ main (int argc, char **argv)
     retval = fclaw_options_read_from_file(options);
     vexit =  fclaw_app_options_parse (app, &first_arg,"fclaw_options.ini.used");
 
-    radialdam_global_post_process(fclaw_opt, clawpatch_opt, user_opt);
-    fclaw_app_print_options(app);
-
     /* Run the program */
     if (!retval & (vexit < 2))
     {
-        /* Options have been checked and are valid */
+        radialdam_global_post_process(fclaw_opt, clawpatch_opt, user_opt);
+        fclaw_app_print_options(app);
 
+        /* Options have been checked and are valid */
         mpicomm = fclaw_app_get_mpi_size_rank (app, NULL, NULL);
         domain = create_domain(mpicomm, fclaw_opt,user_opt);
     


### PR DESCRIPTION
This fixes the seg fault that would occur if the user supplied an unknown option on the command line.      The fix is to only do global option checking if option parsing does not return an error. 