### PR TITLE
(patch) Create user data before calling patch setup

### DIFF
--- a/src/fclaw2d_patch.c
+++ b/src/fclaw2d_patch.c
@@ -153,14 +153,17 @@ void fclaw2d_patch_build(fclaw2d_global_t *glob,
 	pdata->blockno = blockno;
 #endif    
 
+    /* This should go first, in case the setup function relies on this 
+       user data (or just needs to set it up)
+    */
+    if (patch_vt->create_user_data)
+    {
+        patch_vt->create_user_data(glob,this_patch);
+    }
 
     if (patch_vt->setup != NULL)
     {
         patch_vt->setup(glob,this_patch,blockno,patchno);
-    }
-    if (patch_vt->create_user_data)
-    {
-        patch_vt->create_user_data(glob,this_patch);
     }
 }
 
@@ -190,14 +193,15 @@ void fclaw2d_patch_build_from_fine(fclaw2d_global_t *glob,
                               fine0_patchno,
                               build_mode);
 
-    if (patch_vt->setup != NULL && build_mode == FCLAW2D_BUILD_FOR_UPDATE)
-    {
-        patch_vt->setup(glob,coarse_patch,blockno,coarse_patchno);
-    }
     if (patch_vt->create_user_data)
     {
         patch_vt->create_user_data(glob,coarse_patch);
     }    
+
+    if (patch_vt->setup != NULL && build_mode == FCLAW2D_BUILD_FOR_UPDATE)
+    {
+        patch_vt->setup(glob,coarse_patch,blockno,coarse_patchno);
+    }
 }
 
 #if 0

--- a/src/fclaw2d_patch.c
+++ b/src/fclaw2d_patch.c
@@ -156,7 +156,7 @@ void fclaw2d_patch_build(fclaw2d_global_t *glob,
     /* This should go first, in case the setup function relies on this 
        user data (or just needs to set it up)
     */
-    if (patch_vt->create_user_data)
+    if (patch_vt->create_user_data != NULL)
     {
         patch_vt->create_user_data(glob,this_patch);
     }
@@ -193,7 +193,7 @@ void fclaw2d_patch_build_from_fine(fclaw2d_global_t *glob,
                               fine0_patchno,
                               build_mode);
 
-    if (patch_vt->create_user_data)
+    if (patch_vt->create_user_data != NULL)
     {
         patch_vt->create_user_data(glob,coarse_patch);
     }    


### PR DESCRIPTION
(forget to create separate branch).   This is minor fix needed for ForestGemini. 

* The patch user data should be created before patch setup is called.   