### PR TITLE
Feature to separate map from domain

### DIFF
--- a/applications/clawpack/euler/2d/quadrants/quadrants.cpp
+++ b/applications/clawpack/euler/2d/quadrants/quadrants.cpp
@@ -37,21 +37,23 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <fc2d_clawpack5.h>
 
 static
-fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm, 
-                                fclaw_options_t* fclaw_opt)
+fclaw2d_map_context_t *create_map (void)
 {
-    /* Mapped, multi-block domain */
-    p4est_connectivity_t     *conn = NULL;
+    /* no particular mapping */
+    return fclaw2d_map_new_nomap ();
+}
+
+static
+fclaw2d_domain_t* create_domain (sc_MPI_Comm mpicomm,
+                                 fclaw_options_t* fclaw_opt)
+{
+    /* multi-block domain */
+    p4est_connectivity_t     *conn;
     fclaw2d_domain_t         *domain;
-    fclaw2d_map_context_t    *cont = NULL;
 
+    conn = p4est_connectivity_new_unitsquare ();
+    domain = fclaw2d_domain_new_conn (mpicomm, fclaw_opt->minlevel, conn);
 
-
-    conn = p4est_connectivity_new_unitsquare();
-    cont = fclaw2d_map_new_nomap();
-
-    domain = fclaw2d_domain_new_conn_map (mpicomm, 
-                                          fclaw_opt->minlevel, conn, cont);
     fclaw2d_domain_list_levels(domain, FCLAW_VERBOSITY_ESSENTIAL);
     fclaw2d_domain_list_neighbors(domain, FCLAW_VERBOSITY_DEBUG);
     return domain;
@@ -135,10 +137,11 @@ main (int argc, char **argv)
 
         mpicomm = fclaw_app_get_mpi_size_rank (app, NULL, NULL);
         domain = create_domain(mpicomm, fclaw_opt);
-    
+
         /* Create global structure which stores the domain, timers, etc */
-        glob = fclaw2d_global_new();
-        fclaw2d_global_store_domain(glob, domain);
+        glob = fclaw2d_global_new ();
+        fclaw2d_global_store_domain (glob, domain);
+        fclaw2d_global_store_map (glob, create_map ());
 
          /* Store option packages in glob */
         fclaw2d_options_store           (glob, fclaw_opt);

--- a/applications/clawpack/euler/2d/quadrants/quadrants.cpp
+++ b/applications/clawpack/euler/2d/quadrants/quadrants.cpp
@@ -53,8 +53,8 @@ fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm,
     domain = fclaw2d_domain_new_conn_map (mpicomm, 
                                           fclaw_opt->minlevel, conn, cont);
     fclaw2d_domain_list_levels(domain, FCLAW_VERBOSITY_ESSENTIAL);
-    fclaw2d_domain_list_neighbors(domain, FCLAW_VERBOSITY_DEBUG);  
-    return domain;    
+    fclaw2d_domain_list_neighbors(domain, FCLAW_VERBOSITY_DEBUG);
+    return domain;
 }
 
 static
@@ -121,7 +121,7 @@ main (int argc, char **argv)
     clawpatch_opt =   fclaw2d_clawpatch_options_register(app, "clawpatch",  "fclaw_options.ini");
     claw46_opt =        fc2d_clawpack46_options_register(app, "clawpack46", "fclaw_options.ini");
     claw5_opt =          fc2d_clawpack5_options_register(app, "clawpack5",  "fclaw_options.ini");
-    user_opt =                quadrants_options_register(app,               "fclaw_options.ini");  
+    user_opt =                quadrants_options_register(app,               "fclaw_options.ini");
 
     /* Read configuration file(s) and command line, and process options */
     options = fclaw_app_get_options (app);
@@ -148,10 +148,10 @@ main (int argc, char **argv)
         quadrants_options_store         (glob, user_opt);
 
         run_program(glob);
-        
+
         fclaw2d_global_destroy(glob);
     }
-    
+
     fclaw_app_destroy (app);
 
     return 0;

