### PR TITLE
Don't force time interpolation

### DIFF
--- a/applications/clawpack/advection/2d/swirl/afterframe.m
+++ b/applications/clawpack/advection/2d/swirl/afterframe.m
@@ -7,14 +7,15 @@ yrbcolormap;
 showpatchborders;
 setpatchborderprops('linewidth',1)
 
-fprintf('%6s %12s\n','qmin',under_label);
-fprintf('%6s %12s\n\n','qmax',over_label);
-
 caxis([0,1])
 qlo = 0;
 qhi = 1;
 under_label = sprintf('0 - %7.1e',qlo-qmin);
 over_label = sprintf('1 + %7.1e',qmax-qhi);
+
+fprintf('%6s %12s\n','qmin',under_label);
+fprintf('%6s %12s\n\n','qmax',over_label);
+
 
 
 if (ShowUnderOverShoots)

--- a/src/fclaw_options.c
+++ b/src/fclaw_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2021 Carsten Burstedde, Donna Calhoun
+Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -92,6 +92,9 @@ fclaw_register (fclaw_options_t* fclaw_opt, sc_options_t * opt)
 
     sc_options_add_bool (opt, 0, "subcycle", &fclaw_opt->subcycle, 1,
                          "Use subcycling in time [T]");
+
+    sc_options_add_bool (opt, 0, "ghost-fill-uses-time-interp", &fclaw_opt->timeinterp2fillghost, 1,
+                         "Use linear time interpolation when subcycling [T]");
 
     sc_options_add_bool (opt, 0, "weighted_partition", &fclaw_opt->weighted_partition, 1,
                          "Weight grids when partitioning [T]");

--- a/src/fclaw_options.h
+++ b/src/fclaw_options.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2021 Carsten Burstedde, Donna Calhoun
+Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -37,9 +37,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef __cplusplus
 extern "C"
 {
-#if 0
-}                               /* need this because indent is dumb */
-#endif
 #endif
 
 /* Plan is to replace fclaw_options_t with fclaw_options_t */
@@ -120,16 +117,11 @@ struct fclaw_options
     int nout;
     int nstep;
     int subcycle;               /**< Only relevant when subcycling. */
-    int advance_one_step;
-    int outstyle_uses_maxlevel;
     int use_fixed_dt;
     double max_cfl;
     double desired_cfl;
     int reduce_cfl;   /* Do an all-reduce to get max. cfl */
     double *tout;
-
-    /* Initialization of ghost cell */
-    int init_ghostcell;
 
     /* Refinement parameters */
     int refratio;
@@ -138,14 +130,10 @@ struct fclaw_options
     int regrid_interval;
     int smooth_refine;
     int smooth_level;
-    int coarsen_delay;
     double refine_threshold;
-    double coarsen_threshold;
 
     /* Conservation */
     int time_sync;
-    int flux_correction;
-    int fluctuation_correction;
 
     /* Gauges */
     int output_gauges;
@@ -157,6 +145,27 @@ struct fclaw_options
     int mj;
     int periodic_x;
     int periodic_y;
+
+    /* Advanced options */
+    int flux_correction;
+    int fluctuation_correction;
+
+    int coarsen_delay;
+    double coarsen_threshold;
+
+    /* Initialization of ghost cell */
+    int init_ghostcell;
+
+    /* Return after each time step  */
+    int advance_one_step;
+
+    /* nout, when used with outstyle option 3 refers to number of fine grid steps */
+    int outstyle_uses_maxlevel;
+
+    /* Do not use time interpolation.  This will be used for higher order schemes that 
+       may use extra ghost cells, for example. */
+    int timeinterp2fillghost;  
+
 
     const char *scale_string;
     double *scale;
@@ -216,9 +225,6 @@ struct fclaw_options
 };
 
 #ifdef __cplusplus
-#if 0
-{                               /* need this because indent is dumb */
-#endif
 }
 #endif
 

--- a/src/patches/clawpatch/fclaw2d_clawpatch.cpp
+++ b/src/patches/clawpatch/fclaw2d_clawpatch.cpp
@@ -95,10 +95,19 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /* ------------------------------- Static function defs ------------------------------- */
 
 /* Added to turn off time_interp */
-static int fill_ghost(int time_interp)
+static int fill_ghost(fclaw2d_global_t* glob, int time_interp)
 {
-	//return !time_interp;
-	return 1;
+	const fclaw_options_t* fclaw_opt = fclaw2d_get_options(glob);
+	if (fclaw_opt->timeinterp2fillghost)
+		/* This will always fill ghost cells using data from "qsync", which is either 
+		   coarse grid data at time step, or time interpolated data */
+		return 1;
+	else
+		/* Only fill ghost cells with neighboring data if not doing time interpolation. 
+		  If doing time interpolation, then fine grid data at intermediate time steps 
+		  will be filled in some other way (.e.g. by advancing the solution in ghost 
+		  cells.) */
+		return !time_interp;
 }
 
 
@@ -495,7 +504,7 @@ void clawpatch_copy_face(fclaw2d_global_t *glob,
 	double *qneighbor;
 	fclaw2d_clawpatch_timesync_data(glob,neighbor_patch,time_interp,&qneighbor,&meqn);
 
-	if (fill_ghost(time_interp))
+	if (fill_ghost(glob,time_interp))
 	{
 		fclaw2d_clawpatch_vtable_t* clawpatch_vt = fclaw2d_clawpatch_vt(glob);
 #if PATCH_DIM == 2		
@@ -577,7 +586,7 @@ void clawpatch_interpolate_face(fclaw2d_global_t *glob,
 	int my = clawpatch_opt->my;
 	int mbc = clawpatch_opt->mbc;
 
-	if (fill_ghost(time_interp))
+	if (fill_ghost(glob,time_interp))
 	{
 		fclaw2d_clawpatch_vtable_t* clawpatch_vt = fclaw2d_clawpatch_vt(glob);
 #if PATCH_DIM == 2
@@ -616,7 +625,7 @@ void clawpatch_copy_corner(fclaw2d_global_t *glob,
 	double *qcorner;
 	fclaw2d_clawpatch_timesync_data(glob,corner_patch,time_interp,&qcorner,&meqn);
 
-	if (fill_ghost(time_interp))
+	if (fill_ghost(glob,time_interp))
 	{
 		fclaw2d_clawpatch_vtable_t* clawpatch_vt = fclaw2d_clawpatch_vt(glob);
 #if PATCH_DIM == 2
@@ -658,7 +667,7 @@ void clawpatch_average_corner(fclaw2d_global_t *glob,
 
 	const fclaw_options_t *fclaw_opt = fclaw2d_get_options(glob);
 	int manifold = fclaw_opt->manifold;
-	if (fill_ghost(time_interp))
+	if (fill_ghost(glob,time_interp))
 	{
 		int refratio = 2;
 		fclaw2d_clawpatch_vtable_t* clawpatch_vt = fclaw2d_clawpatch_vt(glob);
@@ -699,7 +708,7 @@ void clawpatch_interpolate_corner(fclaw2d_global_t* glob,
 
 	double *qfine = fclaw2d_clawpatch_get_q(glob,fine_patch);
 
-	if (fill_ghost(time_interp))
+	if (fill_ghost(glob,time_interp))
 	{
 		int refratio = 2;
 		fclaw2d_clawpatch_vtable_t* clawpatch_vt = fclaw2d_clawpatch_vt(glob);


### PR DESCRIPTION
This allows gives users more flexibility in setting ghost cells in intermediate time steps (e.g. fine grid steps which have no coarse grid counterpart).  

* This is needed for higher order WPA scheme and active flux method. 