### PR TITLE
(clawpatch) Don't require mx == my

### DIFF
--- a/src/patches/clawpatch/fclaw2d_clawpatch_options.c
+++ b/src/patches/clawpatch/fclaw2d_clawpatch_options.c
@@ -113,11 +113,13 @@ clawpatch_postprocess(fclaw2d_clawpatch_options_t *clawpatch_opt)
 static fclaw_exit_type_t
 clawpatch_check(fclaw2d_clawpatch_options_t *clawpatch_opt)
 {
+#if 0
     if (clawpatch_opt->mx != clawpatch_opt->my)
     {
         fclaw_global_essentialf("Clawpatch error : mx != my\n");
         return FCLAW_EXIT_ERROR;    
     }
+#endif
 
     if (2*clawpatch_opt->mbc > clawpatch_opt->mx)
     {


### PR DESCRIPTION
Remove requirement that mx==my.    This would likely be needed by ForestGemini.    
* We should probably include some tests that test this more robustly.  