--- a/applications/clawpack/euler/2d/shockbubble/shockbubble.cpp
+++ b/applications/clawpack/euler/2d/shockbubble/shockbubble.cpp
@@ -38,32 +38,40 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 static
-fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm, 
-                                fclaw_options_t* fclaw_opt)
+fclaw2d_global_t *create_glob (sc_MPI_Comm mpicomm,
+                               fclaw_options_t *fclaw_opt)
 {
     /* Mapped, multi-block domain */
     p4est_connectivity_t     *conn = NULL;
-    fclaw2d_domain_t         *domain;
+    fclaw2d_domain_t         *domain = NULL;
     fclaw2d_map_context_t    *cont = NULL, *brick = NULL;
+    fclaw2d_global_t         *glob = NULL;
 
-
-    int mi,mj,a,b;
+    /* Build a rectangle that may have periodic boundaries */
+    int                       mi, mj, a, b;
     mi = fclaw_opt->mi;
     mj = fclaw_opt->mj;
     a = fclaw_opt->periodic_x;
     b = fclaw_opt->periodic_y;
 
-    /* Use [ax,bx]x[ay,by] */
+    /* The p4est connectivity is used for both domain and mapping context */
+    conn = p4est_connectivity_new_brick (mi,mj,a,b);
 
-    conn = p4est_connectivity_new_brick(mi,mj,a,b);
-    brick = fclaw2d_map_new_brick(conn,mi,mj);
-    cont = fclaw2d_map_new_nomap_brick(brick);
+    /* Create global structure which stores the domain, timers, etc */
+    glob = fclaw2d_global_new ();
 
-    domain = fclaw2d_domain_new_conn_map (mpicomm, 
-                                          fclaw_opt->minlevel, conn, cont);
-    fclaw2d_domain_list_levels(domain, FCLAW_VERBOSITY_ESSENTIAL);
-    fclaw2d_domain_list_neighbors(domain, FCLAW_VERBOSITY_DEBUG);  
-    return domain;    
+    /* Construct and store domain */
+    domain = fclaw2d_domain_new_conn (mpicomm, fclaw_opt->minlevel, conn);
+    fclaw2d_domain_list_levels (domain, FCLAW_VERBOSITY_ESSENTIAL);
+    fclaw2d_domain_list_neighbors (domain, FCLAW_VERBOSITY_DEBUG);
+    fclaw2d_global_store_domain (glob, domain);
+
+    /* Construct and store map */
+    brick = fclaw2d_map_new_brick (conn, mi, mj);
+    cont = fclaw2d_map_new_nomap_brick (brick);
+    fclaw2d_global_store_map (glob, cont);
+
+    return glob;
 }
 
 static
@@ -117,7 +125,6 @@ main (int argc, char **argv)
     fc2d_clawpack5_options_t    *claw5_opt;
 
     fclaw2d_global_t            *glob;
-    fclaw2d_domain_t            *domain;
     sc_MPI_Comm mpicomm;
 
     int retval;
@@ -130,7 +137,7 @@ main (int argc, char **argv)
     clawpatch_opt =   fclaw2d_clawpatch_options_register(app, "clawpatch",  "fclaw_options.ini");
     claw46_opt =        fc2d_clawpack46_options_register(app, "clawpack46", "fclaw_options.ini");
     claw5_opt =          fc2d_clawpack5_options_register(app, "clawpack5",  "fclaw_options.ini");
-    user_opt =              shockbubble_options_register(app,               "fclaw_options.ini");  
+    user_opt =              shockbubble_options_register(app,               "fclaw_options.ini");
 
     /* Read configuration file(s) and command line, and process options */
     options = fclaw_app_get_options (app);
@@ -142,11 +149,7 @@ main (int argc, char **argv)
         /* Options have been checked and are valid */
 
         mpicomm = fclaw_app_get_mpi_size_rank (app, NULL, NULL);
-        domain = create_domain(mpicomm, fclaw_opt);
-    
-        /* Create global structure which stores the domain, timers, etc */
-        glob = fclaw2d_global_new();
-        fclaw2d_global_store_domain(glob, domain);
+        glob = create_glob (mpicomm, fclaw_opt);
 
         /* Store option packages in glob */
         fclaw2d_options_store           (glob, fclaw_opt);
@@ -157,14 +160,11 @@ main (int argc, char **argv)
 
         /* Run the program */
         run_program(glob);
-        
+
         fclaw2d_global_destroy(glob);
     }
