### PR TITLE
Fix filament example

### DIFF
--- a/applications/clawpack/advection/2d/all/advection_user.h
+++ b/applications/clawpack/advection/2d/all/advection_user.h
@@ -108,9 +108,11 @@ fclaw2d_map_context_t* fclaw2d_map_new_bilinear(fclaw2d_map_context_t *brick,
 /* ---------------------------------- Disk mappings ----------------------------------- */
 
 fclaw2d_map_context_t* fclaw2d_map_new_pillowdisk(const double scale[],
+                                                  const double shift[],
                                                   const double rotate[]);
 
 fclaw2d_map_context_t* fclaw2d_map_new_pillowdisk5(const double scale[],
+                                                   const double shift[],
                                                    const double rotate[],
                                                    const double alpha);
 

--- a/applications/clawpack/advection/2d/all/fclaw2d_map_bilinear.c
+++ b/applications/clawpack/advection/2d/all/fclaw2d_map_bilinear.c
@@ -1,0 +1,130 @@
+/* Cartesian grid, tranformed to Ax + b */
+
+#include <fclaw2d_map.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#if 0
+/* Fix highlighting */
+#endif
+
+#define MAPC2M_BILINEAR FCLAW_F77_FUNC(mapc2m_bilinear,MAPC2M_BILINEAR)
+
+void MAPC2M_BILINEAR(int* blockno, double* xc, double *yc,
+                     double *xp, double *yp, double *zp,
+                     double *center);
+
+static int
+fclaw2d_map_query_bilinear (fclaw2d_map_context_t * cont, int query_identifier)
+{
+    switch (query_identifier)
+    {
+    case FCLAW2D_MAP_QUERY_IS_USED:
+        return 1;
+    case FCLAW2D_MAP_QUERY_IS_SCALEDSHIFT:
+        return 1;
+    case FCLAW2D_MAP_QUERY_IS_AFFINE:
+        return 1;
+    case FCLAW2D_MAP_QUERY_IS_NONLINEAR:
+        return 0;
+    case FCLAW2D_MAP_QUERY_IS_GRAPH:
+        return 0;
+    case FCLAW2D_MAP_QUERY_IS_PLANAR:
+        return 1;
+    case FCLAW2D_MAP_QUERY_IS_ALIGNED:
+        return 0;
+    case FCLAW2D_MAP_QUERY_IS_FLAT:
+        return 1;
+    case FCLAW2D_MAP_QUERY_IS_DISK:
+        return 0;
+    case FCLAW2D_MAP_QUERY_IS_SPHERE:
+        return 0;
+    case FCLAW2D_MAP_QUERY_IS_PILLOWDISK:
+        return 0;
+    case FCLAW2D_MAP_QUERY_IS_SQUAREDDISK:
+        return 0;
+    case FCLAW2D_MAP_QUERY_IS_PILLOWSPHERE:
+        return 0;
+    case FCLAW2D_MAP_QUERY_IS_CUBEDSPHERE:
+        return 0;
+    case FCLAW2D_MAP_QUERY_IS_FIVEPATCH:
+        return 0;
+    case FCLAW2D_MAP_QUERY_IS_BILINEAR:
+        return 1;
+    case FCLAW2D_MAP_QUERY_IS_BRICK:
+        return 0;
+    default:
+        printf("\n");
+        printf("fclaw2d_map_query_bilinear (fclaw2d_map_bilinear.c) : "\
+               "Query id not identified;  Maybe the query is not up to "\
+               "date?\nSee fclaw2d_map_bilinear.h.\n");
+        printf("Requested query id : %d\n",query_identifier);
+        SC_ABORT_NOT_REACHED ();
+    }
+    return 0;
+}
+
+#if 0
+static void
+fclaw2d_map_c2m_basis_bilinear(fclaw2d_map_context_t * cont,
+                               double xc, double yc, 
+                               double *t, double *tinv, 
+                               double *tderivs, int flag)
+{
+    /* Mapping must work for single Cartesian grid.   
+       [xc,yc] \in [0,1]x[0,1] */
+    SQUARE_BASIS_COMPLETE(&xc, &yc, t, tinv, tderivs, &flag);
+}
+#endif
+
+
+static void
+fclaw2d_map_c2m_bilinear(fclaw2d_map_context_t * cont, int blockno,
+                         double xc, double yc,
+                         double *xp, double *yp, double *zp)
+{
+    /* Brick mapping to computational coordinates [0,1]x[0,1] */
+    double center[2];
+    center[0] = cont->user_double[0];
+    center[1] = cont->user_double[1];
+
+    /* Map to unit square in [-1,1] x [-1,1], with middle point shifted to 
+       create four bilinear maps. */
+    MAPC2M_BILINEAR(&blockno,&xc,&yc,xp,yp,zp,center);
+
+    shift_map(cont, xp,yp,zp);
+}
+
+
+fclaw2d_map_context_t* fclaw2d_map_new_bilinear(fclaw2d_map_context_t *brick,
+                                                const double scale[],
+                                                const double shift[],
+                                                const double center[])
+{
+    fclaw2d_map_context_t *cont;
+
+    cont = FCLAW_ALLOC_ZERO(fclaw2d_map_context_t, 1);
+    cont->query = fclaw2d_map_query_bilinear;
+    cont->mapc2m = fclaw2d_map_c2m_bilinear;
+    cont->brick = brick;
+
+
+    /* NOTE : On coarse grids, moving the center too close to one of the edges can lead
+       to problems with the metric terms;  lines will cross and ghost cells can be messed
+       up.  For mx=8, center should be within 0.8 of the boundary.  See map_debug2.m */
+    cont->user_double[0] = center[0];
+    cont->user_double[1] = center[1];
+
+    set_scale(cont,scale);
+    set_shift(cont,shift);
+
+
+    return cont;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/applications/clawpack/advection/2d/all/fclaw2d_map_cart.c
+++ b/applications/clawpack/advection/2d/all/fclaw2d_map_cart.c
@@ -5,9 +5,6 @@
 #ifdef __cplusplus
 extern "C"
 {
-#if 0
-}
-#endif
 #endif
 
 static int
@@ -68,11 +65,10 @@ fclaw2d_map_c2m_cart(fclaw2d_map_context_t * cont, int blockno,
     double xc1, yc1, zc1;
     FCLAW2D_MAP_BRICK2C(&cont,&blockno,&xc,&yc,&xc1,&yc1,&zc1);
 
-
     /* Unit square in [-1,1] x [-1,1] */
     MAPC2M_CART(&blockno,&xc1,&yc1,xp,yp,zp);
 
-    scale_map(cont, xp,yp,zp);
+    /* Shift by (1,1,0) to [0,2]x[0,2] */
     shift_map(cont, xp,yp,zp);
 }
 
@@ -95,8 +91,5 @@ fclaw2d_map_context_t* fclaw2d_map_new_cart(fclaw2d_map_context_t *brick,
 }
 
 #ifdef __cplusplus
-#if 0
-{
-#endif
 }
 #endif

--- a/applications/clawpack/advection/2d/all/fclaw2d_map_fivepatch.c
+++ b/applications/clawpack/advection/2d/all/fclaw2d_map_fivepatch.c
@@ -5,14 +5,13 @@
 #ifdef __cplusplus
 extern "C"
 {
-#if 0
-}
-#endif
 #endif
 
+#if 0
 void mapc2m(int* blockno, double* xc, double *yc,
             double *xp, double *yp, double *zp,
             double *alpha);
+#endif
 
 static int
 fclaw2d_map_query_fivepatch(fclaw2d_map_context_t * cont, int query_identifier)
@@ -68,11 +67,13 @@ fclaw2d_map_c2m_fivepatch(fclaw2d_map_context_t* cont, int blockno,
                           double xc, double yc,
                           double *xp, double *yp, double *zp)
 {
+    /* five patch square in [-1,1]x[-1,1] */
     double alpha = cont->user_double[0];
     MAPC2M_FIVEPATCH(&blockno,&xc,&yc,xp,yp,zp,&alpha);
 
-    scale_map(cont, xp,yp,zp);
+    /* Shift [-1,1]x[-1,1] to [0,2]x[0,2] */
     shift_map(cont, xp,yp,zp);
+
 }
 
 
@@ -95,8 +96,5 @@ fclaw2d_map_context_t* fclaw2d_map_new_fivepatch(const double scale[],
 }
 
 #ifdef __cplusplus
-#if 0
-{
-#endif
 }
 #endif

--- a/applications/clawpack/advection/2d/all/fclaw2d_map_pillowdisk.c
+++ b/applications/clawpack/advection/2d/all/fclaw2d_map_pillowdisk.c
@@ -63,15 +63,27 @@ fclaw2d_map_c2m_pillowdisk(fclaw2d_map_context_t * cont, int blockno,
                       double xc, double yc,
                       double *xp, double *yp, double *zp)
 {
+    /* Unit disk centered at (0,0) */
     MAPC2M_PILLOWDISK(&blockno,&xc,&yc,xp,yp,zp);
 
+<<<<<<< Updated upstream
     /* These can probably be replaced by C functions at some point. */
     scale_map(cont, xp,yp,zp);
     rotate_map(cont, xp,yp,zp);
+=======
+
+    /* Shift center to (1,1) */
+    scale_map(cont, xp, yp, zp);
+    shift_map(cont, xp, yp, zp);
+>>>>>>> Stashed changes
 }
 
 
 fclaw2d_map_context_t* fclaw2d_map_new_pillowdisk(const double scale[],
+<<<<<<< Updated upstream
+=======
+                                                  const double shift[],
+>>>>>>> Stashed changes
                                                   const double rotate[])
 {
     fclaw2d_map_context_t *cont;
@@ -81,6 +93,10 @@ fclaw2d_map_context_t* fclaw2d_map_new_pillowdisk(const double scale[],
     cont->mapc2m = fclaw2d_map_c2m_pillowdisk;
 
     set_scale(cont, scale);
+<<<<<<< Updated upstream
+=======
+    set_shift(cont, shift);
+>>>>>>> Stashed changes
     set_rotate(cont, rotate);
 
     return cont;

--- a/applications/clawpack/advection/2d/all/fclaw2d_map_pillowdisk5.c
+++ b/applications/clawpack/advection/2d/all/fclaw2d_map_pillowdisk5.c
@@ -63,7 +63,13 @@ fclaw2d_map_c2m_pillowdisk5(fclaw2d_map_context_t * cont, int blockno,
                                 double xc, double yc,
                                 double *xp, double *yp, double *zp)
 {
+<<<<<<< Updated upstream
     double alpha = cont->user_double[0];
+=======
+
+    /* Unit disk centered at (0,0) */
+    double alpha = cont->user_double[0];    
+>>>>>>> Stashed changes
     MAPC2M_PILLOWDISK5(&blockno,&xc,&yc,xp,yp,zp,&alpha);
 
     scale_map(cont, xp,yp,zp);
@@ -72,6 +78,10 @@ fclaw2d_map_c2m_pillowdisk5(fclaw2d_map_context_t * cont, int blockno,
 
 
 fclaw2d_map_context_t* fclaw2d_map_new_pillowdisk5(const double scale[],
+<<<<<<< Updated upstream
+=======
+                                                   const double shift[],
+>>>>>>> Stashed changes
                                                    const double rotate[],
                                                    const double alpha)
 {
@@ -84,6 +94,10 @@ fclaw2d_map_context_t* fclaw2d_map_new_pillowdisk5(const double scale[],
     cont->user_double[0] = alpha;
 
     set_scale(cont, scale);
+<<<<<<< Updated upstream
+=======
+    set_shift(cont, shift);
+>>>>>>> Stashed changes
     set_rotate(cont, rotate);
 
     return cont;

--- a/applications/clawpack/advection/2d/filament/CMakeLists.txt
+++ b/applications/clawpack/advection/2d/filament/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(filament
   ${all}/advection_patch_setup_manifold.c
   ${all}/fclaw2d_map_cart.c 
   ${all}/fclaw2d_map_fivepatch.c 
+  ${all}/fclaw2d_map_bilinear.c 
   $<TARGET_OBJECTS:filament_f>
 )
 

--- a/applications/clawpack/advection/2d/filament/fclaw_options.ini
+++ b/applications/clawpack/advection/2d/filament/fclaw_options.ini
@@ -1,9 +1,14 @@
 [user]
      # Mappings : 
-     # 0 : Use [ax,bx]x[ay,by]
-     # 1 : Use brick domain and parameters (mi,mj)
-     # 2 : Five-patch square
-     example = 0        # no mapping
+     # 0 : Use brick domain and parameters (mi,mj)
+     # 1 : Five-patch square
+     # 2 : Bilinear map (must have mi=mj=2)
+     example = 2
+
+     alpha = 0.5  # 5-patch pillowdisk
+
+     # Center of reference bilinear map in [-1,1]x[-1,1]
+     center = 0.2 0.3   
 
      claw-version = 4
 
@@ -20,7 +25,7 @@
      # difference  : difference (e.g. dqx = q(i+1,j)-q(i-1,j)) exceeds threshold
      # gradient    : gradient exceeds threshold
      # user        : User defined criteria
-     refinement-criteria = difference
+     refinement-criteria = minmax
 
      # Equations and boundary conditions
      meqn = 1             # Number of equations
@@ -29,7 +34,7 @@
 [Options]
 # Regridding options
      minlevel = 3         # Minimum level
-     maxlevel = 6         # Maximum levels of refinement
+     maxlevel = 5         # Maximum levels of refinement
 
      regrid_interval = 1  # Regrid every 'regrid_interval' time steps.
      smooth-refine = T
@@ -40,7 +45,7 @@
      tfinal = 8.0          #
 
      use_fixed_dt = F      # Take a fixed time step
-     initial_dt = 0.0025   # Initial time step for 'minlevel'
+     initial_dt = 0.0005   # Initial time step for 'minlevel'
      max_cfl = 1.0         # maximum cfl
      desired_cfl = 0.9     # desired cfl
 
@@ -59,7 +64,7 @@
      report-timing-verbosity=wall
 
 # File and console IO
-     verbosity = production   # verbosity
+     verbosity = essential   # verbosity
      output = T
 
      # -----------
@@ -71,17 +76,25 @@
      tikz-plot-suffix = 'png'
 
 # mapping options
-     manifold = F
+     manifold = T
 
+     # Ignored if manifold == T
      ax = 0
-     bx = 2
+     bx = 1
      ay = 0
-     by = 2
+     by = 1
+
+     # 2x2 needed for bilinear map;  also use for Cart map. 
+     mi = 2
+     mj = 2
+
+     # Shift Cartesian map in [-1,1]x[-1,1] to [0,2]x[0,2]
+     shift = 1 1 0
 
 
 [clawpack46]
      order  = 2 2         # normal and transverse order
-     mcapa = 0            # mcapa
+     mcapa = 1            # mcapa
      src_term = 0         # src_term
 
      mwaves = 1           # mwaves
@@ -95,7 +108,7 @@
 
 [clawpack5]
      order  = 2 2         # normal and transverse order
-     mcapa = 0            # mcapa
+     mcapa = 1            # mcapa
      src_term = 0         # src_term
 
      mwaves = 1           # mwaves

--- a/applications/clawpack/advection/2d/filament/fdisc.f
+++ b/applications/clawpack/advection/2d/filament/fdisc.f
@@ -7,17 +7,10 @@
 
       double precision r
 
-      logical fclaw2d_map_is_used
-
       cont = get_context()
 
-      if (fclaw2d_map_is_used(cont)) then
-         call fclaw2d_map_c2m(cont,
+      call fclaw2d_map_c2m(cont,
      &         blockno,xc,yc,xp,yp,zp)
-      else
-         xp = xc
-         yp = yc
-      endif
 
       r = sqrt((xp-0.5d0)**2 + (yp-1.d0)**2)
 

--- a/applications/clawpack/advection/2d/filament/filament.cpp
+++ b/applications/clawpack/advection/2d/filament/filament.cpp
@@ -37,31 +37,29 @@ fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm,
     p4est_connectivity_t     *conn = NULL;
     fclaw2d_domain_t         *domain;
     fclaw2d_map_context_t    *cont = NULL, *brick = NULL;
-    
+
     int mi = fclaw_opt->mi;
     int mj = fclaw_opt->mj;
     int a = 0; /* non-periodic */
     int b = 0;
 
+    int mx = clawpatch_opt->mx;
+    int minlevel = fclaw_opt->minlevel;
+    
     switch (user->example) {
     case 0:
-        /* Size is set by [ax,bx] x [ay, by], set in .ini file */
-        conn = p4est_connectivity_new_unitsquare();
-        cont = fclaw2d_map_new_nomap();
-        break;
-
-    case 1:
         /* Square brick domain */
         conn = p4est_connectivity_new_brick(mi,mj,a,b);
         brick = fclaw2d_map_new_brick(conn,mi,mj);
+        /* Square in [-1,1]x[-1,1], shifted by (1,1,0) */
         cont = fclaw2d_map_new_cart(brick,
                                     fclaw_opt->scale,
                                     fclaw_opt->shift);
         break;
-    case 2:
-        if (clawpatch_opt->mx*pow_int(2,fclaw_opt->minlevel) < 32)
+    case 1:
+        if (mi*pow_int(mx,minlevel) < 32)
         {
-            fclaw_global_essentialf("The five patch mapping requires mx*2^minlevel > 32\n");
+            fclaw_global_essentialf("The five patch mapping requires mi*mx*2^minlevel > 32\n");
             exit(0);
 
         }
@@ -70,6 +68,16 @@ fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm,
         cont = fclaw2d_map_new_fivepatch (fclaw_opt->scale,
                                           fclaw_opt->shift,
                                           user->alpha);
+        break;
+    case 2:
+        /* bilinear square domain : maps to [-1,1]x[-1,1] */
+        FCLAW_ASSERT(mi == 2 && mj == 2);
+        conn = p4est_connectivity_new_brick(mi,mj,a,b);
+        brick = fclaw2d_map_new_brick(conn,mi,mj);
+        cont = fclaw2d_map_new_bilinear (brick, 
+                                         fclaw_opt->scale,
+                                         fclaw_opt->shift, 
+                                         user->center);
         break;
 
     default:

--- a/applications/clawpack/advection/2d/filament/filament_options.c
+++ b/applications/clawpack/advection/2d/filament/filament_options.c
@@ -42,9 +42,22 @@ filament_register (user_options_t *user, sc_options_t * opt)
     sc_options_add_double (opt, 0, "alpha", &user->alpha, 0.5,
                            "[user] Ratio used for squared- and pillow-disk [0.5]");
 
+    fclaw_options_add_double_array (opt, 0, "center", &user->center_string, "0 0",
+                                    &user->center, 2, 
+                                    "Center point for bilinear mapping  [1,1]");
+
     user->is_registered = 1;
     return NULL;
 }
+
+static fclaw_exit_type_t
+filament_postprocess(user_options_t *user)
+{
+    fclaw_options_convert_double_array(user->center_string, &user->center,2);
+
+    return FCLAW_NOEXIT;
+}
+
 
 static fclaw_exit_type_t
 filament_check (user_options_t *user)
@@ -60,7 +73,7 @@ filament_check (user_options_t *user)
 static void
 filament_destroy (user_options_t *user)
 {
-    /* Nothing to destroy */
+    fclaw_options_destroy_array (user->center);
 }
 
 
@@ -79,6 +92,23 @@ options_register (fclaw_app_t * app, void *package, sc_options_t * opt)
     return filament_register(user,opt);
 }
 
+
+static fclaw_exit_type_t
+options_postprocess (fclaw_app_t * a, void *package, void *registered)
+{
+    FCLAW_ASSERT (a != NULL);
+    FCLAW_ASSERT (package != NULL);
+    FCLAW_ASSERT (registered == NULL);
+
+    /* errors from the key-value options would have showed up in parsing */
+    user_options_t *user = (user_options_t *) package;
+
+    /* post-process this package */
+    FCLAW_ASSERT(user->is_registered);
+
+    /* Convert strings to arrays */
+    return filament_postprocess (user);
+}
 
 static fclaw_exit_type_t
 options_check(fclaw_app_t *app, void *package,void *registered)
@@ -114,7 +144,7 @@ options_destroy (fclaw_app_t * app, void *package, void *registered)
 static const fclaw_app_options_vtable_t options_vtable_user =
 {
     options_register,
-    NULL,
+    options_postprocess,
     options_check,
     options_destroy,
 };

--- a/applications/clawpack/advection/2d/filament/filament_user.cpp
+++ b/applications/clawpack/advection/2d/filament/filament_user.cpp
@@ -25,6 +25,23 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "filament_user.h"
 
+
+void filament_problem_setup(fclaw2d_global_t *glob)
+{
+    const user_options_t* user = filament_get_options(glob);
+    if (glob->mpirank == 0)
+    {
+        FILE *f = fopen("setprob.data","w");
+        fprintf(f,  "%-24d   %s",user->example,"\% example\n");
+        fprintf(f,  "%-24.4f   %s",user->alpha,"\% alpha\n");
+        fprintf(f,  "%-24.4f   %s",user->center[0],"\% center_x\n");
+        fprintf(f,  "%-24.4f   %s",user->center[1],"\% center_y\n");
+        fclose(f);
+    }
+    fclaw2d_domain_barrier (glob->domain);
+    SETPROB();
+}
+
 static
 void filament_patch_setup(fclaw2d_global_t *glob,
                           fclaw2d_patch_t *patch,
@@ -39,51 +56,26 @@ void filament_patch_setup(fclaw2d_global_t *glob,
 void filament_link_solvers(fclaw2d_global_t *glob)
 {
     const fclaw_options_t* fclaw_opt = fclaw2d_get_options(glob);
+    FCLAW_ASSERT(fclaw_opt->manifold != 0);
 
-    if (fclaw_opt->manifold)
-    {
-        fclaw2d_patch_vtable_t *patch_vt = fclaw2d_patch_vt(glob);
-        patch_vt->setup = filament_patch_setup;        
-    }
+    fclaw2d_patch_vtable_t *patch_vt = fclaw2d_patch_vt(glob);
+    patch_vt->setup = filament_patch_setup;        
 
     const user_options_t* user = filament_get_options(glob);
     if (user->claw_version == 4)
     {
         fc2d_clawpack46_vtable_t *clawpack46_vt = fc2d_clawpack46_vt(glob);
 
-        clawpack46_vt->fort_setprob   = &SETPROB;
         clawpack46_vt->fort_qinit     = &CLAWPACK46_QINIT;
-
-        if (fclaw_opt->manifold)
-        {
-            clawpack46_vt->fort_rpn2  = &CLAWPACK46_RPN2ADV_MANIFOLD;
-            clawpack46_vt->fort_rpt2  = &CLAWPACK46_RPT2ADV_MANIFOLD;
-        }
-        else
-        {
-            /* Used in non-manifold case */
-            clawpack46_vt->fort_setaux    = &CLAWPACK46_SETAUX;  
-            clawpack46_vt->fort_rpn2      = &CLAWPACK46_RPN2ADV;
-            clawpack46_vt->fort_rpt2      = &CLAWPACK46_RPT2ADV;
-        }
+        clawpack46_vt->fort_rpn2      = &CLAWPACK46_RPN2ADV_MANIFOLD;
+        clawpack46_vt->fort_rpt2      = &CLAWPACK46_RPT2ADV_MANIFOLD;
     }
     else if (user->claw_version == 5)
     {
         fc2d_clawpack5_vtable_t *claw5_vt = fc2d_clawpack5_vt(glob);
 
-        claw5_vt->fort_setprob   = &SETPROB;
-        claw5_vt->fort_qinit     = &CLAWPACK5_QINIT;
-        
-        if (fclaw_opt->manifold)
-        {
-            claw5_vt->fort_rpn2   = CLAWPACK5_RPN2ADV_MANIFOLD;
-            claw5_vt->fort_rpt2   = CLAWPACK5_RPT2ADV_MANIFOLD;
-        }
-        else
-        {
-            claw5_vt->fort_setaux    = CLAWPACK5_SETAUX;   /* Used in non-manifold case */
-            claw5_vt->fort_rpn2      = CLAWPACK5_RPN2ADV;
-            claw5_vt->fort_rpt2      = CLAWPACK5_RPT2ADV;
-        }
+        claw5_vt->fort_qinit     = &CLAWPACK5_QINIT;        
+        claw5_vt->fort_rpn2   = CLAWPACK5_RPN2ADV_MANIFOLD;
+        claw5_vt->fort_rpt2   = CLAWPACK5_RPT2ADV_MANIFOLD;
     }
 }

--- a/applications/clawpack/advection/2d/filament/filament_user.h
+++ b/applications/clawpack/advection/2d/filament/filament_user.h
@@ -41,6 +41,9 @@ typedef struct user_options
 {
     int example;
     double alpha;
+
+    double *center;
+    const char* center_string;
     int claw_version;
 
     int is_registered;

--- a/applications/clawpack/advection/2d/filament/mapc2m.m
+++ b/applications/clawpack/advection/2d/filament/mapc2m.m
@@ -1,50 +1,43 @@
 function [xp,yp,zp] = mapc2m(xc,yc)
 
-% map = 'nomap';
-% map = 'cart';   % brick
-map = 'fivepatch';
+parms = read_vars();
+if parms.example == 0
+    map = 'cart';   % brick
+elseif parms.example == 1
+    map = 'fivepatch';
+elseif parms.example == 2
+    map = 'bilinear';
+end
 
 % This domain should be in [0,1],[0,1]
 
-alpha = 0.4;
+alpha = parms.alpha;
 
 shift = [1,1,0];
 
 switch map
-    case 'nomap'
-        % Uses [ax,bx] x [ay,by] set in fclaw2d_defaults.ini
-        % This is what is stored in the fort.q files.
-        xp = xc;
-        yp = yc;
-        
     case 'cart'
         % (xc,yc) in [0,1]x[0,1]
-        s = 0.005;
+        s = 0;
         [xc1,yc1,~] = mapc2m_brick(xc,yc,s);
         [xp,yp,~] = mapc2m_cart(xc1,yc1);
                 
-        xp = xp/2;
-        yp = yp/2;
         xp = xp + shift(1);
         yp = yp + shift(2);
         
     case 'fivepatch'
-        alpha = 0.4;
         [xp,yp,~] = mapc2m_fivepatch(xc,yc,alpha);
-        b = getblocknumber();
-        s = 0.005;
-        switch b
-            case 0
-                yp = yp - s;
-            case 1
-                xp = xp - s;
-            case 3
-                xp = xp + s;
-            case 4
-                yp = yp + s;
-        end
-        xp = xp+shift(1);
-        yp = yp+shift(2);
+
+        xp = xp + shift(1);
+        yp = yp + shift(2);
+
+    case 'bilinear'
+        center = parms.center;
+        [xp,yp,~] = mapc2m_bilinear(xc,yc,center);
+
+        xp = xp + shift(1);
+        yp = yp + shift(2);
+
 end
 zp = 0*xp;
 

--- a/applications/clawpack/advection/2d/filament/psi.f
+++ b/applications/clawpack/advection/2d/filament/psi.f
@@ -1,7 +1,7 @@
-      double precision function psi(x,y)
+      double precision function psi(x,y,z)
       implicit none
 
-      double precision x,y,r
+      double precision x,y,z,r
 
       double precision pi, pi2
       common /compi/ pi, pi2
@@ -26,7 +26,7 @@ c      psi = x + y
 
       double precision xd1(3),xd2(3), ds, vn, psi,t
 
-      vn = (psi(xd1(1),xd1(2)) -
-     &      psi(xd2(1),xd2(2)))/ds
+      vn = (psi(xd1(1),xd1(2),xd1(3)) -
+     &      psi(xd2(1),xd2(2),xd2(3)))/ds
 
       end

--- a/applications/clawpack/advection/2d/filament/read_vars.m
+++ b/applications/clawpack/advection/2d/filament/read_vars.m
@@ -1,0 +1,9 @@
+function parms = read_vars()
+
+data = load('setprob.data');
+
+parms.example = data(1);
+parms.alpha = data(2);
+parms.center = data(3:4);
+
+end

--- a/applications/clawpack/advection/2d/filament/setprob.f
+++ b/applications/clawpack/advection/2d/filament/setprob.f
@@ -4,8 +4,23 @@
       double precision pi, pi2
       common /compi/ pi, pi2
 
+      integer example
+      common /com_ex/ example
+
+      double precision alpha
+      common /com_alpha/ alpha
+
+      double precision center(2)
+      common /com_bilinear/ center
+      
       pi = 4.d0*atan(1.d0)
       pi2 = 2*pi
 
+      open(10,file='setprob.data')
+      read(10,*) example
+      read(10,*) alpha
+      read(10,*) center(1)
+      read(10,*) center(2)
+      close(10)
 
       end

--- a/src/fclaw2d_patch.c
+++ b/src/fclaw2d_patch.c
@@ -153,14 +153,17 @@ void fclaw2d_patch_build(fclaw2d_global_t *glob,
 	pdata->blockno = blockno;
 #endif    
 
+    /* This should go first, in case the setup function relies on this 
+       user data (or just needs to set it up)
+    */
+    if (patch_vt->create_user_data)
+    {
+        patch_vt->create_user_data(glob,this_patch);
+    }
 
     if (patch_vt->setup != NULL)
     {
         patch_vt->setup(glob,this_patch,blockno,patchno);
-    }
-    if (patch_vt->create_user_data)
-    {
-        patch_vt->create_user_data(glob,this_patch);
     }
 }
 
@@ -190,14 +193,15 @@ void fclaw2d_patch_build_from_fine(fclaw2d_global_t *glob,
                               fine0_patchno,
                               build_mode);
 
-    if (patch_vt->setup != NULL && build_mode == FCLAW2D_BUILD_FOR_UPDATE)
-    {
-        patch_vt->setup(glob,coarse_patch,blockno,coarse_patchno);
-    }
     if (patch_vt->create_user_data)
     {
         patch_vt->create_user_data(glob,coarse_patch);
     }    
+
+    if (patch_vt->setup != NULL && build_mode == FCLAW2D_BUILD_FOR_UPDATE)
+    {
+        patch_vt->setup(glob,coarse_patch,blockno,coarse_patchno);
+    }
 }
 
 #if 0

--- a/src/fclaw2d_patch.c
+++ b/src/fclaw2d_patch.c
@@ -156,7 +156,7 @@ void fclaw2d_patch_build(fclaw2d_global_t *glob,
     /* This should go first, in case the setup function relies on this 
        user data (or just needs to set it up)
     */
-    if (patch_vt->create_user_data)
+    if (patch_vt->create_user_data != NULL)
     {
         patch_vt->create_user_data(glob,this_patch);
     }
@@ -193,7 +193,7 @@ void fclaw2d_patch_build_from_fine(fclaw2d_global_t *glob,
                               fine0_patchno,
                               build_mode);
 
-    if (patch_vt->create_user_data)
+    if (patch_vt->create_user_data != NULL)
     {
         patch_vt->create_user_data(glob,coarse_patch);
     }    

--- a/src/mappings/pillowdisk/mapc2m_pillowdisk.f
+++ b/src/mappings/pillowdisk/mapc2m_pillowdisk.f
@@ -19,6 +19,7 @@ c     # Map to [-1,1]x[-1,1]
 c     # Get circle of radius sqrt(2.d0)
       call mapc2p_disk_circle(xc,yc,xp,yp)
 
+c     # Scale to get unit circle.
       xp = xp/sqrt(2.d0)
       yp = yp/sqrt(2.d0)
       zp = 0


### PR DESCRIPTION
Fix filament example: 

- Make sure `mcapa` is set to indicate capacity function in clawpack (how did this get unset?)
- Remove `nomap` option; all examples should require `manifold == T`.  
- Add a bilinear square mapping as third mapping.  This requires `mi=mj=2`.    
- add some Matlab functionality so that example parameters can be read automatically in Matlab. 