### PR TITLE
Include integrate functionality in ForestClaw

### DIFF
--- a/applications/clawpack/advection/2d/swirl/CMakeLists.txt
+++ b/applications/clawpack/advection/2d/swirl/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(swirl
   swirl_user.cpp 
   swirl.cpp 
   swirl_options.c
+  swirl_ray.c
   $<TARGET_OBJECTS:swirl_f>
 )
 

--- a/applications/clawpack/advection/2d/swirl/fclaw_options.ini
+++ b/applications/clawpack/advection/2d/swirl/fclaw_options.ini
@@ -58,6 +58,7 @@
      # -------------------
      verbosity = essential        
      output = T
+     output-rays = T
 
      # -----------
      # Tikz output 
@@ -76,6 +77,7 @@
      run-user-diagnostics = F
      compute-error = F
      report-timing=T
+     report-timing-verbosity=wall
 
      # -------
      # Mapping

--- a/applications/clawpack/advection/2d/swirl/swirl.cpp
+++ b/applications/clawpack/advection/2d/swirl/swirl.cpp
@@ -27,6 +27,72 @@
 
 #include "../all/advection_user.h"
 
+typedef enum {
+  SWIRL_RAY_LINE,
+  SWIRL_RAY_CIRCLE,
+  SWIRL_RAY_TYPE_LAST
+}
+swirl_ray_type_t;
+
+typedef struct swirl_ray
+{
+  swirl_ray_type_t    rtype;
+  double              xy[2];
+  union {
+    struct {
+      double              vec[2];
+    } line;
+    struct {
+      double              radius;
+    } circle;
+  } r;
+}
+swirl_ray_t;
+
+static int
+intersect_ray (fclaw2d_domain_t *domain, fclaw2d_patch_t * patch,
+               int blockno, int patchno, void *ray, double *integral)
+{
+  swirl_ray_t *swirl_ray;
+
+  /* assert that ray is a valid swirl_ray_t */
+  swirl_ray = (swirl_ray_t *) ray;
+  FCLAW_ASSERT(swirl_ray != NULL);
+  FCLAW_ASSERT(swirl_ray->rtype == SWIRL_RAY_LINE); /* Circles not there yet. */
+
+  if(patchno >= 0) {
+    /* We are at a leaf and the patch is a valid patch of the domain.
+     * Based on the patch, the domain, the blockno and the information stored
+     * in the swirl_ray_t we defined, we now have to set *integral to be the
+     * contribution of this ray-patch combination to the ray integral.
+     * We should return 1 (even though a leaf return value is ignored). */
+
+    /* This is a dummy example.  We add the ray's x component for each patch.
+       Truly, this example must be updated to compute the exact ray integral. */
+    *integral = swirl_ray->r.line.vec[0];
+    return 1;
+  } else {
+    /* We are not at a leaf and the patch is an artificial patch containing all
+     * standard patch information except for the pointer to the next patch and
+     * user-data of any kind. Only the FCLAW2D_PATCH_CHILDID and the
+     * FCLAW2D_PATCH_ON_BLOCK_FACE_* flags are set.
+     * Based on this, we now can run a test to check if the ray and the patch
+     * intersect.
+     * We return 0 if we are certain that the ray does not intersect any
+     * descendant of this patch.
+     * We return 1 if the test concludes that the ray may intersect the patch.
+     * This test may be overinclusive / false positive to optimize for speed.
+     *
+     * The purpose of this test is to remove irrelevant ancestor
+     * patch-ray-combinations early on to avoid unnecessary computations.
+     * We do not need to assign to the integral value for ancestor patches. */
+
+    /* This is a dummy example.  Truly, implement a fast and over-inclusive test
+     * to see if this ray may possibly intersect the patch and return the answer. */
+    return 1;
+  }
+}
+
 static
 fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm, fclaw_options_t* gparms)
 {
@@ -42,12 +108,12 @@ fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm, fclaw_options_t* gparms)
 
     domain = fclaw2d_domain_new_conn_map (mpicomm, gparms->minlevel, conn, cont);
     fclaw2d_domain_list_levels(domain, FCLAW_VERBOSITY_ESSENTIAL);
-    fclaw2d_domain_list_neighbors(domain, FCLAW_VERBOSITY_DEBUG);  
+    fclaw2d_domain_list_neighbors(domain, FCLAW_VERBOSITY_DEBUG);
     return domain;
 }
 
 static
-void run_program(fclaw2d_global_t* glob)
+void run_program(fclaw2d_global_t* glob, sc_array_t *rays, sc_array_t *integrals)
 {
     const user_options_t           *user_opt;
 
@@ -78,14 +144,53 @@ void run_program(fclaw2d_global_t* glob)
        --------------------------------------------------------------- */
     fclaw2d_initialize(glob);
     fclaw2d_run(glob);
+
+    /* For convenience, we integrate after the run of the solver has finished.
+     * In practice, it may be of interest to integrate several times during the
+     * run for different time steps.  To implement this, move the following
+     * call into a repeated diagnostic steps and output the integral values.
+     */
+    fclaw2d_domain_integrate_rays(glob->domain, intersect_ray, rays, integrals);
+
     fclaw2d_finalize(glob);
+}
+
+static int           nlines = 3;
+
+static sc_array_t *
+swirl_rays_new (void)
+{
+  int                 i;
+  swirl_ray_t        *ray;
+  sc_array_t         *a = sc_array_new (sizeof (swirl_ray_t));
+
+  /* add a couple straight rays */
+  for (i = 0; i < nlines; ++i) {
+    ray = (swirl_ray_t *) sc_array_push (a);
+    ray->rtype = SWIRL_RAY_LINE;
+    ray->xy[0] = 0.;
+    ray->xy[1] = 0.;
+    ray->r.line.vec[0] = cos (i * M_PI / nlines);
+    ray->r.line.vec[1] = sin (i * M_PI / nlines);
+  }
+
+  /* add no circles yet */
+  return a;
+}
+
+static sc_array_t *
+swirl_integrals_new(void)
+{
+  return sc_array_new_count (sizeof (double), nlines);
 }
 
 int
 main (int argc, char **argv)
 {
-    fclaw_app_t *app;
     int first_arg;
+    sc_array_t *rays;
+    sc_array_t *integrals;
+    fclaw_app_t *app;
     fclaw_exit_type_t vexit;
 
     /* Options */
@@ -110,12 +215,16 @@ main (int argc, char **argv)
     clawpatch_opt =   fclaw2d_clawpatch_options_register(app,"fclaw_options.ini");
     claw46_opt =        fc2d_clawpack46_options_register(app,"fclaw_options.ini");
     claw5_opt =          fc2d_clawpack5_options_register(app,"fclaw_options.ini");
-    user_opt =                    swirl_options_register(app,"fclaw_options.ini");  
+    user_opt =                    swirl_options_register(app,"fclaw_options.ini");
 
     /* Read configuration file(s) and command line, and process options */
     options = fclaw_app_get_options (app);
     retval = fclaw_options_read_from_file(options);
     vexit =  fclaw_app_options_parse (app, &first_arg,"fclaw_options.ini.used");
+
+    /* Setup some rays to integrate along/around */
+    rays = swirl_rays_new ();
+    integrals = swirl_integrals_new();
 
     /* Run the program */
     if (!retval & !vexit)
@@ -124,7 +233,7 @@ main (int argc, char **argv)
 
         mpicomm = fclaw_app_get_mpi_size_rank (app, NULL, NULL);
         domain = create_domain(mpicomm, fclaw_opt);
-    
+
         /* Create global structure which stores the domain, timers, etc */
         glob = fclaw2d_global_new();
         fclaw2d_global_store_domain(glob, domain);
@@ -136,11 +245,12 @@ main (int argc, char **argv)
         fc2d_clawpack5_options_store    (glob, claw5_opt);
         swirl_options_store             (glob, user_opt);
 
-        run_program(glob);
-
-        fclaw2d_global_destroy(glob);        
+        run_program(glob, rays, integrals);
+        fclaw2d_global_destroy(glob);
     }
