### PR TITLE
Fix 3d VTK mapping

### DIFF
--- a/src/patches/clawpatch/fclaw2d_clawpatch_output_vtk.c
+++ b/src/patches/clawpatch/fclaw2d_clawpatch_output_vtk.c
@@ -742,9 +742,11 @@ fclaw2d_output_vtk_coordinate_cb (fclaw2d_global_t * glob,
     fclaw2d_clawpatch_grid_data(glob,patch,&mx,&my,&mz, &mbc,
                                 &xlower,&ylower,&zlower, &dx,&dy, &dz);
 
+    const fclaw_options_t *fclaw_opt = fclaw2d_get_options(glob);
     /* Enumerate point coordinates in the patch */
     double *d = (double *) a;
     int i, j, k;
+    double xpp,ypp,zpp;
     for (k = 0; k <= mz; ++k)
     {
         const double z = zlower + k * dz;
@@ -754,6 +756,15 @@ fclaw2d_output_vtk_coordinate_cb (fclaw2d_global_t * glob,
             for (i = 0; i <= mx; ++i)
             {
                 const double x = xlower + i * dx;
+                if (fclaw_opt->manifold)
+                {
+                    fclaw2d_map_context_t *cont = glob->cont;
+                    FCLAW3D_MAP_C2M(&cont,&blockno,&x,&y,&z,&xpp,&ypp,&zpp);
+                    *d++ = xpp;
+                    *d++ = ypp;
+                    *d++ = zpp;
+                }
+                else
                 {
                     *d++ = x;
                     *d++ = y;


### PR DESCRIPTION
3d VTK output wasn't being mapped. Added support for the case of mapped grids.