### PR TITLE
Fix corner issue

### DIFF
--- a/applications/clawpack/advection/2d/swirl/swirl.cpp
+++ b/applications/clawpack/advection/2d/swirl/swirl.cpp
@@ -29,17 +29,17 @@
 
 
 static
-void create_domain_map (fclaw2d_global_t *glob, fclaw_options_t* gparms)
+void create_domain_map (fclaw2d_global_t *glob, fclaw_options_t* fclaw_opt)
 {
     /* Mapped, multi-block domain */
     fclaw2d_domain_t         *domain = NULL;
-    domain = fclaw2d_domain_new_unitsquare (glob->mpicomm, gparms->minlevel);
+    domain = fclaw2d_domain_new_unitsquare (glob->mpicomm, fclaw_opt->minlevel);
     fclaw2d_domain_list_levels(domain, FCLAW_VERBOSITY_ESSENTIAL);
     fclaw2d_domain_list_neighbors(domain, FCLAW_VERBOSITY_DEBUG);
     fclaw2d_global_store_domain (glob, domain);
 
     /* Map unit square to disk using mapc2m_disk.f */
-    gparms->manifold = 0;
+    fclaw_opt->manifold = 0;
     fclaw2d_global_store_map (glob, fclaw2d_map_new_nomap ());
 }
 

--- a/scripts/compare_files/compare_files.f90
+++ b/scripts/compare_files/compare_files.f90
@@ -315,6 +315,7 @@ SUBROUTINE write_tfile(iframe,time,meqn,ngrids,dir3)
   dir3_fname2 = TRIM(dir3)//'/'//trim(fname2)
 
   maux = 0
+  matunit2 = 52
   OPEN(matunit2,file=dir3_fname2)
   WRITE(matunit2,1000) time,meqn,ngrids,maux
 1000 FORMAT(e18.8,'    time', /, &

--- a/src/fclaw2d_corner_neighbors.c
+++ b/src/fclaw2d_corner_neighbors.c
@@ -453,6 +453,7 @@ void cb_corner_fill(fclaw2d_domain_t *domain,
             int remote_neighbor = fclaw2d_patch_is_ghost(corner_patch);
             if (is_coarse && ((read_parallel_patches && remote_neighbor) || !remote_neighbor))
             {
+                /* Remote neighbor is a corner patch.  */
                 transform_data.neighbor_patch = corner_patch;
                 if (neighbor_level == FINER_GRID)
                 {
@@ -460,7 +461,7 @@ void cb_corner_fill(fclaw2d_domain_t *domain,
                     fclaw2d_patch_t* fine_patch = corner_patch;
                     int coarse_blockno = this_block_idx;
                     int fine_blockno = corner_block_idx;
-                    if (interpolate_to_neighbor && !remote_neighbor)
+                    if (interpolate_to_neighbor) // && !remote_neighbor)                        
                     {
                         /* No need to interpolate to remote ghost patches. */
                         fclaw2d_patch_interpolate_corner(s->glob,
@@ -512,7 +513,24 @@ void cb_corner_fill(fclaw2d_domain_t *domain,
                 int coarse_blockno = corner_block_idx;
                 int fine_blockno = this_patch_idx;
 
-                if (interpolate_to_neighbor)
+                if (average_from_neighbor)
+                {
+                    /* Average from local fine grid to remote coarse ghost, since interpolation
+                    stencil may need corner coarse grid values */
+                    int coarse_icorner = transform_data_finegrid.icorner;
+                    //printf("Averaging from neighbors : %d %d\n",icorner,coarse_icorner);
+                    fclaw2d_patch_average_corner(s->glob,
+                                                 coarse_patch,
+                                                 fine_patch,
+                                                 coarse_blockno,
+                                                 fine_blockno,
+                                                 is_block_corner,
+                                                 coarse_icorner,time_interp,
+                                                 &transform_data_finegrid);                        
+
+                }
+
+                else if (interpolate_to_neighbor)
                 {
                     /* Interpolate from remote coarse grid patch (coarse grid) to
                        local fine grid patch.  We do not need to average to the 

--- a/src/fclaw2d_face_neighbors.c
+++ b/src/fclaw2d_face_neighbors.c
@@ -506,7 +506,7 @@ void fclaw2d_face_neighbor_ghost(fclaw2d_global_t* glob,
 
 			/* We are only looking for faces between two ghost patches
 			   from different processors, since these will not have
-			   exchange face data before being thrown over proc fence.
+			   exchanged face data before being thrown over proc fence.
 			*/
 			fclaw2d_patch_relation_t neighbor_type =
 				fclaw2d_domain_indirect_neighbors(domain,


### PR DESCRIPTION
Remote parallel patches will now have corner ghost values filled.  This is needed for interpolation stencils that require corner values.   Added in for ActiveFlux method. 