-    
+
     fclaw_app_destroy (app);
 
     return 0;
 }
-
-
-

--- a/applications/clawpack/shallow/2d/sphere/sphere.cpp
+++ b/applications/clawpack/shallow/2d/sphere/sphere.cpp
@@ -198,10 +198,7 @@ void run_program(fclaw_app_t* app)
     fclaw2d_initialize(&domain);
     fclaw2d_run(&domain);
     fclaw2d_finalize(&domain);
-
-    fclaw2d_map_destroy(cont);
 }
-
 
 int
 main (int argc, char **argv)

--- a/applications/metric/2d/all_mappings/metric.cpp
+++ b/applications/metric/2d/all_mappings/metric.cpp
@@ -196,11 +196,6 @@ void run_program(fclaw_app_t* app)
   fclaw2d_initialize(&domain);
   fclaw2d_run(&domain);
   fclaw2d_finalize(&domain);
-
-  /* --------------------------------------------------
-     Clean up.
-     -------------------------------------------------- */
-  fclaw2d_map_destroy(cont);
 }
 
 int

--- a/src/fclaw2d_convenience.c
+++ b/src/fclaw2d_convenience.c
@@ -366,31 +366,38 @@ fclaw2d_domain_new_disk (sc_MPI_Comm mpicomm, int initial_level)
         (p4est_wrap_new_disk (mpicomm, 0, 0, initial_level), NULL);
 }
 
+#endif /* 0 */
+
 fclaw2d_domain_t *
-fclaw2d_domain_new_brick_map (sc_MPI_Comm mpicomm,
-                              int blocks_in_x, int blocks_in_y,
-                              int periodic_in_x, int periodic_in_y,
-                              int initial_level, fclaw2d_map_context_t * cont)
+fclaw2d_domain_new_brick (sc_MPI_Comm mpicomm,
+                          int blocks_in_x, int blocks_in_y,
+#ifdef P4_TO_P8
+                          int blocks_in_z,
+#endif
+                          int periodic_in_x, int periodic_in_y,
+#ifdef P4_TO_P8
+                          int periodic_in_z,
+#endif
+                          int initial_level)
 {
     p4est_wrap_t *wrap;
-    fclaw2d_domain_t *domain;
 
     fclaw2d_check_initial_level (mpicomm, initial_level);
     wrap = p4est_wrap_new_brick (mpicomm, blocks_in_x, blocks_in_y,
-                                 periodic_in_x, periodic_in_y, initial_level);
-    domain = fclaw2d_domain_new (wrap, NULL);
-    if (cont != NULL)
-    {
-        fclaw2d_domain_attribute_add (domain, "fclaw_map_context", cont);
-    }
-
-    return domain;
+#ifdef P4_TO_P8
+                                 blocks_in_z,
+#endif
+                                 periodic_in_x, periodic_in_y,
+#ifdef P4_TO_P8
+                                 periodic_in_z,
+#endif
+                                 initial_level);
+    return fclaw2d_domain_new (wrap, NULL);
 }
 
 fclaw2d_domain_t *