-    
+
+    sc_array_destroy (rays);
+    sc_array_destroy (integrals);
     fclaw_app_destroy (app);
 
     return 0;

--- a/applications/clawpack/advection/2d/swirl/swirl.cpp
+++ b/applications/clawpack/advection/2d/swirl/swirl.cpp
@@ -79,13 +79,15 @@ void run_program(fclaw2d_global_t* glob)
      * run for different time steps.  To implement this, move the following
      * call into a repeated diagnostic steps and output the integral values.
      */
+#if 0    
     sc_array_t *rays = swirl_rays_new ();
     sc_array_t *integrals = swirl_integrals_new();
 
-    //fclaw2d_domain_integrate_rays(glob->domain, swirl_intersect_ray, rays, integrals);
+    fclaw2d_domain_integrate_rays(glob->domain, swirl_intersect_ray, rays, integrals);
 
     sc_array_destroy (rays);
     sc_array_destroy (integrals);
+#endif    
 
     fclaw2d_finalize(glob);
 }

--- a/applications/clawpack/advection/2d/swirl/swirl_ray.c
+++ b/applications/clawpack/advection/2d/swirl/swirl_ray.c
@@ -350,9 +350,12 @@ void swirl_deallocate_rays(fclaw2d_global_t *glob,
         rs = NULL;
     }
     /* Match FCLAW_ALLOC, above */
-    FCLAW_FREE(*rays);  
-    *num_rays = 0;  
-    *rays = NULL;
+    if (*num_rays > 0)
+    {
+        FCLAW_FREE(*rays);  
+        *num_rays = 0;  
+        *rays = NULL;        
+    }
 }
 
 void swirl_initialize_rays(fclaw2d_global_t* glob)

--- a/applications/clawpack/advection/2d/swirl/swirl_ray.c
+++ b/applications/clawpack/advection/2d/swirl/swirl_ray.c
@@ -1,0 +1,188 @@
+/*
+  Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "swirl_user.h"
+
+#include "../all/advection_user.h"
+
+#include <fclaw2d_rays.h>
+
+typedef enum 
+{
+    SWIRL_RAY_LINE,
+    SWIRL_RAY_CIRCLE,
+    SWIRL_RAY_TYPE_LAST
+} swirl_ray_type_t;
+
+typedef struct swirl_ray
+{
+    swirl_ray_type_t rtype;
+    double xy[2];
+    union 
+    {
+        struct 
+        {
+            double vec[2];
+        } line;
+        struct 
+        {
+            double radius;
+        } circle;
+    } r;
+} swirl_ray_t;
+
+int swirl_intersect_ray (fclaw2d_domain_t *domain, 
+                         fclaw2d_patch_t * patch,
+                         int blockno, 
+                         int patchno, 
+                         void *ray, 
+                         double *integral)
+{
+  /* assert that ray is a valid swirl_ray_t */
+  swirl_ray_t *swirl_ray = (swirl_ray_t *) ray;
+  FCLAW_ASSERT(swirl_ray != NULL);
+  FCLAW_ASSERT(swirl_ray->rtype == SWIRL_RAY_LINE); /* Circles not there yet. */
+
+  if (patchno >= 0) 
+  {
+     /* We are at a leaf and the patch is a valid patch of the domain.
+     * Based on the patch, the domain, the blockno and the information stored
+     * in the swirl_ray_t we defined, we now have to set *integral to be the
+     * contribution of this ray-patch combination to the ray integral.
+     * We should return 1 (even though a leaf return value is ignored). */
+
+    /* This is a dummy example.  We add the ray's x component for each patch.
+       Truly, this example must be updated to compute the exact ray integral. */
+    *integral = swirl_ray->r.line.vec[0];
+    return 1;
+  } 
+  else 
+  {
+    /* We are not at a leaf and the patch is an artificial patch containing all
+     * standard patch information except for the pointer to the next patch and
+     * user-data of any kind. Only the FCLAW2D_PATCH_CHILDID and the
+     * FCLAW2D_PATCH_ON_BLOCK_FACE_* flags are set.
+     * Based on this, we now can run a test to check if the ray and the patch
+     * intersect.
+     * We return 0 if we are certain that the ray does not intersect any
+     * descendant of this patch.
+     * We return 1 if the test concludes that the ray may intersect the patch.
+     * This test may be overinclusive / false positive to optimize for speed.
+     *
+     * The purpose of this test is to remove irrelevant ancestor
+     * patch-ray-combinations early on to avoid unnecessary computations.
+     * We do not need to assign to the integral value for ancestor patches. */
+
+    /* This is a dummy example.  Truly, implement a fast and over-inclusive test
+     * to see if this ray may possibly intersect the patch and return the answer. */
+    return 1;
+  }
+}
+
+
+static int nlines = 3;
+
+sc_array_t * swirl_rays_new (void)
+{
+    swirl_ray_t *ray;
+    sc_array_t  *a = sc_array_new (sizeof (swirl_ray_t));
+
+    /* add a couple straight rays */
+    for (int i = 0; i < nlines; ++i) 
+    {
+        ray = (swirl_ray_t *) sc_array_push (a);
+        ray->rtype = SWIRL_RAY_LINE;
+        ray->xy[0] = 0.;
+        ray->xy[1] = 0.;
+        ray->r.line.vec[0] = cos (i * M_PI / nlines);
+        ray->r.line.vec[1] = sin (i * M_PI / nlines);
+    }
+
+    /* add no circles yet */
+    return a;
+}
+
+
+
+
+/* Virtual function for setting rays */
+static
+void swirl_allocate_and_define_rays(fclaw2d_global_t *glob, 
+                                    fclaw2d_ray_t** rays, 
+                                    int* num_rays)
+{
+    *num_rays = nlines;
+
+    /* We let the user allocate an array of rays, although what is inside the 
+       generic ray type is left opaque. This is destroy in matching FREE,
+       below. */
+    *rays = (fclaw2d_ray_t*) FCLAW_ALLOC(fclaw2d_ray_t,*num_rays);
+    for (int i = 0; i < nlines; ++i) 
+    {
+        swirl_ray_t *sr = (swirl_ray_t*) FCLAW_ALLOC(swirl_ray_t,1);
+        sr->rtype = SWIRL_RAY_LINE;
+        sr->xy[0] = 0.;
+        sr->xy[1] = 0.;
+        sr->r.line.vec[0] = cos (i * M_PI / nlines);
+        sr->r.line.vec[1] = sin (i * M_PI / nlines);
+        fclaw2d_ray_set_ray(glob,&(*rays)[i],i, sr);
+    }
+}
+
+
+static
+void swirl_deallocate_rays(fclaw2d_global_t *glob, 
+                           fclaw2d_ray_t** rays, 
+                           int* num_rays)
+{
+    for(int i = 0; i < *num_rays; i++)
+    {
+        /* Retrieve rays set above and deallocate them */
+        int id;
+        swirl_ray_t *rs = (swirl_ray_t*) fclaw2d_ray_get_ray(glob,&(*rays)[i],&id);
+        FCLAW_ASSERT(rs != NULL);
+        FCLAW_FREE(rs);
+        rs = NULL;
+    }
+    /* Match FCLAW_ALLOC, above */
+    FCLAW_FREE(*rays);  
+    *num_rays = 0;  
+    *rays = NULL;
+}
+
+void swirl_initialize_rays(fclaw2d_global_t* glob)
+{
+    /* Set up rays */
+    fclaw2d_ray_vtable_t* rays_vt = fclaw2d_ray_vt(); 
+
+    rays_vt->allocate_and_define = swirl_allocate_and_define_rays;
+    rays_vt->deallocate = swirl_deallocate_rays;
+}
+
+
+sc_array_t * swirl_integrals_new(void)
+{
+    return sc_array_new_count (sizeof (double), nlines);
+}

