### PR TITLE
Fix coda tests for external project.

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -11,9 +11,11 @@
   "name": "ci",
   "binaryDir": "${sourceDir}/build",
   "generator": "Ninja",
+  "environment": {
+    "CUDAARCHS": "72"
+  },
   "cacheVariables": {
-    "CMAKE_BUILD_TYPE": "Release",
-    "CMAKE_CUDA_ARCHITECTURES": "72"
+    "CMAKE_BUILD_TYPE": "Release"
   }
 },
 {

--- a/applications/CMakePresets.json
+++ b/applications/CMakePresets.json
@@ -11,9 +11,11 @@
   "name": "ci",
   "binaryDir": "${sourceDir}/build",
   "generator": "Ninja",
+  "environment": {
+    "CUDAARCHS": "72"
+  },
   "cacheVariables": {
-    "CMAKE_BUILD_TYPE": "Release",
-    "CMAKE_CUDA_ARCHITECTURES": "72"
+    "CMAKE_BUILD_TYPE": "Release"
   }
 },
 {


### PR DESCRIPTION
The `CMAKE_CUDA_ARCHITECTURES` cache variable wasn't propagating correctly to the external project in CMake, switched to specifying the architecture in the `CUDAARCHS` environment variable instead.