-fclaw2d_domain_new_conn_map (sc_MPI_Comm mpicomm, int initial_level,
-                             p4est_connectivity_t * conn,
-                             fclaw2d_map_context_t * cont)
+fclaw2d_domain_new_conn (sc_MPI_Comm mpicomm, int initial_level,
+                         p4est_connectivity_t * conn)
 {
     p4est_wrap_t *wrap;
     fclaw2d_domain_t *domain;
@@ -398,6 +405,22 @@ fclaw2d_domain_new_conn_map (sc_MPI_Comm mpicomm, int initial_level,
     fclaw2d_check_initial_level (mpicomm, initial_level);
     wrap = p4est_wrap_new_conn (mpicomm, conn, initial_level);
     domain = fclaw2d_domain_new (wrap, NULL);
+
+    return domain;
+}
+
+#ifndef P4_TO_P8
+
+/* function to be removed once no longer called by applications */
+
+fclaw2d_domain_t *
+fclaw2d_domain_new_conn_map (sc_MPI_Comm mpicomm, int initial_level,
+                             p4est_connectivity_t * conn,
+                             fclaw2d_map_context_t * cont)
+{
+    fclaw2d_domain_t *domain =
+      fclaw2d_domain_new_conn (mpicomm, initial_level, conn);
+
     fclaw2d_domain_attribute_add (domain, "fclaw_map_context", cont);
 
     return domain;

--- a/src/fclaw2d_convenience.h
+++ b/src/fclaw2d_convenience.h
@@ -38,12 +38,12 @@ extern "C"
 #endif
 #endif
 
-/* TODO: The unit square is a special case of the brick.  Use that instead. */
 fclaw2d_domain_t *fclaw2d_domain_new_unitsquare (sc_MPI_Comm mpicomm,
                                                  int initial_level);
-/* TODO: The torus is a special case of the brick.  Use that instead. */
+
 fclaw2d_domain_t *fclaw2d_domain_new_torus (sc_MPI_Comm mpicomm,
                                             int initial_level);
+
 fclaw2d_domain_t *fclaw2d_domain_new_twosphere (sc_MPI_Comm mpicomm,
                                                 int initial_level);
 fclaw2d_domain_t *fclaw2d_domain_new_cubedsphere (sc_MPI_Comm mpicomm,
@@ -61,16 +61,23 @@ fclaw2d_domain_t *fclaw2d_domain_new_disk (sc_MPI_Comm mpicomm,
  *                              leftmost blocks.
  * \param [in] periodic_in_y    Periodicity along the vertical direction.
  * \param [in] initial_level    A non-negative integer <= P4EST_QMAXLEVEL.
- * \param [in] cont             We do NOT take ownership of the mapping.
- *                              It is legal to pass NULL for this parameter.
  * \return                      A fully initialized domain structure.
  */
 fclaw2d_domain_t *fclaw2d_domain_new_brick (sc_MPI_Comm mpicomm,
                                             int blocks_in_x, int blocks_in_y,
                                             int periodic_in_x,
                                             int periodic_in_y,
-                                            int initial_level,
-                                            fclaw2d_map_context_t * cont);
+                                            int initial_level);
+
+/** Create a domain from a given forest connectivity.
+ * \param [in] mpicomm          We expect sc_MPI_Init to be called earlier.
+ * \param [in] initial_level    A non-negative integer <= P4EST_QMAXLEVEL.
+ * \param [in] conn             We DO take ownership of the connectivity.
+ * \return                      A fully initialized domain structure.
+ */
+fclaw2d_domain_t *fclaw2d_domain_new_conn (sc_MPI_Comm mpicomm,
+                                           int initial_level,
+                                           p4est_connectivity_t * conn);
 
 /** Create a domain from a given forest connectivity and matching map.
  * \param [in] mpicomm          We expect sc_MPI_Init to be called earlier.

--- a/src/fclaw2d_finalize.c
+++ b/src/fclaw2d_finalize.c
@@ -42,7 +42,9 @@ void fclaw2d_finalize(fclaw2d_global_t* glob)
 
     fclaw_global_essentialf("Finalizing run\n");
     fclaw2d_diagnostics_finalize(glob);
-    fclaw2d_map_destroy(glob->cont);
+    if (glob->cont != NULL) {
+        fclaw2d_map_destroy(glob->cont);
+    }
     fclaw2d_domain_barrier (glob->domain);
 
     if (gparms->report_timing)

--- a/src/fclaw2d_global.c
+++ b/src/fclaw2d_global.c
@@ -108,6 +108,11 @@ fclaw2d_global_store_domain (fclaw2d_global_t* glob, fclaw2d_domain_t* domain)
     glob->mpisize = domain->mpisize;
     glob->mpirank = domain->mpirank;
 
+    /*
+     * This is an assignment that might get removed in the future.
+     * There is a separate function, fclow2d_global_store_map (see below),
+     * wich accomplishes this without accessing the domain attributes.
+     */
     glob->cont = (fclaw2d_map_context_t*)
            fclaw2d_domain_attribute_access (glob->domain, "fclaw_map_context", NULL);
 }

--- a/src/fclaw2d_global.c
+++ b/src/fclaw2d_global.c
@@ -100,6 +100,18 @@ fclaw2d_global_t* fclaw2d_global_new (void)
     return glob;
 }
 
+fclaw2d_global_t* fclaw2d_global_new_comm (sc_MPI_Comm mpicomm,
+                                           int mpisize, int mpirank)
+{
+    fclaw2d_global_t *glob = fclaw2d_global_new ();
+
+    glob->mpicomm = mpicomm;
+    glob->mpisize = mpisize;
+    glob->mpirank = mpirank;
+
+    return glob;
+}
+
 void
 fclaw2d_global_store_domain (fclaw2d_global_t* glob, fclaw2d_domain_t* domain)
 {

--- a/src/fclaw2d_global.c
+++ b/src/fclaw2d_global.c
@@ -99,6 +99,7 @@ fclaw2d_global_t* fclaw2d_global_new (void)
 
     return glob;
 }
+
 void
 fclaw2d_global_store_domain (fclaw2d_global_t* glob, fclaw2d_domain_t* domain)
 {
@@ -106,9 +107,16 @@ fclaw2d_global_store_domain (fclaw2d_global_t* glob, fclaw2d_domain_t* domain)
     glob->mpicomm = domain->mpicomm;
     glob->mpisize = domain->mpisize;
     glob->mpirank = domain->mpirank;
-    
+
     glob->cont = (fclaw2d_map_context_t*)
            fclaw2d_domain_attribute_access (glob->domain, "fclaw_map_context", NULL);
+}
+
+void
+fclaw2d_global_store_map (fclaw2d_global_t* glob,
+                          struct fclaw2d_map_context * map)
+{
+    glob->cont = map;
 }
 
 void

--- a/src/fclaw2d_global.h
+++ b/src/fclaw2d_global.h
@@ -27,6 +27,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define FCLAW2D_GLOBAL_H
 
 #include <forestclaw2d.h>  /* Needed to declare callbacks (below) */
+#include <fclaw2d_map.h>   /* Needed to store the map context */
 
 #include <fclaw_timer.h>   /* Needed to create statically allocated array of timers */
 
@@ -110,7 +111,11 @@ fclaw2d_global_t* fclaw2d_global_new (void);
 
 void fclaw2d_global_destroy (fclaw2d_global_t * glob);
 
-void fclaw2d_global_store_domain (fclaw2d_global_t* glob, struct fclaw2d_domain* domain);
+void fclaw2d_global_store_domain (fclaw2d_global_t* glob,
+                                  struct fclaw2d_domain* domain);
+
+void fclaw2d_global_store_map (fclaw2d_global_t* glob,
+                               struct fclaw2d_map_context * map);
 
 void fclaw2d_global_iterate_level (fclaw2d_global_t * glob, int level,
                                    fclaw2d_patch_callback_t pcb, void *user);

--- a/src/fclaw2d_global.h
+++ b/src/fclaw2d_global.h
@@ -109,6 +109,9 @@ struct fclaw2d_diagnostics_accumulator;
 
 fclaw2d_global_t* fclaw2d_global_new (void);
 
+fclaw2d_global_t* fclaw2d_global_new_comm (sc_MPI_Comm mpicomm,
+                                           int mpisize, int mpirank);
+
 void fclaw2d_global_destroy (fclaw2d_global_t * glob);
 
 void fclaw2d_global_store_domain (fclaw2d_global_t* glob,

--- a/src/fclaw2d_to_3d.h
+++ b/src/fclaw2d_to_3d.h
@@ -78,6 +78,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define fclaw2d_domain_dimension        fclaw3d_domain_dimension
 #define fclaw2d_check_initial_level     fclaw3d_check_initial_level
 #define fclaw2d_domain_new_unitsquare   fclaw3d_domain_new_unitcube
+#define fclaw2d_domain_new_brick        fclaw3d_domain_new_brick
+#define fclaw2d_domain_new_conn         fclaw3d_domain_new_conn
 #define fclaw2d_domain_num_faces        fclaw3d_domain_num_faces
 #define fclaw2d_domain_num_corners      fclaw3d_domain_num_corners
 #define fclaw2d_domain_num_face_corners     fclaw3d_domain_num_face_corners
@@ -137,6 +139,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define fclaw2d_domain_iterate_cb       fclaw3d_domain_iterate_cb
 #define fclaw_domain_new2d              fclaw_domain_new3d
 #define fclaw_domain_destroy2d          fclaw_domain_destroy3d
+
 #define fclaw2d_iterate_patch_cb        fclaw3d_iterate_patch_cb
 #define fclaw2d_iterate_family_cb       fclaw3d_iterate_family_cb
 #define fclaw2d_domain_integrate_rays   fclaw3d_domain_integrate_rays

--- a/src/fclaw3d_convenience.h
+++ b/src/fclaw3d_convenience.h
@@ -27,9 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define FCLAW3D_CONVENIENCE_H
 
 #include <forestclaw3d.h>
-#if 0
-#include <fclaw3d_map.h>
-#endif
 #include <p8est_connectivity.h>
 
 #ifdef __cplusplus
@@ -40,7 +37,6 @@ extern "C"
 #endif
 #endif
 
-/* TODO: The unit cube is a special case of the brick.  Use that instead. */
 fclaw3d_domain_t *fclaw3d_domain_new_unitcube (sc_MPI_Comm mpicomm,
                                                int initial_level);
 
@@ -54,6 +50,8 @@ fclaw3d_domain_t *fclaw3d_domain_new_twosphere (sc_MPI_Comm mpicomm,
 fclaw3d_domain_t *fclaw3d_domain_new_cubedsphere (sc_MPI_Comm mpicomm,
                                                   int initial_level);
 
+#endif
+
 /** Create a brick connectivity, that is, a rectangular grid of blocks.
  * The origin is in the lower-left corner of the brick.
  * \param [in] mpicomm          We expect sc_MPI_Init to be called earlier.
@@ -64,30 +62,25 @@ fclaw3d_domain_t *fclaw3d_domain_new_cubedsphere (sc_MPI_Comm mpicomm,
  *                              leftmost blocks.
  * \param [in] periodic_in_y    Periodicity along the vertical direction.
  * \param [in] initial_level    A non-negative integer <= P4EST_QMAXLEVEL.
- * \param [in] cont             We do NOT take ownership of the mapping.
- *                              It is legal to pass NULL for this parameter.
  * \return                      A fully initialized domain structure.
  */
-fclaw2d_domain_t *fclaw2d_domain_new_brick (sc_MPI_Comm mpicomm,
+fclaw3d_domain_t *fclaw3d_domain_new_brick (sc_MPI_Comm mpicomm,
                                             int blocks_in_x, int blocks_in_y,
+                                            int blocks_in_z,
                                             int periodic_in_x,
                                             int periodic_in_y,
-                                            int initial_level,
-                                            fclaw2d_map_context_t * cont);
+                                            int periodic_in_z,
+                                            int initial_level);
 
-/** Create a domain from a given forest connectivity and matching map.
+/** Create a domain from a given forest connectivity.
  * \param [in] mpicomm          We expect sc_MPI_Init to be called earlier.
  * \param [in] initial_level    A non-negative integer <= P4EST_QMAXLEVEL.
  * \param [in] conn             We DO take ownership of the connectivity.
- * \param [in] cont             We do NOT take ownership of the mapping.
  * \return                      A fully initialized domain structure.
  */
-fclaw2d_domain_t *fclaw2d_domain_new_conn_map (sc_MPI_Comm mpicomm,
-                                               int initial_level,
-                                               p4est_connectivity_t * conn,
-                                               fclaw2d_map_context_t * cont);
-
-#endif /* 0 */
+fclaw3d_domain_t *fclaw3d_domain_new_conn (sc_MPI_Comm mpicomm,
+                                           int initial_level,
+                                           p8est_connectivity_t * conn);
 
 void fclaw3d_domain_destroy (fclaw3d_domain_t * domain);
 


### PR DESCRIPTION
Previously, the mapping, if any, was attached to the domain as attribute, and then retrieved as an attribute from the domain and stored in the global structure. This commit

 - Removes the detour of the map through the domain, which simplifies dependencies.
 - Adapts the clawpack/euler/2d/quadrants example, which uses the simple nomap.
 - Adapts the clawpack/euler/2d/shockbubble example, which is more sophisticated.

Please comment on how everybody likes the changes two applications mentioned.
With that feedback, we can continue to modify the other 55 examples.

It would be nice to merge this PR as soon as possible since we include a couple 3D translations.