--- a/applications/clawpack/advection/2d/swirl/swirl_ray.c
+++ b/applications/clawpack/advection/2d/swirl/swirl_ray.c
@@ -284,6 +284,11 @@ sc_array_t * swirl_rays_new (void)
     /* add no circles yet */
     return a;
 }
+
+sc_array_t * swirl_integrals_new(void)
+{
+    return sc_array_new_count (sizeof (double), nlines);
+}
 #endif
 
 
@@ -362,7 +367,3 @@ void swirl_initialize_rays(fclaw2d_global_t* glob)
 }
 
 
-sc_array_t * swirl_integrals_new(void)
-{
-    return sc_array_new_count (sizeof (double), nlines);
-}

--- a/applications/clawpack/advection/2d/swirl/swirl_user.cpp
+++ b/applications/clawpack/advection/2d/swirl/swirl_user.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2021 Carsten Burstedde, Donna Calhoun
+Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -43,11 +43,12 @@ void swirl_problem_setup(fclaw2d_global_t* glob)
     SETPROB();
 }
 
-
 void swirl_link_solvers(fclaw2d_global_t *glob)
 {
     fclaw2d_vtable_t *vt = fclaw2d_vt();
     vt->problem_setup = &swirl_problem_setup;  /* Version-independent */
+
+    swirl_initialize_rays(glob);
 
     const user_options_t* user = swirl_get_options(glob);
     if (user->claw_version == 4)

--- a/applications/clawpack/advection/2d/swirl/swirl_user.cpp
+++ b/applications/clawpack/advection/2d/swirl/swirl_user.cpp
@@ -47,7 +47,7 @@ void swirl_link_solvers(fclaw2d_global_t *glob)
 {
     fclaw2d_vtable_t *vt = fclaw2d_vt();
     vt->problem_setup = &swirl_problem_setup;  /* Version-independent */
-
+    
     swirl_initialize_rays(glob);
 
     const user_options_t* user = swirl_get_options(glob);

--- a/applications/clawpack/advection/2d/swirl/swirl_user.h
+++ b/applications/clawpack/advection/2d/swirl/swirl_user.h
@@ -31,9 +31,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef __cplusplus
 extern "C"
 {
-#if 0
-}
 #endif
+
+#if 0
+/* fix syntax highlighting */
 #endif
 
 typedef struct user_options
@@ -54,10 +55,57 @@ void swirl_options_store (fclaw2d_global_t* glob, user_options_t* user);
 
 const user_options_t* swirl_get_options(fclaw2d_global_t* glob);
 
-#ifdef __cplusplus
+
+/* ------------------------------------- Rays ---------------------------------------*/
+
 #if 0
+typedef enum 
 {
+  SWIRL_RAY_LINE,
+  SWIRL_RAY_CIRCLE,
+  SWIRL_RAY_TYPE_LAST
+} swirl_ray_type_t;
+
+
+typedef struct swirl_ray
+{
+  swirl_ray_type_t    rtype;
+  double              xy[2];
+  union {
+    struct {
+      double              vec[2];
+    } line;
+    struct {
+      double              radius;
+    } circle;
+  } r;
+} swirl_ray_t;
 #endif
+
+int swirl_intersect_ray(fclaw2d_domain_t *domain, 
+                         fclaw2d_patch_t * patch,
+                         int blockno, 
+                         int patchno, 
+                         void *ray, 
+                         double *integral);
+
+#if 0
+void swirl_define_ray(fclaw2d_global_t *glob, 
+                      fclaw2d_ray_t** rays, 
+                      int* num_rays);
+
+void swirl_destroy_ray(fclaw2d_global_t *glob,void* ray);
+#endif
+
+void swirl_initialize_rays(fclaw2d_global_t* glob);
+
+
+sc_array_t * swirl_integrals_new(void);
+sc_array_t * swirl_rays_new (void);
+
+
+
+#ifdef __cplusplus
 }
 #endif
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,7 @@
 add_library(forestclaw_c OBJECT 
   fclaw_base.c 
   fclaw_options.c 
-  fclaw_gauges.c 
+  fclaw_gauges.c
   fclaw_package.c 
   fclaw_math.c 
   fclaw_timer.c 
@@ -26,6 +26,7 @@ add_library(forestclaw_c OBJECT
   fclaw2d_output.c 
   fclaw2d_run.c 
   fclaw2d_diagnostics.c 
+  fclaw2d_rays.c
   fclaw2d_update_single_step.c 
   fclaw2d_domain.c
   fclaw2d_regrid.c 

--- a/src/fclaw2d_convenience.c
+++ b/src/fclaw2d_convenience.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012 Carsten Burstedde, Donna Calhoun
+Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -1099,3 +1099,130 @@ fclaw2d_domain_search_points (fclaw2d_domain_t * domain,
     /* tidy up memory */
     sc_array_destroy (points);
 }
+typedef struct fclaw2d_ray_integral
+{
+    void *ray;
+    double *integral;
+}
+fclaw2d_ray_integral_t;
+
+typedef struct fclaw2d_integrate_ray_data
+{
+    fclaw2d_domain_t *domain;
+    fclaw2d_integrate_ray_t integrate_ray;
+}
+fclaw2d_integrate_ray_data_t;
+
+static int
+integrate_ray_fn (p4est_t * p4est, p4est_topidx_t which_tree,
+                  p4est_quadrant_t * quadrant, p4est_locidx_t local_num,
+                  void *point)
+{
+    double integral;
+    int intersects;
+    fclaw2d_domain_t *domain;
+    fclaw2d_patch_t *patch;
+    fclaw2d_patch_t fclaw2d_patch;
+    int patchno;
+
+    /* assert that the user_pointer contains a valid integrate_ray_data_t */
+    fclaw2d_integrate_ray_data_t *ird
+        = (fclaw2d_integrate_ray_data_t *) p4est->user_pointer;
+    FCLAW_ASSERT (ird != NULL);
+    FCLAW_ASSERT (ird->domain != NULL);
+    FCLAW_ASSERT (ird->integrate_ray != NULL);
+
+    /* assert that point is a valid ray_integral_t */
+    fclaw2d_ray_integral_t *ri = (fclaw2d_ray_integral_t *) point;
+    FCLAW_ASSERT (ri != NULL);
+    FCLAW_ASSERT (ri->ray != NULL);
+    FCLAW_ASSERT (ri->integral != NULL);
+
+    /* collect patch information */
+    domain = ird->domain;
+    if (local_num >= 0)
+    {
+        fclaw2d_block_t *block = domain->blocks + which_tree;
+        patchno = local_num - block->num_patches_before;
+        patch = block->patches + patchno;
+    }
+    else
+    {
+        /* create artifical patch and fill it based on the quadrant */
+        patchno = -1;
+        patch = &fclaw2d_patch;
+        patch->level = quadrant->level;
+        patch->target_level = quadrant->level;
+        patch->flags = p4est_quadrant_child_id (quadrant);
+        fclaw2d_patch_set_boundary_xylower (patch, quadrant);
+        patch->u.next = NULL;
+        patch->user = NULL;
+    }
+
+    /* compute local integral and add it onto the ray integral */
+    integral = 0.;
+    intersects = ird->integrate_ray (domain, patch, which_tree, patchno,
+                                     ri->ray, &integral);
+    if (local_num >= 0) {
+        *(ri->integral) += integral;
+    }
+    return intersects;
+}
+
+void
+fclaw2d_domain_integrate_rays (fclaw2d_domain_t * domain,
+                               fclaw2d_integrate_ray_t intersect,
+                               sc_array_t * rays, sc_array_t * integrals)
+{
+    size_t i, nintz;
+    sc_array_t lints[1];
+    sc_array_t ri[1];
+    fclaw2d_ray_integral_t *rayint;
+    fclaw2d_integrate_ray_data_t integrate_ray_data, *ird =
+        &integrate_ray_data;
+    p4est_t p4est;
+    p4est_wrap_t *wrap;
+
+    /* assert validity of parameters */
+    FCLAW_ASSERT (domain != NULL);
+    FCLAW_ASSERT (intersect != NULL);
+    FCLAW_ASSERT (rays != NULL);
+    FCLAW_ASSERT (integrals != NULL);
+    FCLAW_ASSERT (integrals->elem_size == sizeof (double));
+    FCLAW_ASSERT (rays->elem_count == integrals->elem_count);
+
+    /* create local storage for integral values */
+    nintz = integrals->elem_count;
+    sc_array_init_count (lints, sizeof (double), nintz);
+    memset (lints->array, 0, sizeof (double) * nintz);
+
+    /* construct ray_integral_t array from rays */
+    sc_array_init_count (ri, sizeof (fclaw2d_ray_integral_t), nintz);
+    for (i = 0; i < nintz; i++)
+    {
+        rayint = (fclaw2d_ray_integral_t *) sc_array_index_int (ri, i);
+        rayint->ray = sc_array_index_int (rays, i);
+        rayint->integral = (double *) sc_array_index_int (lints, i);
+    }
+
+    /* construct fclaw2d_integrate_ray_data_t */
+    ird->domain = domain;
+    ird->integrate_ray = intersect;
+
+    /* process-local integration through p4est */
+    wrap = (p4est_wrap_t *) domain->pp;
+    FCLAW_ASSERT (wrap != NULL);
+    FCLAW_ASSERT (wrap->p4est != NULL);
+    p4est = *(wrap->p4est);
+    p4est.user_pointer = ird;
+    p4est_search_local (&p4est, 0, NULL, integrate_ray_fn, ri);
+
+    /* allreduce local integral values in parallel */
+    sc_MPI_Allreduce (lints->array, integrals->array, nintz,
+                      sc_MPI_DOUBLE, sc_MPI_SUM, domain->mpicomm);
+
+    sc_array_reset (ri);
+    sc_array_reset (lints);
+}
+
+#endif /* !P4_TO_P8 */

--- a/src/fclaw2d_convenience.c
+++ b/src/fclaw2d_convenience.c
@@ -723,6 +723,8 @@ fclaw2d_domain_complete (fclaw2d_domain_t * domain)
     p4est_wrap_complete (wrap);
 }
 
+#ifndef P4_TO_P8
+
 void
 fclaw2d_domain_write_vtk (fclaw2d_domain_t * domain, const char *basename)
 {

--- a/src/fclaw2d_convenience.h
+++ b/src/fclaw2d_convenience.h
@@ -185,6 +185,73 @@ void fclaw2d_domain_search_points (fclaw2d_domain_t * domain,
                                    sc_array_t * coordinates,
                                    sc_array_t * results);
 
+/** Callback function to compute the integral of a "ray" within a patch.
+ *
+ * This function can be passed to \ref fclaw2d_domain_integrate_rays to
+ * eventually compute the integrals over the whole domain for an array of rays.
+ *
+ * \param [in] domain           The domain to integrate on.
+ * \param [in] patch            The patch under consideration.
+ *                              When on a leaf, this is a valid forestclaw patch.
+ *                              Otherwise, this is a temporary artificial patch
+ *                              containing all standard patch information except
+ *                              for the pointer to the next patch and user-data.
+ *                              Only the FCLAW2D_PATCH_CHILDID and the
+ *                              FCLAW2D_PATCH_ON_BLOCK_FACE_* flags are set.
+ *                              Artificial patches are generally ancestors of
+ *                              valid forestclaw patches that are leaves.
+ * \param [in] blockno          The block id of the patch under consideration.
+ * \param [in] patchno          When on a leaf, this is a valid patch number.
+ *                              In this case, this callback must set the
+ *                              integral value to the local contribution of this
+ *                              patch and ray.
+ *                              Otherwise, patchno is -1.  In this case, the
+ *                              integral value is ignored.
+ * \param [in] ray              Representation of a "ray"; user-defined.
+ *                              Points to an array element of the rays passed
+ *                              to \ref fclaw2d_domain_integrate_rays.
+ * \param [in,out] integral     The integral value associated with the ray.
+ *                              On input this is 0.
+ *                              For leaves this callback must set it to the
+ *                              exact integral contribution for this patch and
+ *                              ray.
+ * \return                      True if there is a possible/partial intersection of the
+ *                              patch (which may be an ancestor) with the ray.
+ *                              This may be a false positive; we'll be fine.
+ *                              Return false if there is definitely no intersection.
+ *                              Only for leaves, this function must compute
+ *                              the exact integral contribution for this
+ *                              patch by intersecting this ray and store it in
+ *                              the \a integral output argument.
+ *                              The integral value may well be 0. if the intersection
+ *                              is, in fact, none (a false positive).
+ */
+typedef int (*fclaw2d_integrate_ray_t) (fclaw2d_domain_t * domain,
+                                        fclaw2d_patch_t * patch,
+                                        int blockno, int patchno,
+                                        void *ray, double *integral);
+
+/** Compute the integrals of an array of user-defined rays.
+ * The integral for each ray and intersection quadrant is supplied by a callback.
+ * We store the results in an array of integral values of type double.
+ *
+ * \param [in] domain           The domain to integrate on.
+ * \param [in] intersect        Callback function that returns true if a ray
+ *                              intersects a patch and -- when called for a leaf
+ *                              -- shall output the integral of the ray segment.
+ * \param [in] rays             Array containing the rays of user-defined type.
+ *                              Each entry contains one item of arbitrary data.
+ *                              We do not dereference, just pass pointers around.
+ * \param [out] integrals       On output, array of double types representing a
+ *                              ray's integral value.  Input values are ignored.
+ *                              The number of entries must equal the number of rays.
+ *                              On output, we provide the final integral values.
+ */
+void fclaw2d_domain_integrate_rays (fclaw2d_domain_t * domain,
+                                    fclaw2d_integrate_ray_t intersect,
+                                    sc_array_t * rays,
+                                    sc_array_t * integrals);
+
 #ifdef __cplusplus
 #if 0
 {                               /* need this because indent is dumb */

--- a/src/fclaw2d_diagnostics.c
+++ b/src/fclaw2d_diagnostics.c
@@ -101,6 +101,10 @@ void fclaw2d_diagnostics_initialize(fclaw2d_global_t *glob)
     if (diag_vt->gauges_init_diagnostics != NULL)
         diag_vt->gauges_init_diagnostics(glob,&acc->gauge_accumulator);
 
+    /* rays */
+    if (diag_vt->ray_init_diagnostics != NULL)
+        diag_vt->ray_init_diagnostics(glob,&acc->ray_accumulator);
+
     /* solvers */
     if (diag_vt->solver_init_diagnostics != NULL)
         diag_vt->solver_init_diagnostics(glob,&acc->solver_accumulator);
@@ -133,6 +137,10 @@ void fclaw2d_diagnostics_gather(fclaw2d_global_t *glob,
     if (diag_vt->gauges_compute_diagnostics != NULL)
         diag_vt->gauges_compute_diagnostics(glob,acc->gauge_accumulator);
 
+    /* Rays diagnostics */
+    if (diag_vt->ray_compute_diagnostics != NULL)
+        diag_vt->ray_compute_diagnostics(glob,acc->ray_accumulator);
+
     /* Solver diagnostics */
     if (diag_vt->solver_compute_diagnostics != NULL)
         diag_vt->solver_compute_diagnostics(glob,acc->solver_accumulator);
@@ -154,6 +162,9 @@ void fclaw2d_diagnostics_gather(fclaw2d_global_t *glob,
 
     if (diag_vt->gauges_gather_diagnostics != NULL)
         diag_vt->gauges_gather_diagnostics(glob,acc->gauge_accumulator,init_flag);
+
+    if (diag_vt->ray_gather_diagnostics != NULL)
+        diag_vt->ray_gather_diagnostics(glob,acc->ray_accumulator,init_flag);
 
     if (diag_vt->solver_gather_diagnostics != NULL)
         diag_vt->solver_gather_diagnostics(glob,acc->solver_accumulator,init_flag);
@@ -180,6 +191,9 @@ void fclaw2d_diagnostics_reset(fclaw2d_global_t *glob)
     if (diag_vt->gauges_reset_diagnostics != NULL)
         diag_vt->gauges_reset_diagnostics(glob,acc->gauge_accumulator);
 
+    if (diag_vt->ray_reset_diagnostics != NULL)
+        diag_vt->ray_reset_diagnostics(glob,acc->ray_accumulator);
+
     if (diag_vt->solver_reset_diagnostics != NULL)
         diag_vt->solver_reset_diagnostics(glob,acc->solver_accumulator);
 
@@ -202,6 +216,9 @@ void fclaw2d_diagnostics_finalize(fclaw2d_global_t *glob)
 
     if (diag_vt->gauges_finalize_diagnostics != NULL)
         diag_vt->gauges_finalize_diagnostics(glob,&acc->gauge_accumulator);
+
+    if (diag_vt->ray_finalize_diagnostics != NULL)
+        diag_vt->ray_finalize_diagnostics(glob,&acc->ray_accumulator);
 
     if (diag_vt->solver_finalize_diagnostics != NULL)
         diag_vt->solver_finalize_diagnostics(glob,&acc->solver_accumulator);

--- a/src/fclaw2d_diagnostics.h
+++ b/src/fclaw2d_diagnostics.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012 Carsten Burstedde, Donna Calhoun
+Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -29,9 +29,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef __cplusplus
 extern "C"
 {
-#if 0
-}
-#endif
 #endif
 
 struct fclaw2d_global;
@@ -47,6 +44,7 @@ struct fclaw2d_diagnostics_accumulator
     void* solver_accumulator;
     void* user_accumulator;
     void* gauge_accumulator;
+    void* ray_accumulator;
 };
 
 /* Diagnostic information */
@@ -89,6 +87,13 @@ struct fclaw2d_diagnostics_vtable
     fclaw2d_diagnostics_reset_t          gauges_reset_diagnostics;
     fclaw2d_diagnostics_finalize_t       gauges_finalize_diagnostics;
 
+    /* ray defined diagnostics */
+    fclaw2d_diagnostics_initialize_t     ray_init_diagnostics;
+    fclaw2d_diagnostics_compute_t        ray_compute_diagnostics;
+    fclaw2d_diagnostics_gather_t         ray_gather_diagnostics;
+    fclaw2d_diagnostics_reset_t          ray_reset_diagnostics;
+    fclaw2d_diagnostics_finalize_t       ray_finalize_diagnostics;
+
     /* user defined diagnostics */
     fclaw2d_diagnostics_initialize_t     user_init_diagnostics;
     fclaw2d_diagnostics_compute_t        user_compute_diagnostics;
@@ -114,9 +119,6 @@ void fclaw2d_diagnostics_reset(struct fclaw2d_global *glob);
 void fclaw2d_diagnostics_finalize(struct fclaw2d_global *glob);
 
 #ifdef __cplusplus
-#if 0
-{
-#endif
 }
 #endif
 

--- a/src/fclaw2d_forestclaw.c
+++ b/src/fclaw2d_forestclaw.c
@@ -30,6 +30,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <fclaw2d_vtable.h>
 #include <fclaw2d_diagnostics.h>
 #include <fclaw_gauges.h>
+#include <fclaw2d_rays.h>
 
 #include <fclaw2d_elliptic_solver.h>
 
@@ -40,7 +41,8 @@ void fclaw2d_vtables_initialize(fclaw2d_global_t *glob)
     fclaw2d_diagnostics_vtable_initialize();
     fclaw2d_elliptic_vtable_initialize();
 
-    fclaw_gauges_vtable_initialize();    
+    fclaw_gauges_vtable_initialize();
+    fclaw2d_ray_vtable_initialize();
 }
 
 void fclaw2d_problem_setup(fclaw2d_global_t *glob)

--- a/src/fclaw2d_rays.c
+++ b/src/fclaw2d_rays.c
@@ -180,6 +180,7 @@ void ray_finalize(fclaw2d_global_t *glob, void** acc)
     {
         ray_deallocate(glob,&ray_acc->rays,&ray_acc->num_rays);
     }
+    /* Matches allocation in ray_initialize */
     FCLAW_FREE(*acc);
     *acc = 0;
 }

--- a/src/fclaw2d_rays.c
+++ b/src/fclaw2d_rays.c
@@ -1,0 +1,200 @@
+/*
+Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "fclaw2d_rays.h"
+#include "fclaw2d_global.h"
+#include "fclaw2d_options.h"
+#include "fclaw2d_diagnostics.h"
+
+static fclaw2d_ray_vtable_t s_ray_vt;
+
+
+typedef struct fclaw2d_ray_acc
+{
+    int num_rays;
+    int is_latest_domain;
+    fclaw2d_ray_t *rays;
+} fclaw2d_ray_acc_t;
+
+
+
+/* ------------------------------ Virtualized functions ------------------------------- */
+
+/* Do I need this level of indirection? */
+static
+void ray_allocate_and_define(fclaw2d_global_t* glob, 
+                             fclaw2d_ray_t **rays, 
+                             int *num_rays)
+{
+    const fclaw2d_ray_vtable_t* ray_vt = fclaw2d_ray_vt();
+
+    FCLAW_ASSERT(ray_vt->allocate_and_define != NULL);
+    ray_vt->allocate_and_define(glob, rays, num_rays);    
+}
+
+static
+void ray_deallocate(fclaw2d_global_t* glob, 
+                    fclaw2d_ray_t **rays, 
+                    int *num_rays)
+{
+    const fclaw2d_ray_vtable_t* ray_vt = fclaw2d_ray_vt();
+
+    FCLAW_ASSERT(ray_vt->deallocate != NULL);
+    ray_vt->deallocate(glob, rays, num_rays);    
+}
+
+
+
+
+static
+void ray_initialize(fclaw2d_global_t* glob, void** acc)
+{
+    fclaw2d_ray_acc_t *ray_acc = (fclaw2d_ray_acc_t*) FCLAW_ALLOC(fclaw2d_ray_acc_t,1);
+
+    /* Check to see if user wants ray output */
+    int num_rays;
+    const fclaw_options_t * fclaw_opt = fclaw2d_get_options(glob);
+    if (!fclaw_opt->output_rays)
+    {
+        num_rays = 0;
+        ray_acc->rays = NULL;
+    }
+    else
+    {
+        /* This allocates memory for pointers to fclaw2d_ray_t types, 
+           User defined rays are also allocated and stored. 
+           We could allocate ray_acc->rays here, but we don't know ahead of time 
+           how many rays to create.  Only the user knows this */
+        ray_allocate_and_define(glob, &ray_acc->rays, &num_rays);
+    }
+    *acc = ray_acc;
+    ray_acc->num_rays = num_rays;
+
+
+    if (num_rays > 0)
+    {
+        /* Things that could be done here : 
+           1. Open ray files to write out time series data for each ray 
+           2. Set integral to 0? 
+        */
+        //fclaw2d_ray_t *rays = ray_acc->rays;
+        for(int i = 0; i < num_rays; i++)
+        {
+            //fclaw2d_ray_t *r = &rays[i];
+            fclaw_global_essentialf("ray_initialize : Setting up ray %d : \n",i);
+            /* do something? */
+        }
+    }
+}
+
+#if 0
+static
+void rays_reset(fclaw2d_global_t *glob, void**acc)
+{
+    /* Do nothing for now */
+}
+#endif
+
+
+static
+void ray_integrate(fclaw2d_global_t *glob, void *acc)
+{
+    /* Do nothing for now */
+}
+
+static
+void ray_finalize(fclaw2d_global_t *glob, void** acc)
+{
+    fclaw2d_ray_acc_t* ray_acc = *((fclaw2d_ray_acc_t**) acc);
+    FCLAW_ASSERT(ray_acc->rays != NULL);
+
+    ray_deallocate(glob,&ray_acc->rays,&ray_acc->num_rays);
+
+    FCLAW_FREE(*acc);
+    *acc = 0;
+}
+
+
+/* ---------------------------------- Virtual table  ---------------------------------- */
+
+static
+fclaw2d_ray_vtable_t* fclaw2d_ray_vt_init()
+{
+    //FCLAW_ASSERT(s_rays_vt.is_set == 0);
+    return &s_ray_vt;
+}
+
+fclaw2d_ray_vtable_t* fclaw2d_ray_vt()
+{
+    FCLAW_ASSERT(s_ray_vt.is_set != 0);
+    return &s_ray_vt;
+}
+
+void fclaw2d_ray_vtable_initialize()
+{
+
+    fclaw2d_diagnostics_vtable_t * diag_vt = fclaw2d_diagnostics_vt();
+    fclaw2d_ray_vtable_t* rays_vt = fclaw2d_ray_vt_init(); 
+
+    diag_vt->ray_init_diagnostics     = ray_initialize;    
+    diag_vt->ray_compute_diagnostics  = ray_integrate;
+    diag_vt->ray_gather_diagnostics  = NULL; /* Gather is handled in compute step */
+    diag_vt->ray_finalize_diagnostics = ray_finalize;
+
+    rays_vt->is_set = 1;
+}
+
+
+/* ---------------------------- Get Access Functions ---------------------------------- */
+
+
+/* Routines that operate on a single array */
+void fclaw2d_ray_set_ray(fclaw2d_global_t *glob, 
+                         fclaw2d_ray_t *r,
+                         int id, 
+                         void* ray_data)
+{
+    /* User calls this to set ray data */
+    r->num = id;
+    r->ray_data = ray_data;
+}
+
+
+
+void* fclaw2d_ray_get_ray(fclaw2d_global_t *glob, 
+                          fclaw2d_ray_t *r,
+                          int *id)
+{
+    *id = r->num;
+    return r->ray_data;
+}
+
+
+#ifdef __cplusplus
+}
+#endif
+
+
+

--- a/src/fclaw2d_rays.c
+++ b/src/fclaw2d_rays.c
@@ -113,7 +113,8 @@ void ray_initialize(fclaw2d_global_t* glob, void** acc)
 static
 void rays_reset(fclaw2d_global_t *glob, void**acc)
 {
-    /* Do nothing for now */
+    /* The obvious thing to do is to set the integral to 0, 
+       but this is handled by fclaw2d_convenience.c */
 }
 #endif
 
@@ -154,6 +155,8 @@ void ray_integrate(fclaw2d_global_t *glob, void *acc)
 static
 void ray_gather(fclaw2d_global_t *glob, void* acc, int init_flag)
 {
+    /* Here is where we would do an all-reduce, but again this
+      is handled by fclaw2d_convenience routines */
     fclaw2d_ray_acc_t* ray_acc = (fclaw2d_ray_acc_t*) acc;
     FCLAW_ASSERT(ray_acc != NULL);
 
@@ -164,7 +167,7 @@ void ray_gather(fclaw2d_global_t *glob, void* acc, int init_flag)
         fclaw2d_ray_t *ray = &rays[i];
         int id = ray->num;
         double intval = ray->integral;
-        fclaw_global_essentialf("ray[%d] : id = %2d; integral = %16.6e\n",i,id,intval);
+        fclaw_global_essentialf("ray[%d] : id = %2d; integral = %24.16e\n",i,id,intval);
     }
 }
 
@@ -173,10 +176,10 @@ static
 void ray_finalize(fclaw2d_global_t *glob, void** acc)
 {
     fclaw2d_ray_acc_t* ray_acc = *((fclaw2d_ray_acc_t**) acc);
-    FCLAW_ASSERT(ray_acc->rays != NULL);
-
-    ray_deallocate(glob,&ray_acc->rays,&ray_acc->num_rays);
-
+    if (ray_acc->rays != NULL)
+    {
+        ray_deallocate(glob,&ray_acc->rays,&ray_acc->num_rays);
+    }
     FCLAW_FREE(*acc);
     *acc = 0;
 }

--- a/src/fclaw2d_rays.c
+++ b/src/fclaw2d_rays.c
@@ -68,8 +68,6 @@ void ray_deallocate(fclaw2d_global_t* glob,
 }
 
 
-
-
 static
 void ray_initialize(fclaw2d_global_t* glob, void** acc)
 {
@@ -94,20 +92,21 @@ void ray_initialize(fclaw2d_global_t* glob, void** acc)
     *acc = ray_acc;
     ray_acc->num_rays = num_rays;
 
-
+#if 0
     if (num_rays > 0)
     {
         /* Things that could be done here : 
            1. Open ray files to write out time series data for each ray 
            2. Set integral to 0? 
         */
-        //fclaw2d_ray_t *rays = ray_acc->rays;
+        fclaw2d_ray_t *rays = ray_acc->rays;
         for(int i = 0; i < num_rays; i++)
         {
-            //fclaw2d_ray_t *r = &rays[i];
+            fclaw2d_ray_t *r = &rays[i];
             /* do something? */
         }
     }
+#endif    
 }
 
 #if 0
@@ -125,8 +124,6 @@ void ray_integrate(fclaw2d_global_t *glob, void *acc)
     fclaw2d_ray_acc_t* ray_acc = (fclaw2d_ray_acc_t*) acc;
     FCLAW_ASSERT(ray_acc != NULL);
 
-    const fclaw2d_ray_vtable_t* ray_vt = fclaw2d_ray_vt();
-
     /* Copy arrays stored in accumulator to an sc_array */
     sc_array_t  *sc_rays = sc_array_new (sizeof (fclaw2d_ray_t));
     int num_rays = ray_acc->num_rays;
@@ -140,6 +137,7 @@ void ray_integrate(fclaw2d_global_t *glob, void *acc)
     sc_array_t *integrals = sc_array_new_count (sizeof (double), num_rays);
 
     /* This does a compute and a gather. */
+    const fclaw2d_ray_vtable_t* ray_vt = fclaw2d_ray_vt();
     fclaw2d_domain_integrate_rays(glob->domain, ray_vt->integrate, sc_rays, integrals);
 
     /* Copy integral value back to fclaw2d_ray_t */

--- a/src/fclaw2d_rays.h
+++ b/src/fclaw2d_rays.h
@@ -1,0 +1,128 @@
+/*
+Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef FCLAW2D_INTEGRATE_H
+#define FCLAW2D_INTEGRATE_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#if 0
+/* fix syntax highlighting */
+#endif    
+
+struct fclaw2d_global;
+struct fclaw2d_domain;
+
+
+//#include "fclaw2d_convenience.h"
+
+typedef struct fclaw2d_ray_vtable fclaw2d_ray_vtable_t;
+
+struct fclaw2d_global;
+
+/* This is a polynmorphic type */
+typedef struct fclaw2d_ray
+{
+    int num;                /* User defined ID */
+    void* ray_data;         /* User defined */
+} fclaw2d_ray_t;
+
+
+typedef void (*fclaw2d_ray_allocate_and_define_t)(struct fclaw2d_global *glob, 
+                                                  fclaw2d_ray_t **rays, 
+                                                  int *num);
+
+typedef void (*fclaw2d_ray_deallocate_t)(struct fclaw2d_global *glob, 
+                                         fclaw2d_ray_t **rays, 
+                                         int *num);
+
+#if 0
+typedef void (*fclaw2d_ray_create_files_t)(struct fclaw2d_global *glob, 
+                                           struct fclaw2d_ray *rays, 
+                                           int num_rays);
+
+typedef void (*fclaw2d_ray_normalize_t)(struct fclaw2d_global *glob, 
+                                       struct fclaw2d_block *block,
+                                       int blockno, 
+                                       struct fclaw2d_ray *g,
+                                       double *xc, double *yc);
+
+
+typedef void (*fclaw2d_ray_update_t)(struct fclaw2d_global* glob, 
+                                     struct fclaw2d_block* block,
+                                     struct fclaw2d_patch* patch, 
+                                     int blockno, int patchno,
+                                     double tcurr, struct fclaw2d_ray *g);
+
+typedef void (*fclaw2d_ray_print_t)(struct fclaw2d_global *glob, 
+                                    struct fclaw2d_ray *ray);
+
+typedef void (*fclaw2d_ray_destroy_buffer_data_t)(struct fclaw2d_global *glob, 
+                                                  void* gdata);
+
+#endif
+
+
+struct fclaw2d_ray_vtable
+{
+    fclaw2d_ray_allocate_and_define_t   allocate_and_define;
+    fclaw2d_ray_deallocate_t            deallocate;
+#if 0
+    fclaw2d_ray_create_files_t  create_ray_files;
+    fclaw2d_ray_update_t        update_ray;
+    fclaw2d_ray_print_t         print_ray_buffer;
+    fclaw2d_ray_normalize_t     normalize_coordinates;
+#endif    
+
+    int is_set;
+};
+
+
+void fclaw2d_ray_allocate_and_define(struct fclaw2d_global* glob, 
+                                     fclaw2d_ray_t **rays, 
+                                     int *num_rays);
+
+void fclaw2d_ray_deallocate(struct fclaw2d_global* glob, 
+                            fclaw2d_ray_t **rays, 
+                            int *num_rays);
+
+void fclaw2d_ray_set_ray(struct fclaw2d_global *glob, 
+                         fclaw2d_ray_t *r,
+                         int id, void* ray_data);
+
+void* fclaw2d_ray_get_ray(struct fclaw2d_global *glob, 
+                         fclaw2d_ray_t *r,
+                         int *id);
+
+fclaw2d_ray_vtable_t* fclaw2d_ray_vt();
+
+void fclaw2d_ray_vtable_initialize();
+
+
+
+#endif

--- a/src/fclaw2d_rays.h
+++ b/src/fclaw2d_rays.h
@@ -26,6 +26,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef FCLAW2D_INTEGRATE_H
 #define FCLAW2D_INTEGRATE_H
 
+#include "fclaw2d_convenience.h"  /* Needed for def. of fclaw2d_integrate_t */
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -39,7 +41,6 @@ struct fclaw2d_global;
 struct fclaw2d_domain;
 
 
-//#include "fclaw2d_convenience.h"
 
 typedef struct fclaw2d_ray_vtable fclaw2d_ray_vtable_t;
 
@@ -50,6 +51,7 @@ typedef struct fclaw2d_ray
 {
     int num;                /* User defined ID */
     void* ray_data;         /* User defined */
+    double integral;
 } fclaw2d_ray_t;
 
 
@@ -92,6 +94,8 @@ struct fclaw2d_ray_vtable
 {
     fclaw2d_ray_allocate_and_define_t   allocate_and_define;
     fclaw2d_ray_deallocate_t            deallocate;
+
+    fclaw2d_integrate_ray_t             integrate;   /* Function that does the integration */
 #if 0
     fclaw2d_ray_create_files_t  create_ray_files;
     fclaw2d_ray_update_t        update_ray;
@@ -111,13 +115,12 @@ void fclaw2d_ray_deallocate(struct fclaw2d_global* glob,
                             fclaw2d_ray_t **rays, 
                             int *num_rays);
 
-void fclaw2d_ray_set_ray(struct fclaw2d_global *glob, 
-                         fclaw2d_ray_t *r,
-                         int id, void* ray_data);
+void fclaw2d_ray_set_ray(fclaw2d_ray_t *r, 
+                         int id, 
+                         void* ray_data);
 
-void* fclaw2d_ray_get_ray(struct fclaw2d_global *glob, 
-                         fclaw2d_ray_t *r,
-                         int *id);
+void* fclaw2d_ray_get_ray(fclaw2d_ray_t *r, 
+                          int *id);
 
 fclaw2d_ray_vtable_t* fclaw2d_ray_vt();
 

--- a/src/fclaw_options.c
+++ b/src/fclaw_options.c
@@ -123,6 +123,11 @@ fclaw_register (fclaw_options_t* fclaw_opt, sc_options_t * opt)
                        &fclaw_opt->gauge_buffer_length, 1,
                        "Number of lines of gauge output to buffer before printing [1]");
 
+    /* ---------------------------------------- Rays  --------------------------------- */
+    /* Gauge options */
+    sc_options_add_bool (opt, 0, "output-rays", &fclaw_opt->output_rays, 0,
+                            "Print ray output [F]");
+
     /* -------------------------------- tikz output ----------------------------------- */
     sc_options_add_bool (opt, 0, "tikz-out", &fclaw_opt->tikz_out, 0,
                          "Enable tikz output for gridlines [F]");

--- a/src/fclaw_options.h
+++ b/src/fclaw_options.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2021 Carsten Burstedde, Donna Calhoun
+Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -150,6 +150,8 @@ struct fclaw_options
     /* Gauges */
     int output_gauges;
     int gauge_buffer_length;       
+
+    int output_rays;
 
     /* Mapping functions */
     int manifold;


### PR DESCRIPTION
This added @cburstedde integrate functionality to ForestClaw. 

* See simple example in swirl.  This example integrates a ray that starts at the origin (lower left corner of swirl domain) and ends along quarter circle in x>0, y>0. Radius of circle is set to .25, so integral along ray (which now only computes length of ray) is easy to compute.  
* Code checks intersection of simple ray (arrow) with  p4est quad, and determines if (1) ray misses quad entirely, (2) quad enters and exits quad, (3) ray enters quad but  ends inside quad, (4) ray starts inside quad and exits.  
The length of the ray is computed by compute length of any segment of the intersection of ray with quad. 

Several outstanding issues : 

* What happens if a general ray (possible parameterized curve) does not intersection coarse level quad.  Will finer levels quad in this coarser quad be tested? 
* Direction of integration should be taken into account 
* Interesting to see how to compute intersection with generalized parameterized curves.  