### PR TITLE
Mesh overlap feature and example

### DIFF
--- a/applications/clawpack/advection/2d/filament_swirl/filament_swirl.cpp
+++ b/applications/clawpack/advection/2d/filament_swirl/filament_swirl.cpp
@@ -135,7 +135,6 @@ overlap_prodata_t;
 
 typedef struct overlap_point
 {
-  int                 rank;
   p4est_locidx_t      lnum;
   double              xy[2];
   overlap_prodata_t   prodata;
@@ -151,7 +150,6 @@ create_query_points (sc_array_t *query_points)
     npz = query_points->elem_count;
     for (iz = 0; iz < npz; iz++) {
         op = (overlap_point_t *) sc_array_index(query_points, iz);
-        op->rank = -1;
         op->prodata.isset = 0;
         op->prodata.myvalue = 0;
         op->xy[0] = 0.5 + 0.4 * cos ((iz) * 2 * M_PI / npz);
@@ -178,13 +176,7 @@ overlap_interpolate (fclaw2d_domain_t * domain, fclaw2d_patch_t * patch,
     if (consumer_side)
     {
         /* we are on the consumer side and can only rely on basic domain
-         * information */
-        if (op->rank >= 0)
-        {
-            return 0;           /* avoid multiple matches */
-        }
-
-        /* we do a stricter interpolation test in order to not lose
+         * information. We do a stricter interpolation test in order to not lose
          * the accepted points on the producer side */
         tol = 0.5 * SC_1000_EPS;
     }
@@ -205,13 +197,6 @@ overlap_interpolate (fclaw2d_domain_t * domain, fclaw2d_patch_t * patch,
     printf ("Found point [%f,%f] in patch [%f,%f]x[%f,%f].\n",
             op->xy[0], op->xy[1], patch->xlower, patch->xupper, patch->ylower,
             patch->yupper);
-
-    if (consumer_side && domain->mpirank >= 0)
-    {
-        /* we are at a leaf (patch belonging to just one process) of the
-         * partition search, so we will send the point to domain->mpirank */
-        op->rank = domain->mpirank;
-    }
 
     /* update interpolation data */
     if (patchno >= 0)

--- a/applications/clawpack/advection/2d/filament_swirl/filament_swirl.cpp
+++ b/applications/clawpack/advection/2d/filament_swirl/filament_swirl.cpp
@@ -151,9 +151,9 @@ typedef struct overlap_consumer
 }
 overlap_consumer_t;
 
-void
-add_cell_centers (fclaw2d_domain_t * domain, fclaw2d_patch_t * patch,
-                  int blockno, int patchno, void *user)
+static
+void add_cell_centers (fclaw2d_domain_t * domain, fclaw2d_patch_t * patch,
+                       int blockno, int patchno, void *user)
 {
     overlap_point_t *op;
     int mx, my, mbc, i, j;
@@ -189,8 +189,8 @@ add_cell_centers (fclaw2d_domain_t * domain, fclaw2d_patch_t * patch,
     }
 }
 
-void
-create_query_points (overlap_consumer_t * c)
+static
+void create_query_points (overlap_consumer_t * c)
 {
     /* We create a process-local set of query points, for which we want to
      * obtain interpolation data from the producer side. We query the
@@ -207,9 +207,9 @@ create_query_points (overlap_consumer_t * c)
                   c->num_cells_in_patch);
 }
 
-int
-overlap_interpolate (fclaw2d_domain_t * domain, fclaw2d_patch_t * patch,
-                     int blockno, int patchno, void *point, void *user)
+static
+int overlap_interpolate (fclaw2d_domain_t * domain, fclaw2d_patch_t * patch,
+                         int blockno, int patchno, void *point, void *user)
 {
     overlap_point_t *op;
     double tol;
@@ -285,8 +285,8 @@ overlap_interpolate (fclaw2d_domain_t * domain, fclaw2d_patch_t * patch,
     return 1;
 }
 
-void
-output_query_points (overlap_consumer_t * c)
+static
+void output_query_points (overlap_consumer_t * c)
 {
     size_t iz, npz;
     overlap_point_t *op;

--- a/applications/clawpack/advection/2d/filament_swirl/filament_swirl.cpp
+++ b/applications/clawpack/advection/2d/filament_swirl/filament_swirl.cpp
@@ -183,6 +183,11 @@ void add_cell_centers (fclaw2d_domain_t * domain, fclaw2d_patch_t * patch,
             /* initialize the query-point corresponding to this cell */
             op = (overlap_point_t *) sc_array_index (c->query_points,
                                                      c->cell_idx);
+
+            /* Initialize all struct bytes to 0. Not doing so can lead to
+             * valgrind warnings due to uninitialized compiler padding bytes. */
+            memset(op, 0, sizeof(overlap_point_t));
+
             op->lnum = c->cell_idx++;   /* local index of the cell */
             op->prodata.isset = 0;
             op->prodata.myvalue = -1;

--- a/applications/clawpack/advection/2d/filament_swirl/filament_swirl.cpp
+++ b/applications/clawpack/advection/2d/filament_swirl/filament_swirl.cpp
@@ -160,6 +160,32 @@ int
 overlap_interpolate (fclaw2d_domain_t * domain, fclaw2d_patch_t * patch,
                      int blockno, int patchno, void *point, void *user)
 {
+    overlap_point_t *op;
+    double tol;
+
+    FCLAW_ASSERT (point != NULL);
+    op = (overlap_point_t *) point;
+
+    if (patchno == -1)
+    {
+        if (domain->local_num_patches == -1)
+        {
+            /* do stricter interpolation test on consumer side, so we will not
+             * lose the accepted points on the producer side */
+            tol = 0.5 * SC_1000_EPS;
+        }
+        else
+        {
+            tol = SC_1000_EPS;
+        }
+        if ((op->xy[0] < patch->xlower - tol
+             || op->xy[0] > patch->xupper + tol)
+            || (op->xy[1] < patch->ylower - tol
+                || op->xy[1] > patch->yupper + tol))
+        {
+            return 0;
+        }
+    }
     return 1;
 }
 

--- a/applications/clawpack/advection/2d/filament_swirl/filament_swirl.cpp
+++ b/applications/clawpack/advection/2d/filament_swirl/filament_swirl.cpp
@@ -213,6 +213,14 @@ overlap_interpolate (fclaw2d_domain_t * domain, fclaw2d_patch_t * patch,
                   op->xy[0], op->xy[1], patch->xlower, patch->xupper,
                   patch->ylower, patch->yupper);
 
+    /* Although the point is located within a certain tolerance of the patch,
+     * it may still lie outside of the [0,1]x[0,1]-block on which the domain is
+     * defined. */
+    op->xy[0] = SC_MAX (op->xy[0], 0.);
+    op->xy[0] = SC_MIN (op->xy[0], 1.);
+    op->xy[1] = SC_MAX (op->xy[1], 0.);
+    op->xy[1] = SC_MIN (op->xy[1], 1.);
+
     /* update interpolation data */
     if (patchno >= 0)
     {

--- a/applications/clawpack/advection/2d/filament_swirl/filament_swirl.cpp
+++ b/applications/clawpack/advection/2d/filament_swirl/filament_swirl.cpp
@@ -169,10 +169,11 @@ overlap_interpolate (fclaw2d_domain_t * domain, fclaw2d_patch_t * patch,
     op = (overlap_point_t *) point;
 
     /* set tolerances */
-    if (domain->local_num_patches == -1)
+    if (domain_is_meta (domain))
     {
-        /* do stricter interpolation test on consumer side, so we will not
-         * lose the accepted points on the producer side */
+        /* We are on the consumer side and can only rely on basic domain
+         * information. We do a stricter interpolation test on consumer side,
+         * in order to not lose the accepted points on the producer side */
         tol = 0.5 * SC_1000_EPS;
     }
     else

--- a/applications/clawpack/advection/2d/filament_swirl/filament_swirl.cpp
+++ b/applications/clawpack/advection/2d/filament_swirl/filament_swirl.cpp
@@ -137,7 +137,7 @@ typedef struct overlap_point
 {
   int                 rank;
   p4est_locidx_t      lnum;
-  double              xyz[3];
+  double              xy[2];
   overlap_prodata_t   prodata;
 }
 overlap_point_t;
@@ -151,9 +151,8 @@ create_query_points (sc_array_t *query_points)
     npz = query_points->elem_count;
     for (iz = 0; iz < npz; iz++) {
         op = (overlap_point_t *) sc_array_index(query_points, iz);
-        op->xyz[0] = 0.1;
-        op->xyz[1] = 0.2;
-        op->xyz[2] = 0.3;
+        op->xy[0] = 0.5 + 0.4 * cos ((iz) * 2 * M_PI / npz);
+        op->xy[1] = 0.5 + 0.4 * sin ((iz) * 2 * M_PI / npz);
     }
 }
 
@@ -260,8 +259,8 @@ main (int argc, char **argv)
         create_query_points(query_points);
         for (iz = 0; iz < npz; iz++) {
             op = (overlap_point_t *)sc_array_index(query_points, iz);
-            printf("Query point %ld is [%f,%f,%f].\n", iz, op->xyz[0],
-                        op->xyz[1], op->xyz[2]);
+            printf("Query point %ld is [%f,%f].\n", iz, op->xy[0],
+                        op->xy[1]);
         }
 
         fclaw2d_overlap_exchange(filament_domain, query_points,

--- a/applications/clawpack/advection/2d/filament_swirl/filament_swirl.cpp
+++ b/applications/clawpack/advection/2d/filament_swirl/filament_swirl.cpp
@@ -191,7 +191,7 @@ void add_cell_centers (fclaw2d_domain_t * domain, fclaw2d_patch_t * patch,
 
             /* Initialize all struct bytes to 0. Not doing so can lead to
              * valgrind warnings due to uninitialized compiler padding bytes. */
-            memset (op, 0, sizeof (overlap_point_t));
+            memset (op, -1, sizeof (overlap_point_t));
 
             op->lnum = c->cell_idx++;   /* local index of the cell */
             op->prodata.isset = 0;

--- a/applications/clawpack/advection/2d/filament_swirl/user_run.c
+++ b/applications/clawpack/advection/2d/filament_swirl/user_run.c
@@ -35,6 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <fclaw2d_vtable.h>
 
 #include "fclaw_math.h"
+#include "user.h"
 
 /*  -----------------------------------------------------------------
     Time stepping

--- a/src/fclaw2d_convenience.c
+++ b/src/fclaw2d_convenience.c
@@ -1284,19 +1284,6 @@ fclaw2d_domain_integrate_rays (fclaw2d_domain_t * domain,
     sc_array_reset (lints);
 }
 
-/* dummy replacement until real p4est_search_partition_gfx is available */
-void
-p4est_search_partition_gfx (const p4est_gloidx_t * gfq,
-                            const p4est_quadrant_t * gfp,
-                            int nmemb, p4est_topidx_t num_trees,
-                            int call_post, void *user,
-                            p4est_search_partition_t quadrant_fn,
-                            p4est_search_partition_t point_fn,
-                            sc_array_t * points)
-{
-
-}
-
 typedef enum comm_tag
 {
     COMM_TAG_CONSDATA,

--- a/src/fclaw2d_convenience.c
+++ b/src/fclaw2d_convenience.c
@@ -1416,9 +1416,9 @@ interpolate_partition_fn (p4est_t * p4est, p4est_topidx_t which_tree,
     /* assert that the point is a valid overlap_point_t and was not added yet */
     overlap_point_t *op = (overlap_point_t *) point;
     FCLAW_ASSERT (op != NULL && op->point != NULL);
-    if (pfirst == plast && pfirst == op->rank)
+    if (op->rank >= 0)
     {
-        return 0;               /* avoid sending the same point twice to the same process */
+        return 0;               /* avoid sending the same point twice */
     }
 
     /* assert that the user_pointer contains a valid interpolation_data_t */

--- a/src/fclaw2d_convenience.c
+++ b/src/fclaw2d_convenience.c
@@ -1388,6 +1388,20 @@ overlap_consumer_add (fclaw2d_interpolation_data_t * ipd, void *point,
     memcpy (sc_array_push (&sb->ops), point, ipd->point_size);
 }
 
+int
+domain_is_meta (fclaw2d_domain_t * domain)
+{
+    FCLAW_ASSERT (domain != NULL);
+    if (domain->local_num_patches == -1)
+    {
+        return 1;
+    }
+    else
+    {
+        return 0;
+    }
+}
+
 static int
 interpolate_partition_fn (p4est_t * p4est, p4est_topidx_t which_tree,
                           p4est_quadrant_t * quadrant, int pfirst, int plast,

--- a/src/fclaw2d_convenience.c
+++ b/src/fclaw2d_convenience.c
@@ -1429,7 +1429,9 @@ interpolate_partition_fn (p4est_t * p4est, p4est_topidx_t which_tree,
     FCLAW_ASSERT (ipd->interpolate != NULL);
 
     /* create artifical domain, that only contains mpi and tree structure data */
-    domain = FCLAW_ALLOC(fclaw2d_domain_t, 1);
+    domain = FCLAW_ALLOC (fclaw2d_domain_t, 1);
+    memset (domain, 0, sizeof (fclaw2d_domain_t));      /* initialize to zero */
+    domain->local_num_patches = -1;     /* mark as artifical patch */
     domain->mpicomm = p4est->mpicomm;
     domain->mpisize = p4est->mpisize;
     domain->mpirank = (pfirst == plast) ? pfirst : -1;
@@ -1439,33 +1441,6 @@ interpolate_partition_fn (p4est_t * p4est, p4est_topidx_t which_tree,
     domain->pp = ipd->domain->pp;
     domain->pp_owned = 0;
     domain->attributes = ipd->domain->attributes;
-
-    /* mark uninitialized state of remaining variables */
-    domain->possible_maxlevel = -1;
-    domain->p.smooth_level = -1;
-    domain->p.smooth_refine = -1;
-    domain->local_num_patches = -1;
-    domain->local_minlevel = -1;
-    domain->local_maxlevel = -1;
-    domain->global_num_patches = -1;
-    domain->global_num_patches_before = -1;
-    domain->global_minlevel = -1;
-    domain->global_maxlevel = -1;
-    domain->just_adapted = 0; /* as asserted in domain_destroy */
-    domain->just_partitioned = 0; /* as asserted in domain_destroy */
-    domain->partition_unchanged_first = -1;
-    domain->partition_unchanged_length = -1;
-    domain->partition_unchanged_old_first = -1;
-    domain->num_blocks = -1;
-    domain->blocks = NULL;
-    domain->num_exchange_patches = -1;
-    domain->exchange_patches = NULL;
-    domain->num_ghost_patches = -1;
-    domain->ghost_patches = NULL;
-    domain->mirror_target_levels = NULL;
-    domain->ghost_target_levels = NULL;
-    domain->attributes = NULL;
-    domain->user = NULL;
 
     /* create artifical patch and fill it based on the quadrant */
     patch = &fclaw2d_patch;

--- a/src/fclaw2d_convenience.c
+++ b/src/fclaw2d_convenience.c
@@ -1469,6 +1469,8 @@ interpolate_partition_fn (p4est_t * p4est, p4est_topidx_t which_tree,
         ipd->interpolate (domain, patch, which_tree, patchno, op->point,
                           ipd->user);
 
+    fclaw2d_domain_destroy (domain);
+
     if (!intersects)
     {
         return 0;
@@ -1481,7 +1483,6 @@ interpolate_partition_fn (p4est_t * p4est, p4est_topidx_t which_tree,
         overlap_consumer_add (ipd, op->point, pfirst);
         op->rank = pfirst;      /* mark, that we added this point to the process buffer */
     }
-    fclaw2d_domain_destroy(domain);
     return 1;
 }
 

--- a/src/fclaw2d_convenience.c
+++ b/src/fclaw2d_convenience.c
@@ -1286,8 +1286,8 @@ fclaw2d_domain_integrate_rays (fclaw2d_domain_t * domain,
 
 typedef enum comm_tag
 {
-    COMM_TAG_CONSDATA,
-    COMM_TAG_PRODATA
+    COMM_TAG_CONSDATA = 5526,
+    COMM_TAG_PRODATA = 5527
 }
 comm_tag_t;
 

--- a/src/fclaw2d_convenience.c
+++ b/src/fclaw2d_convenience.c
@@ -1804,7 +1804,7 @@ consumer_free_communication_data (overlap_consumer_comm_t * c)
 {
     overlap_ind_t *qi;
     overlap_buf_t *sb;
-    int i;
+    int i, num_queries;
 #ifdef FCLAW_ENABLE_MPI
     overlap_buf_t *rb;
 #ifdef FCLAW_ENABLE_DEBUG
@@ -1847,7 +1847,8 @@ consumer_free_communication_data (overlap_consumer_comm_t * c)
         sc_array_reset (&sb->ops);
     }
 #endif
-    for (i = 0; i < c->query_indices->elem_count; i++)
+    num_queries = (int) c->query_indices->elem_count;
+    for (i = 0; i < num_queries; i++)
     {
         qi = (overlap_ind_t *) sc_array_index_int (c->query_indices, i);
         sc_array_reset (&qi->oqs);

--- a/src/fclaw2d_convenience.h
+++ b/src/fclaw2d_convenience.h
@@ -262,6 +262,15 @@ void fclaw2d_domain_integrate_rays (fclaw2d_domain_t * domain,
                                     sc_array_t * integrals,
                                     void * user);
 
+/** Return true if \b domain is an artifical domain.
+ *
+ * This function can be used in \ref fclaw2d_interpolate_point_t callbacks to
+ * distinguish domains that were created during a consumer-side partition search
+ * (and only contain some meta information) from real domains in a producer-side
+ * local search.
+ */
+int domain_is_meta (fclaw2d_domain_t * domain);
+
 /** Callback function to compute the interpolation data for a point and a patch.
  *
  * This function can be passed to \ref fclaw2d_overlap_exchange to eventually

--- a/src/fclaw2d_convenience.h
+++ b/src/fclaw2d_convenience.h
@@ -293,8 +293,7 @@ int domain_is_meta (fclaw2d_domain_t * domain);
  *                              of the partition search, else it will be -1.
  * \param [in] patch            The patch under consideration.
  *                              When on a leaf on the producer side, this is a
- *                              valid patch number, as always relative to its
- *                              block.
+ *                              valid patch from the producer domain.
  *                              Otherwise, this is a temporary artificial patch
  *                              containing all standard patch information except
  *                              for the pointer to the next patch and user-data.
@@ -318,11 +317,13 @@ int domain_is_meta (fclaw2d_domain_t * domain);
  *                              interpolation data.
  *                              Return false if there is definitely no
  *                              contribution.
- *                              If patchno is non-negative this callback should
- *                              compute the exact interpolation data of the
- *                              point-patch-combination.
- *                              If patchno is -1, the return value may be a
- *                              false positive, we'll be fine.
+ *                              If we are on a leaf on the producer side
+ *                              (patchno is non-negative) or the consumer side
+ *                              (domain_is_meta and mpirank is non-negative)
+ *                              this callback should do an exact test for
+ *                              contribution.
+ *                              Else, the return value may be a false positive,
+ *                              we'll be fine.
  */
 typedef int (*fclaw2d_interpolate_point_t) (fclaw2d_domain_t * domain,
                                             fclaw2d_patch_t * patch,
@@ -343,10 +344,10 @@ typedef int (*fclaw2d_interpolate_point_t) (fclaw2d_domain_t * domain,
  *                              We do not dereference, just pass pointers around.
  *                              The array is defined processor-local and may
  *                              contain different points on different processes.
- *                              The query points are supposed to be computed and
- *                              transformed to the producer space (by an
+ *                              The query points are supposed to be computed
+ *                              (and transformed to the producer space by an
  *                              inverse mapping) locally on the consumer side.
- *                              On output the points will contain collected
+ *                              On output, the points will contain collected
  *                              interpolation data according to \b interpolate.
  * \param [in] interpolate      Callback function that returns true if a point
  *                              intersects a patch and -- when called for a leaf

--- a/src/fclaw2d_convenience.h
+++ b/src/fclaw2d_convenience.h
@@ -342,6 +342,8 @@ typedef int (*fclaw2d_interpolate_point_t) (fclaw2d_domain_t * domain,
  * \param [in,out] query_points Array containing points of user-defined type.
  *                              Each entry contains one item of arbitrary data.
  *                              We do not dereference, just pass pointers around.
+ *                              The points will be sent via MPI, so they may not
+ *                              contain pointers to further data.
  *                              The array is defined processor-local and may
  *                              contain different points on different processes.
  *                              The query points are supposed to be computed

--- a/src/fclaw2d_convenience.h
+++ b/src/fclaw2d_convenience.h
@@ -306,7 +306,7 @@ int domain_is_meta (fclaw2d_domain_t * domain);
  * \param [in] patchno          If patchno is -1, we are on an artifical patch.
  *                              Otherwise, this is a valid patchno from the
  *                              producer domain.
- * \param [in] point            Representation of a point; user-defined.
+ * \param [in,out] point        Representation of a point; user-defined.
  *                              Points to an array element of the query points
  *                              passed to \ref fclaw2d_overlap_exchange.
  *                              If patchno is non-negative, the points


### PR DESCRIPTION
We provide functionality to query interpolation data from a domain for a process-dependent local set of points. To query the interpolation data, the user must provide a domain, an array of query-points and an interpolation-callback to fclaw2d_overlap_exchange.

This can be used to facilitate working with two overlapping domains at the same time. In this case, we distinguish a consumer side (which "consumes" interpolation data and posts the query points) and a producer side (which produces the interpolation data). Both domains must operate on the same communicator.

The filament_swirl example was extended to include the exchange functionalities. Here, the swirl domain represents the consumer side and the filament domain represents the producer side. The exchange-functionalities are not yet integrated into the time loop and are only called once at the start of the program. 

The consumer creates a process-local array of query points - the center points of all local cells. The interpolation callback applies the inverse mapping of the filament-side to the query point, before intersecting it with the patch boundaries. Currently, we do not implement actual interpolation of the point data. Instead, the interpolation value is set to the respective rank on the producer side.

What the example still leaves to be desired is the proper implementation of a non-trivial consumer mapping and producer inverse mapping. Furthermore, actual interpolation including the producer side cells should be added.