### PR TITLE
Update checkout action to v3 in GitHub workflows

### DIFF
--- a/.github/workflows/ci_automake.yml
+++ b/.github/workflows/ci_automake.yml
@@ -73,10 +73,10 @@ jobs:
 
     name: Automake ${{ matrix.name }} Build on Linux
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       name: "Checkout Source code"
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       name: "Checkout ThunderEgg Source code"
       if: ${{ matrix.thunderegg }}
       with:

--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -63,7 +63,7 @@ jobs:
 
     name: CMake ${{ matrix.name }} Build on Linux
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       name: Checkout source code
 
     - name: Install system dependencies
@@ -123,7 +123,7 @@ jobs:
       FC: gfortran-11
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       name: Checkout source code
 
     - name: Install system dependencies

--- a/.github/workflows/ci_external_project.yml
+++ b/.github/workflows/ci_external_project.yml
@@ -59,7 +59,7 @@ jobs:
 
     name: External ${{ matrix.name }} Build on Linux
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       name: Checkout source code
 
     - name: Install system dependencies

--- a/.github/workflows/cmake_autools_compare.yml
+++ b/.github/workflows/cmake_autools_compare.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Check for Build System Files
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       name: Checkout source code
     - name: Run Compare Script
       run: scripts/ci/check_for_automake_and_cmake_files.py


### PR DESCRIPTION
Minor change to workflow files. This will remove all of the `Node.js 12 actions are deprecated.` warnings.