### PR TITLE
Update user tagging routines to take vector of values

### DIFF
--- a/applications/clawpack/advection/2d/all/advection_user_fort.h
+++ b/applications/clawpack/advection/2d/all/advection_user_fort.h
@@ -155,6 +155,7 @@ void USER5_B4STEP2_MANIFOLD(const int* mx, const int* my, const int* mbc,
                                               USER_EXCEEDS_THRESHOLD)
 
 int USER_EXCEEDS_THRESHOLD(const int* blockno,
+                           const int* meqn,
                            const double qval[], 
                            const double* qmin, 
                            const double *qmax,
@@ -163,6 +164,7 @@ int USER_EXCEEDS_THRESHOLD(const int* blockno,
                            const double *dy, 
                            const double *xc, 
                            const double *yc, 
+                           const int* ivar_threshold,
                            const double* tag_threshold, 
                            const int* init_flag,
                            const int* is_ghost);

--- a/applications/clawpack/advection/2d/slotted_disk/slotted_disk_exceeds_th.f90
+++ b/applications/clawpack/advection/2d/slotted_disk/slotted_disk_exceeds_th.f90
@@ -2,7 +2,7 @@
 
 integer function user_exceeds_threshold(blockno,meqn,& 
                                      qval,qmin,qmax,quad, & 
-                                     dx,dy,xc,yc,threshold, ivar_threshold, &
+                                     dx,dy,xc,yc,ivar_threshold, threshold, &
                                      init_flag, is_ghost)
     implicit none
     

--- a/applications/clawpack/advection/2d/slotted_disk/slotted_disk_exceeds_th.f90
+++ b/applications/clawpack/advection/2d/slotted_disk/slotted_disk_exceeds_th.f90
@@ -1,21 +1,26 @@
 !! # check to see if value exceeds threshold
 
-integer function user_exceeds_threshold(blockno,& 
+integer function user_exceeds_threshold(blockno,meqn,& 
                                      qval,qmin,qmax,quad, & 
-                                     dx,dy,xc,yc,threshold, &
+                                     dx,dy,xc,yc,threshold, ivar_threshold, &
                                      init_flag, is_ghost)
     implicit none
     
-    double precision :: qval,qmin,qmax,threshold
-    double precision :: quad(-1:1,-1:1)
+    integer :: meqn,ivar_threshold
+    double precision :: qval(meqn),qmin(meqn),qmax(meqn),threshold
+    double precision :: quad(-1:1,-1:1,meqn)
     double precision :: dx,dy, xc, yc
     integer :: blockno, init_flag, refine
     logical(kind=4) :: is_ghost
 
+    integer :: mq
+
     refine = 0
 
+    mq = ivar_threshold
+
     if (.not. is_ghost) then
-        if (qval .gt. threshold .and. qval .lt. 1-threshold) then
+        if (qval(mq) .gt. threshold .and. qval(mq) .lt. 1-threshold) then
             refine = 1
         endif
     endif

--- a/src/patches/clawpatch/CMakeLists.txt
+++ b/src/patches/clawpatch/CMakeLists.txt
@@ -81,8 +81,8 @@ add_library(clawpatch
   fclaw3dx_clawpatch_output_vtk.c
   fclaw3dx_clawpatch_conservation.c
 
-  fort_user/fclaw2d_clawpatch_exceeds_threshold.c
-  fort3_user/fclaw3dx_clawpatch_exceeds_threshold.c
+  fort_user/fclaw2d_clawpatch_tag_criteria.c
+  fort3_user/fclaw3dx_clawpatch_tag_criteria.c
   ${metric}/fclaw2d_metric.cpp
   ${metric}/fclaw2d_metric_default.c
   ${metric}/fclaw3d_metric.cpp 

--- a/src/patches/clawpatch/Makefile.am
+++ b/src/patches/clawpatch/Makefile.am
@@ -57,13 +57,13 @@ libclawpatch_compiled_sources = \
 	src/patches/clawpatch/fclaw3dx_clawpatch_output_vtk.c \
 	src/patches/clawpatch/fclaw3dx_clawpatch_utils.f \
 	\
-	src/patches/clawpatch/fort_user/fclaw2d_clawpatch_exceeds_threshold.c \
+	src/patches/clawpatch/fort_user/fclaw2d_clawpatch_tag_criteria.c \
 	src/patches/clawpatch/fort_user/fclaw2d_clawpatch_difference_exceeds_th.f90 \
 	src/patches/clawpatch/fort_user/fclaw2d_clawpatch_value_exceeds_th.f90 \
 	src/patches/clawpatch/fort_user/fclaw2d_clawpatch_minmax_exceeds_th.f90 \
 	src/patches/clawpatch/fort_user/fclaw2d_clawpatch_gradient_exceeds_th.f90 \
 	\
-	src/patches/clawpatch/fort3_user/fclaw3dx_clawpatch_exceeds_threshold.c \
+	src/patches/clawpatch/fort3_user/fclaw3dx_clawpatch_tag_criteria.c \
 	src/patches/clawpatch/fort3_user/fclaw3dx_clawpatch_difference_exceeds_th.f90 \
 	src/patches/clawpatch/fort3_user/fclaw3dx_clawpatch_value_exceeds_th.f90 \
 	src/patches/clawpatch/fort3_user/fclaw3dx_clawpatch_minmax_exceeds_th.f90 \

--- a/src/patches/clawpatch/fclaw2d_clawpatch.h.TEST.cpp
+++ b/src/patches/clawpatch/fclaw2d_clawpatch.h.TEST.cpp
@@ -29,7 +29,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <fclaw3dx_clawpatch.h>
 #include <test.hpp>
 
-TEST_CASE("fclaw2d_clawpatch_vtable_initialize stores two seperate vtables in two seperate globs")
+TEST_CASE("fclaw2d_clawpatch_vtable_initialize stores two separate vtables in two separate globs")
 {
 	fclaw2d_global_t* glob1 = fclaw2d_global_new();
 	fclaw2d_global_t* glob2 = fclaw2d_global_new();
@@ -45,7 +45,7 @@ TEST_CASE("fclaw2d_clawpatch_vtable_initialize stores two seperate vtables in tw
 	fclaw2d_global_destroy(glob2);
 }
 
-TEST_CASE("fclaw3dx_clawpatch_vtable_initialize stores two seperate vtables in two seperate globs")
+TEST_CASE("fclaw3dx_clawpatch_vtable_initialize stores two separate vtables in two separate globs")
 {
 	fclaw2d_global_t* glob1 = fclaw2d_global_new();
 	fclaw2d_global_t* glob2 = fclaw2d_global_new();

--- a/src/patches/clawpatch/fclaw2d_clawpatch_fort.h
+++ b/src/patches/clawpatch/fclaw2d_clawpatch_fort.h
@@ -230,9 +230,10 @@ typedef void (*clawpatch_fort_tag4coarsening_t)(const int* mx, const int* my,
 												int* tag_patch);
 
 /** 
- * @deprecated Checks if solution exceeds a threshold
+ * @brief Checks if solution exceeds a threshold
  */
 typedef int (*clawpatch_fort_exceeds_threshold_t)(const int *blockno,
+                                                  const int* meqn, 
                                                   const double *qval, 
                                                   const double *qmin, 
                                                   const double *qmax,
@@ -241,9 +242,12 @@ typedef int (*clawpatch_fort_exceeds_threshold_t)(const int *blockno,
                                                   const double *dy, 
                                                   const double *xc, 
                                                   const double *yc, 
+                                                  const int* ivar_threshold,
                                                   const double *tag_threshold,
                                                   const int    *init_flag,
                                                   const int    *is_ghost);
+
+
 
 /** 
  * @brief Averages a fine patch to a coarse patch
@@ -462,6 +466,27 @@ int FCLAW2D_CLAWPATCH_GET_REFINEMENT_CRITERIA();
 
 /* ------------------------------- General threshold ---------------------------------- */
 
+/** @brief Tagging criteria routine used internally by clawpatch tagging routines.*/
+#define FCLAW2D_CLAWPATCH_TAG_CRITERIA \
+                  FCLAW_F77_FUNC(fclaw2d_clawpatch_tag_criteria, \
+                                 FCLAW2D_CLAWPATCH_TAG_CRITERIA)
+
+
+int FCLAW2D_CLAWPATCH_TAG_CRITERIA(const int* blockno,
+                                        const double qval[], 
+                                        const double qmin[], 
+                                        const double qmax[],
+                                        const double quad[], 
+                                        const double *dx, 
+                                        const double *dy, 
+                                        const double *xc, 
+                                        const double *yc, 
+                                        const double *tag_threshold,
+                                        const int* init_flag,
+                                        const int* is_ghost);
+
+
+
 /** @brief C declaration of fclaw2d_clawpatch_exceeds_threshold() subroutine */
 #define FCLAW2D_CLAWPATCH_EXCEEDS_THRESHOLD \
                   FCLAW_F77_FUNC(fclaw2d_clawpatch_exceeds_threshold, \
@@ -483,6 +508,7 @@ int FCLAW2D_CLAWPATCH_GET_REFINEMENT_CRITERIA();
  * @return 1 if exceeds threshold, 0 if not, -1 if inconclusive.
  */
 int FCLAW2D_CLAWPATCH_EXCEEDS_THRESHOLD(const int *blockno,
+                                        const int* meqn, 
                                         const double *qval, 
                                         const double *qmin, 
                                         const double *qmax,
@@ -491,18 +517,22 @@ int FCLAW2D_CLAWPATCH_EXCEEDS_THRESHOLD(const int *blockno,
                                         const double *dy, 
                                         const double *xc, 
                                         const double *yc, 
+                                        const int* ivar_threshold,
                                         const double *tag_threshold,
                                         const int *init_flag,
                                         const int *is_ghost);
 
 /* ----------------------------- Value threshold -------------------------------------- */
+
+
 /** @brief C declaration of fclaw2d_clawpatch_value_exceeds_th() subroutine */
 #define FCLAW2D_CLAWPATCH_VALUE_EXCEEDS_TH \
                   FCLAW_F77_FUNC(fclaw2d_clawpatch_value_exceeds_th, \
                                  FCLAW2D_CLAWPATCH_VALUE_EXCEEDS_TH)
     
 /** @brief C declaration of fclaw2d_clawpatch_value_exceeds_th() subroutine */
-int FCLAW2D_CLAWPATCH_VALUE_EXCEEDS_TH(const int* blockno,
+int FCLAW2D_CLAWPATCH_VALUE_EXCEEDS_TH(const int* blockno, 
+                                       const int* meqn,
                                        const double *qval, 
                                        const double* qmin, 
                                        const double *qmax,
@@ -511,6 +541,7 @@ int FCLAW2D_CLAWPATCH_VALUE_EXCEEDS_TH(const int* blockno,
                                        const double *dy, 
                                        const double *xc, 
                                        const double *yc, 
+                                       const int* ivar_variable, 
                                        const double* tag_threshold,
                                        const int* init_flag,
                                        const int* is_ghost);
@@ -524,6 +555,7 @@ int FCLAW2D_CLAWPATCH_VALUE_EXCEEDS_TH(const int* blockno,
 
 /** @brief C declaration of fclaw2d_clawpatch_difference_exceeds_th() subroutine */
 int FCLAW2D_CLAWPATCH_DIFFERENCE_EXCEEDS_TH(const int    *blockno,
+                                            const int* meqn,
                                             const double *qval, 
                                             const double *qmin, 
                                             const double *qmax,
@@ -532,6 +564,7 @@ int FCLAW2D_CLAWPATCH_DIFFERENCE_EXCEEDS_TH(const int    *blockno,
                                             const double *dy, 
                                             const double *xc, 
                                             const double *yc, 
+                                            const int* ivar_threshold, 
                                             const double *tag_threshold,
                                             const int *init_flag,
                                             const int *is_ghost);
@@ -545,6 +578,7 @@ int FCLAW2D_CLAWPATCH_DIFFERENCE_EXCEEDS_TH(const int    *blockno,
 
 /** @brief C declaration of fclaw2d_clawpatch_minmax_exceeds_th() subroutine */
 int FCLAW2D_CLAWPATCH_MINMAX_EXCEEDS_TH(const int *blockno,
+                                        const int* meqn,
                                         const double *qval, 
                                         const double* qmin, 
                                         const double *qmax,
@@ -553,6 +587,7 @@ int FCLAW2D_CLAWPATCH_MINMAX_EXCEEDS_TH(const int *blockno,
                                         const double *dy, 
                                         const double *xc, 
                                         const double *yc, 
+                                        const int* ivar_threshold,
                                         const double *tag_threshold,                        
                                         const int *init_flag,
                                         const int *is_ghost);
@@ -565,6 +600,7 @@ int FCLAW2D_CLAWPATCH_MINMAX_EXCEEDS_TH(const int *blockno,
 
 /** @brief C declaration of fclaw2d_clawpatch_gradient_exceeds_th() subroutine */
 int FCLAW2D_CLAWPATCH_GRADIENT_EXCEEDS_TH(const int *blockno,
+                                          const int* meqn, 
                                           const double *qval, 
                                           const double* qmin, 
                                           const double *qmax,
@@ -573,6 +609,7 @@ int FCLAW2D_CLAWPATCH_GRADIENT_EXCEEDS_TH(const int *blockno,
                                           const double *dy, 
                                           const double *xc, 
                                           const double *yc, 
+                                          const int* ivar_threshold,
                                           const double *tag_threshold,
                                           const int *init_flag,
                                           const int *is_ghost);
@@ -586,6 +623,7 @@ int FCLAW2D_CLAWPATCH_GRADIENT_EXCEEDS_TH(const int *blockno,
 
 /** @brief C declaration of user_exceeds_th() subroutine */
 int USER_EXCEEDS_TH(const int *blockno,
+                    const int* meqn,
                     const double *qval, 
                     const double* qmin, 
                     const double *qmax,
@@ -594,6 +632,7 @@ int USER_EXCEEDS_TH(const int *blockno,
                     const double *dy, 
                     const double *xc, 
                     const double *yc, 
+                    const int* ivar_threshold,
                     const double *tag_threshold,
                     const int *init_flag,
                     const int *is_ghost);

--- a/src/patches/clawpatch/fclaw2d_clawpatch_fort.h.TEST.cpp
+++ b/src/patches/clawpatch/fclaw2d_clawpatch_fort.h.TEST.cpp
@@ -40,20 +40,22 @@ namespace{
     struct exceeds_test_parameters
     {
         int *blockno          = (int*)    1;
-        double *qval          = (double*) 2;
-        double* qmin          = (double*) 3;
-        double *qmax          = (double*) 4;
-        double *quad          = (double*) 5;
-        double *dx            = (double*) 6;
-        double *dy            = (double*) 7;
-        double *dz            = (double*) 8;
-        double *xc            = (double*) 9;
-        double *yc            = (double*)10;
-        double *zc            = (double*)11;
-        double *tag_threshold = (double*)12;
-        int *init_flag        = (int*)   13;
-        int *is_ghost         = (int*)   14;
-        int return_value      =          15;
+        int* meqn             = (int*)    2; 
+        double *qval          = (double*) 3;
+        double* qmin          = (double*) 4;
+        double *qmax          = (double*) 5;
+        double *quad          = (double*) 6;
+        double *dx            = (double*) 7;
+        double *dy            = (double*) 8;
+        double *dz            = (double*) 9;
+        double *xc            = (double*)10;
+        double *yc            = (double*)11;
+        double *zc            = (double*)12;
+        int* ivar_threshold   = (int*)   13; 
+        double *tag_threshold = (double*)14;
+        int *init_flag        = (int*)   15;
+        int *is_ghost         = (int*)   16;
+        int return_value      =          17;
     };
 
     exceeds_test_parameters global_exceeds_test_parameters;
@@ -70,6 +72,7 @@ TEST_CASE("FCLAW2D_CLAWPATCH_EXCEEDS_THRESHOLD calls user function")
 
     fclaw2d_clawpatch_vt(glob)->fort_user_exceeds_threshold = 
         [](const int *blockno,
+           const int* meqn,
            const double *qval, 
            const double* qmin, 
            const double *qmax,
@@ -78,12 +81,14 @@ TEST_CASE("FCLAW2D_CLAWPATCH_EXCEEDS_THRESHOLD calls user function")
            const double *dy, 
            const double *xc, 
            const double *yc, 
+           const int* ivar_threshold, 
            const double *tag_threshold,
            const int *init_flag,
            const int *is_ghost)
         {
             exceeds_test_parameters& params = global_exceeds_test_parameters;
             CHECK_EQ(blockno, params.blockno);
+            //CHECK_EQ(meqn, params.meqn);  // This is changed inside function
             CHECK_EQ(qval, params.qval);
             CHECK_EQ(qmin, params.qmin);
             CHECK_EQ(qmax, params.qmax);
@@ -92,6 +97,7 @@ TEST_CASE("FCLAW2D_CLAWPATCH_EXCEEDS_THRESHOLD calls user function")
             CHECK_EQ(dy, params.dy);
             CHECK_EQ(xc, params.xc);
             CHECK_EQ(yc, params.yc);
+            // CHECK_EQ(ivar_threshold, params.ivar_threshold);    //Will change
             CHECK_EQ(tag_threshold, params.tag_threshold);
             CHECK_EQ(init_flag, params.init_flag);
             CHECK_EQ(is_ghost, params.is_ghost);
@@ -103,7 +109,7 @@ TEST_CASE("FCLAW2D_CLAWPATCH_EXCEEDS_THRESHOLD calls user function")
     fclaw2d_clawpatch_options_store(glob, &opts);
 
     fclaw2d_global_set_global(glob);
-    int ret = FCLAW2D_CLAWPATCH_EXCEEDS_THRESHOLD(params.blockno,
+    int ret = FCLAW2D_CLAWPATCH_TAG_CRITERIA(params.blockno,
                                                   params.qval,
                                                   params.qmin,
                                                   params.qmax,
@@ -133,6 +139,7 @@ TEST_CASE("FCLAW3DX_CLAWPATCH_EXCEEDS_THRESHOLD calls user function")
 
     fclaw3dx_clawpatch_vt(glob)->fort_user_exceeds_threshold = 
         [](const int *blockno,
+           const int* meqn,
            const double *qval, 
            const double* qmin, 
            const double *qmax,
@@ -143,12 +150,14 @@ TEST_CASE("FCLAW3DX_CLAWPATCH_EXCEEDS_THRESHOLD calls user function")
            const double *xc, 
            const double *yc, 
            const double *zc, 
+           const int* ivar_threshold, 
            const double *tag_threshold,
            const int *init_flag,
            const int *is_ghost)
         {
             exceeds_test_parameters& params = global_exceeds_test_parameters;
             CHECK_EQ(blockno, params.blockno);
+            //CHECK_EQ(meqn, params.meqn);
             CHECK_EQ(qval, params.qval);
             CHECK_EQ(qmin, params.qmin);
             CHECK_EQ(qmax, params.qmax);
@@ -159,7 +168,8 @@ TEST_CASE("FCLAW3DX_CLAWPATCH_EXCEEDS_THRESHOLD calls user function")
             CHECK_EQ(xc, params.xc);
             CHECK_EQ(yc, params.yc);
             CHECK_EQ(zc, params.zc);
-            CHECK_EQ(tag_threshold, params.tag_threshold);
+            //CHECK_EQ(ivar_threshold, params.ivar_threshold); 
+            CHECK_EQ(tag_threshold, params.tag_threshold); 
             CHECK_EQ(init_flag, params.init_flag);
             CHECK_EQ(is_ghost, params.is_ghost);
             return params.return_value;
@@ -170,7 +180,7 @@ TEST_CASE("FCLAW3DX_CLAWPATCH_EXCEEDS_THRESHOLD calls user function")
     fclaw3dx_clawpatch_options_store(glob, &opts);
 
     fclaw2d_global_set_global(glob);
-    int ret = FCLAW3DX_CLAWPATCH_EXCEEDS_THRESHOLD(params.blockno,
+    int ret = FCLAW3DX_CLAWPATCH_TAG_CRITERIA(params.blockno,
                                                    params.qval,
                                                    params.qmin,
                                                    params.qmax,

--- a/src/patches/clawpatch/fclaw2d_clawpatch_options.c
+++ b/src/patches/clawpatch/fclaw2d_clawpatch_options.c
@@ -99,6 +99,11 @@ clawpatch_register(fclaw2d_clawpatch_options_t *clawpatch_options,
                              &clawpatch_options->refinement_criteria, "minmax",
                              kv, "Refinement criteria [minmax]");
 
+    sc_options_add_int (opt, 0, "threshold-variable",
+                        &clawpatch_options->threshold_variable,
+                        1, "Index of variable used for tagging in [1,meqn] [1]");
+
+
     clawpatch_options->is_registered = 1;
 
     return NULL;

--- a/src/patches/clawpatch/fclaw2d_clawpatch_options.h
+++ b/src/patches/clawpatch/fclaw2d_clawpatch_options.h
@@ -78,6 +78,7 @@ struct fclaw2d_clawpatch_options
 
     int refinement_criteria; /**< The refinement criteria */
     sc_keyvalue_t *kv_refinement_criteria; /**< The refinement criteria */
+    int threshold_variable;
 
     /* Advanced options */
     int interp_stencil_width; /**< The width of the interpolation stencil */

--- a/src/patches/clawpatch/fclaw3dx_clawpatch_fort.h
+++ b/src/patches/clawpatch/fclaw3dx_clawpatch_fort.h
@@ -280,6 +280,7 @@ typedef void (*fclaw3dx_clawpatch_fort_tag4coarsening_t)(const int* mx,
  * @deprecated Checks if solution exceeds a threshold
  */
 typedef int (*fclaw3dx_clawpatch_fort_exceeds_threshold_t)(const int *blockno,
+                                                           const int* meqn,
                                                            const double *qval, 
                                                            const double *qmin, 
                                                            const double *qmax,
@@ -290,6 +291,7 @@ typedef int (*fclaw3dx_clawpatch_fort_exceeds_threshold_t)(const int *blockno,
                                                            const double *xc, 
                                                            const double *yc, 
                                                            const double *zc,
+                                                           const int* ivar_variable,
                                                            const double *tag_threshold,
                                                            const int *init_flag,
                                                            const int *is_ghost);
@@ -569,6 +571,27 @@ typedef void (*fclaw3dx_clawpatch_fort_norm_t)(int* blockno,
 
 /** @} */
 
+/** 
+ * @brief Checks if solution exceeds a threshold
+ */
+typedef int (*fclaw3dx_fort_exceeds_threshold_t)(const int *blockno,
+                                                 const int* meqn, 
+                                                 const double *qval, 
+                                                 const double *qmin, 
+                                                 const double *qmax,
+                                                 const double quad[], 
+                                                 const double *dx, 
+                                                 const double *dy, 
+                                                 const double *dz,
+                                                 const double *xc, 
+                                                 const double *yc,
+                                                 const double *zc, 
+                                                 const int* ivar_threshold,
+                                                 const double *tag_threshold,
+                                                 const int    *init_flag,
+                                                 const int    *is_ghost);
+
+
 /** @{ @name Fortran Headers *//*-------------------------------------------------------*/
 
 /** @brief Fortran subroutine name */
@@ -580,6 +603,41 @@ int FCLAW3DX_CLAWPATCH_GET_REFINEMENT_CRITERIA();
 
 
 /* ------------------------------- General threshold ---------------------------------- */
+
+/** Fortran subroutine name */
+#define FCLAW3DX_CLAWPATCH_TAG_CRITERIA \
+                  FCLAW_F77_FUNC(fclaw3dx_clawpatch_tag_criteria, \
+                                  FCLAW3DX_CLAWPATCH_TAG_CRITERIA)
+
+/**
+ * @brief Check if the refinment threshold is exceeded
+ *
+ * @param[in] blockno the block number
+ * @param[in] qval the 
+ * @param[in] qmin the minimum q value
+ * @param[in] qmax the maximum q value
+ * @param[in] quad the value and adjacent values of q
+ * @param[in] dx, dy the spacing in the x and y directions
+ * @param[in] xc, yc the coordinate of the cell
+ * @param[in] threshold the threshold
+ * @param[in] init_flag true if in init stage
+ * @param[in] is_ghost true if cell is a ghost cell
+ * @return 1 if exceeds threshold, 0 if not, -1 if inconclusive.
+ */
+int FCLAW3DX_CLAWPATCH_TAG_CRITERIA(const int *blockno,
+                                        const double *qval, 
+                                        const double *qmin, 
+                                        const double *qmax,
+                                        const double quad[], 
+                                        const double *dx, 
+                                        const double *dy, 
+                                        const double *dz,
+                                        const double *xc, 
+                                        const double *yc,
+                                        const double *zc, 
+                                        const double *tag_threshold,
+                                        const int *init_flag,
+                                        const int *is_ghost);
 
 /** Fortran subroutine name */
 #define FCLAW3DX_CLAWPATCH_EXCEEDS_THRESHOLD \
@@ -602,6 +660,7 @@ int FCLAW3DX_CLAWPATCH_GET_REFINEMENT_CRITERIA();
  * @return 1 if exceeds threshold, 0 if not, -1 if inconclusive.
  */
 int FCLAW3DX_CLAWPATCH_EXCEEDS_THRESHOLD(const int *blockno,
+                                         const int* meqn, 
                                         const double *qval, 
                                         const double *qmin, 
                                         const double *qmax,
@@ -612,6 +671,7 @@ int FCLAW3DX_CLAWPATCH_EXCEEDS_THRESHOLD(const int *blockno,
                                         const double *xc, 
                                         const double *yc,
                                         const double *zc, 
+                                        const int* ivar_variable,
                                         const double *tag_threshold,
                                         const int *init_flag,
                                         const int *is_ghost);
@@ -625,6 +685,7 @@ int FCLAW3DX_CLAWPATCH_EXCEEDS_THRESHOLD(const int *blockno,
     
 /** @brief C declaration of fclaw3dx_clawpatch_value_exceeds_th() subroutine */
 int FCLAW3DX_CLAWPATCH_VALUE_EXCEEDS_TH(const int* blockno,
+                                        const int* meqn, 
                                        const double *qval, 
                                        const double* qmin, 
                                        const double *qmax,
@@ -635,6 +696,7 @@ int FCLAW3DX_CLAWPATCH_VALUE_EXCEEDS_TH(const int* blockno,
                                        const double *xc, 
                                        const double *yc,
                                        const double *zc, 
+                                       const int* ivar_variable,
                                        const double* tag_threshold,
                                        const int* init_flag,
                                        const int* is_ghost);
@@ -648,6 +710,7 @@ int FCLAW3DX_CLAWPATCH_VALUE_EXCEEDS_TH(const int* blockno,
 
 /** @brief C declaration of fclaw3dx_clawpatch_difference_exceeds_th() subroutine */
 int FCLAW3DX_CLAWPATCH_DIFFERENCE_EXCEEDS_TH(const int *blockno,
+                                             const int *meqn,
                                             const double *qval, 
                                             const double *qmin, 
                                             const double *qmax,
@@ -658,6 +721,7 @@ int FCLAW3DX_CLAWPATCH_DIFFERENCE_EXCEEDS_TH(const int *blockno,
                                             const double *xc, 
                                             const double *yc,
                                             const double *zc, 
+                                            const int* ivar_variable, 
                                             const double *tag_threshold,
                                             const int *init_flag,
                                             const int *is_ghost);
@@ -671,6 +735,7 @@ int FCLAW3DX_CLAWPATCH_DIFFERENCE_EXCEEDS_TH(const int *blockno,
 
 /** @brief C declaration of fclaw3dx_clawpatch_minmax_exceeds_th() subroutine */
 int FCLAW3DX_CLAWPATCH_MINMAX_EXCEEDS_TH(const int *blockno,
+                                         const int* meqn,
                                          const double *qval, 
                                          const double* qmin, 
                                          const double *qmax,
@@ -681,6 +746,7 @@ int FCLAW3DX_CLAWPATCH_MINMAX_EXCEEDS_TH(const int *blockno,
                                          const double *xc, 
                                          const double *yc,
                                          const double *zc, 
+                                         const int* ivar_variable,
                                          const double *tag_threshold,                        
                                          const int *init_flag,
                                          const int *is_ghost);
@@ -693,6 +759,7 @@ int FCLAW3DX_CLAWPATCH_MINMAX_EXCEEDS_TH(const int *blockno,
 
 /** @brief C declaration of fclaw3dx_clawpatch_gradient_exceeds_th() subroutine */
 int FCLAW3DX_CLAWPATCH_GRADIENT_EXCEEDS_TH(const int *blockno,
+                                           const int* meqn,
                                            const double *qval, 
                                            const double* qmin, 
                                            const double *qmax,
@@ -703,6 +770,7 @@ int FCLAW3DX_CLAWPATCH_GRADIENT_EXCEEDS_TH(const int *blockno,
                                            const double *xc, 
                                            const double *yc,
                                            const double *zc, 
+                                           const int* ivar_variable,
                                            const double *tag_threshold,
                                            const int *init_flag,
                                            const int *is_ghost);
@@ -716,6 +784,7 @@ int FCLAW3DX_CLAWPATCH_GRADIENT_EXCEEDS_TH(const int *blockno,
 
 /** @brief C declaration of user_exceeds_th() subroutine */
 int FCLAW3DX_USER_EXCEEDS_TH(const int *blockno,
+                             const int* meqn,
                              const double *qval, 
                              const double* qmin, 
                              const double *qmax,
@@ -726,6 +795,7 @@ int FCLAW3DX_USER_EXCEEDS_TH(const int *blockno,
                              const double *xc, 
                              const double *yc,
                              const double *zc, 
+                             const int* ivar_variable,
                              const double *tag_threshold,
                              const int *init_flag,
                              const int *is_ghost);

--- a/src/patches/clawpatch/fclaw3dx_clawpatch_options.h
+++ b/src/patches/clawpatch/fclaw3dx_clawpatch_options.h
@@ -79,6 +79,7 @@ struct fclaw3dx_clawpatch_options
 
     int refinement_criteria; /**< The refinement criteria */
     sc_keyvalue_t *kv_refinement_criteria; /**< The refinement criteria */
+    int threshold_variable;
 
     /* Advanced options */
     int interp_stencil_width; /**< The width of the interpolation stencil */

--- a/src/patches/clawpatch/fort3_4.6/fclaw3dx_clawpatch46_tag4coarsening.f90
+++ b/src/patches/clawpatch/fort3_4.6/fclaw3dx_clawpatch46_tag4coarsening.f90
@@ -1,6 +1,6 @@
 subroutine fclaw3dx_clawpatch46_fort_tag4coarsening(mx,my,mz, mbc,meqn, & 
-           xlower,ylower,zlower,dx,dy, dz, blockno, q0, q1, q2, q3, & 
-          coarsen_threshold, initflag, tag_patch)
+           xlower,ylower,zlower,dx,dy, dz, blockno, q0, q1, q2, q3, &
+           coarsen_threshold, initflag, tag_patch)
     implicit none
 
     integer :: mx,my, mz, mbc, meqn, tag_patch, initflag
@@ -12,8 +12,9 @@ subroutine fclaw3dx_clawpatch46_fort_tag4coarsening(mx,my,mz, mbc,meqn, &
     double precision :: q2(1-mbc:mx+mbc,1-mbc:my+mbc,1-mbc:mz+mbc,meqn)
     double precision :: q3(1-mbc:mx+mbc,1-mbc:my+mbc,1-mbc:mz+mbc,meqn)
 
+
     integer :: mq
-    double precision :: qmin, qmax
+    double precision :: qmin(meqn), qmax(meqn)
 
     !! # Don't coarsen when initializing the mesh
     if (initflag .ne. 0) then
@@ -24,46 +25,49 @@ subroutine fclaw3dx_clawpatch46_fort_tag4coarsening(mx,my,mz, mbc,meqn, &
     !! # Assume that we will coarsen a family unless we find a grid
     !! # that doesn't pass the coarsening test.
     tag_patch = 1
-    mq = 1
-    qmin = q0(1,1,1,mq)
-    qmax = q0(1,1,1,mq)
+    do mq = 1,meqn
+        qmin(mq) = q0(1,1,1,mq)
+        qmax(mq) = q0(1,1,1,mq)
+    end do
 
     call fclaw3dx_clawpatch46_test_refine3(blockno,mx,my,mz,mbc,meqn, & 
-           mq,q0,qmin,qmax, dx,dy,dz,xlower(0), ylower(0),zlower, &
+           q0,qmin,qmax, dx,dy,dz,xlower(0), ylower(0),zlower,  &
            coarsen_threshold,initflag, tag_patch)
     if (tag_patch == 0) return
 
     call fclaw3dx_clawpatch46_test_refine3(blockno,mx,my,mz,mbc,meqn, & 
-           mq,q1,qmin,qmax,dx,dy,dz,xlower(1), ylower(1),  zlower, & 
+           q1,qmin,qmax,dx,dy,dz,xlower(1), ylower(1),  zlower, & 
            coarsen_threshold,initflag, tag_patch)
     if (tag_patch == 0) return
 
     call fclaw3dx_clawpatch46_test_refine3(blockno,mx,my,mz,mbc,meqn, & 
-           mq,q2,qmin,qmax,dx,dy,dz,xlower(2), ylower(2),zlower, &
+           q2,qmin,qmax,dx,dy,dz,xlower(2), ylower(2),zlower,  &
            coarsen_threshold,initflag, tag_patch)
     if (tag_patch == 0) return
 
     call fclaw3dx_clawpatch46_test_refine3(blockno,mx,my,mz,mbc,meqn, &
-           mq,q3,qmin,qmax,dx,dy,dz,xlower(3), ylower(3),zlower, &
+           q3,qmin,qmax,dx,dy,dz,xlower(3), ylower(3),zlower, &
            coarsen_threshold,initflag, tag_patch)
 
 end subroutine fclaw3dx_clawpatch46_fort_tag4coarsening
 
 subroutine fclaw3dx_clawpatch46_test_refine3(blockno,mx,my,mz,mbc, & 
-      meqn,mq,q, qmin,qmax,dx,dy,dz,xlower,ylower,zlower, &
+      meqn,q, qmin,qmax,dx,dy,dz,xlower,ylower,zlower, &
       coarsen_threshold,init_flag,tag_patch)
 
     implicit none
-    integer :: mx,my,mz,mbc,meqn,mq,tag_patch, init_flag, blockno
+    integer :: mx,my,mz,mbc,meqn,tag_patch, init_flag, blockno
     double precision :: coarsen_threshold
-    double precision :: qmin,qmax, dx, dy, dz, xlower, ylower,zlower
+    double precision :: dx, dy, dz, xlower, ylower,zlower
     double precision :: q(1-mbc:mx+mbc,1-mbc:my+mbc,1-mbc:mz+mbc,meqn)
+    double precision :: qmin(meqn),qmax(meqn)
 
-    double precision :: xc,yc,zc, quad(-1:1,-1:1,-1:1),qval
+    !! Dummy variables
+    double precision :: xc,yc,zc, quad(-1:1,-1:1,-1:1,meqn),qval(meqn)
 
-    integer i,j, k, ii, jj,kk
+    integer i,j, k, ii, jj,kk, mq
 
-    integer :: exceeds_th, fclaw3dx_clawpatch_exceeds_threshold
+    integer :: exceeds_th, fclaw3dx_clawpatch_tag_criteria
     logical(kind=4) :: is_ghost, clawpatch3_is_ghost
 
 
@@ -73,20 +77,24 @@ subroutine fclaw3dx_clawpatch46_test_refine3(blockno,mx,my,mz,mbc, &
                 xc = xlower + (i-0.5)*dx
                 yc = ylower + (j-0.5)*dy
                 zc = zlower + (k-0.5)*dz
-                qmin = min(q(i,j,k,mq),qmin)
-                qmax = max(q(i,j,k,mq),qmax)
-                qval = q(i,j,k,mq)
+                do mq = 1,meqn
+                    qval(mq) = q(i,j,k,mq)
+                    qmin(mq) = min(q(i,j,k,mq),qmin(mq))
+                    qmax(mq) = max(q(i,j,k,mq),qmax(mq))
+                end do
                 is_ghost = clawpatch3_is_ghost(i,j,k,mx,my,mz)
                 if (.not. is_ghost) then
                     do ii = -1,1               
                         do jj = -1,1
                             do kk = -1,1
-                                quad(ii,jj,kk) = q(i+ii,j+jj,k+kk,mq)
+                                do mq = 1,meqn
+                                    quad(ii,jj,kk,mq) = q(i+ii,j+jj,k+kk,mq)
+                                end do
                             end do
                         end do
                     end do
                 endif
-                exceeds_th = fclaw3dx_clawpatch_exceeds_threshold( & 
+                exceeds_th = fclaw3dx_clawpatch_tag_criteria( & 
                     blockno, qval,qmin,qmax,quad, dx,dy,dz,xc,yc,zc,  &
                     coarsen_threshold, init_flag, is_ghost)
             

--- a/src/patches/clawpatch/fort3_4.6/fclaw3dx_clawpatch46_tag4refinement.f90
+++ b/src/patches/clawpatch/fort3_4.6/fclaw3dx_clawpatch46_tag4refinement.f90
@@ -4,7 +4,7 @@ subroutine fclaw3dx_clawpatch46_fort_tag4refinement(mx,my,mz,mbc, &
     implicit none
 
     integer :: mx,my, mz, mbc, meqn, tag_patch, init_flag
-    integer :: blockno, ivar_threshold
+    integer :: blockno
     double precision :: xlower, ylower, zlower, dx, dy, dz
     double precision :: tag_threshold
     double precision :: q(1-mbc:mx+mbc,1-mbc:my+mbc,1-mbc:mz+mbc,meqn)

--- a/src/patches/clawpatch/fort3_4.6/fclaw3dx_clawpatch46_tag4refinement.f90
+++ b/src/patches/clawpatch/fort3_4.6/fclaw3dx_clawpatch46_tag4refinement.f90
@@ -4,17 +4,17 @@ subroutine fclaw3dx_clawpatch46_fort_tag4refinement(mx,my,mz,mbc, &
     implicit none
 
     integer :: mx,my, mz, mbc, meqn, tag_patch, init_flag
-    integer :: blockno
+    integer :: blockno, ivar_threshold
     double precision :: xlower, ylower, zlower, dx, dy, dz
     double precision :: tag_threshold
     double precision :: q(1-mbc:mx+mbc,1-mbc:my+mbc,1-mbc:mz+mbc,meqn)
 
     integer :: i,j,k, mq
-    double precision :: qmin, qmax
+    double precision :: qmin(meqn), qmax(meqn)
 
-    integer :: exceeds_th, fclaw3dx_clawpatch_exceeds_threshold
+    integer :: exceeds_th, fclaw3dx_clawpatch_tag_criteria
     integer :: ii,jj,kk
-    double precision :: xc,yc,zc, quad(-1:1,-1:1,-1:1), qval
+    double precision :: xc,yc,zc, quad(-1:1,-1:1,-1:1,meqn), qval(meqn)
 
     logical(kind=4) :: is_ghost, clawpatch3_is_ghost
 
@@ -25,29 +25,34 @@ subroutine fclaw3dx_clawpatch46_fort_tag4refinement(mx,my,mz,mbc, &
     !! # Users can modify this by creating a local copy of this routine
     !! # and the corresponding tag4coarsening routine.
 
-    mq = 1
-    qmin = q(1,1,1,mq)
-    qmax = q(1,1,1,mq)
+    do mq = 1,meqn
+        qmin(mq) = q(1,1,1,mq)
+        qmax(mq) = q(1,1,1,mq)
+    end do
     do k = 1-mbc,mz+mbc
         do j = 1-mbc,my+mbc
             do i = 1-mbc,mx+mbc
                 xc = xlower + (i-0.5)*dx
-                yc = ylower + (j-0.5)*dy   
-                zc = zlower + (k-0.5)*dz             
-                qmin = min(qmin,q(i,j,k,mq))
-                qmax = max(qmax,q(i,j,k,mq))
-                qval = q(i,j,k,mq)
+                yc = ylower + (j-0.5)*dy 
+                zc = zlower + (k-0.5)*dz
+                do mq = 1,meqn
+                    qval(mq) = q(i,j,k,mq)
+                    qmin(mq) = min(qmin(mq),q(i,j,k,mq))                    
+                    qmax(mq) = max(qmax(mq),q(i,j,k,mq))
+                end do
                 is_ghost = clawpatch3_is_ghost(i,j,k, mx,my,mz)
                 if (.not. is_ghost) then
                     do jj = -1,1
                         do ii = -1,1
                             do kk = -1,1
-                                quad(ii,jj,kk) = q(i+ii,j+jj,k+kk,mq)
+                                do mq = 1,meqn
+                                    quad(ii,jj,kk,mq) = q(i+ii,j+jj,k+kk,mq)
+                                end do
                             end do
                         end do
                     end do
                 endif
-                exceeds_th = fclaw3dx_clawpatch_exceeds_threshold( & 
+                exceeds_th = fclaw3dx_clawpatch_tag_criteria(& 
                       blockno, qval,qmin,qmax,quad, dx,dy,dz,xc,yc,zc, & 
                       tag_threshold,init_flag, is_ghost)
                 !! # -1 : Not conclusive (possibly ghost cell); don't tag for refinement

--- a/src/patches/clawpatch/fort3_user/fclaw3dx_clawpatch_difference_exceeds_th.f90
+++ b/src/patches/clawpatch/fort3_user/fclaw3dx_clawpatch_difference_exceeds_th.f90
@@ -16,20 +16,22 @@
 !! @param[in] is_ghost true if cell is a ghost cell
 !! @return 1 if exceeds threshold, 0 if not, -1 if inconclusive.
 !  --------------------------------------------------------------
-integer function fclaw3dx_clawpatch_difference_exceeds_th(blockno,& 
+integer function fclaw3dx_clawpatch_difference_exceeds_th(blockno, meqn, & 
                                      qval,qmin,qmax,quad, & 
-                                     dx,dy,dz,xc,yc,zc,threshold,&
+                                     dx,dy,dz,xc,yc,zc,ivar_threshold, threshold,&
                                      init_flag, is_ghost)
     implicit none
     
-    double precision :: qval,qmin,qmax,threshold
-    double precision :: quad(-1:1,-1:1,-1:1)
+    integer :: meqn, ivar_threshold
+    double precision :: qval(meqn),qmin(meqn),qmax(meqn),threshold
+    double precision :: quad(-1:1,-1:1,-1:1,meqn)
     double precision :: dx,dy, dz, xc, yc, zc
     integer :: blockno, init_flag
     logical(kind=4) :: is_ghost
 
     double precision :: dqx, dqy, dqz, dq
     integer :: refine
+    integer :: mq
 
     if (is_ghost) then
 !!      # quad may have uninitialized values;  test inconclusive
@@ -37,9 +39,11 @@ integer function fclaw3dx_clawpatch_difference_exceeds_th(blockno,&
         return
     endif
 
-    dqx = abs(quad(1,0,0) - quad(-1,0,0))
-    dqy = abs(quad(0,1,0) - quad(0,-1,0))
-    dqz = abs(quad(0,0,1) - quad(0,0,-1))
+    mq = ivar_threshold
+
+    dqx = abs(quad(1,0,0,mq) - quad(-1,0,0,mq))
+    dqy = abs(quad(0,1,0,mq) - quad(0,-1,0,mq))
+    dqz = abs(quad(0,0,1,mq) - quad(0,0,-1,mq))
     dq  = max(dqx, dqy, dqz)
 
     refine = 0

--- a/src/patches/clawpatch/fort3_user/fclaw3dx_clawpatch_gradient_exceeds_th.f90
+++ b/src/patches/clawpatch/fort3_user/fclaw3dx_clawpatch_gradient_exceeds_th.f90
@@ -16,14 +16,15 @@
 !! @param[in] is_ghost true if cell is a ghost cell
 !! @return 1 if exceeds threshold, 0 if not, -1 if inconclusive.
 !  --------------------------------------------------------------
-integer function fclaw3dx_clawpatch_gradient_exceeds_th(blockno,& 
+integer function fclaw3dx_clawpatch_gradient_exceeds_th(blockno, meqn, & 
                                      qval,qmin,qmax,quad, & 
-                                     dx,dy,dz, xc,yc,zc, threshold, &
+                                     dx,dy,dz, xc,yc,zc, ivar_threshold, threshold, &
                                      init_flag, is_ghost)
     implicit none
     
-    double precision :: qval,qmin,qmax,threshold
-    double precision :: quad(-1:1,-1:1,-1:1)
+    integer :: meqn, ivar_threshold
+    double precision :: qval(meqn),qmin(meqn),qmax(meqn),threshold
+    double precision :: quad(-1:1,-1:1,-1:1,meqn)
     double precision :: dx,dy, dz, xc, yc, zc
     integer :: blockno, init_flag
     logical(kind=4) :: is_ghost
@@ -34,6 +35,10 @@ integer function fclaw3dx_clawpatch_gradient_exceeds_th(blockno,&
 
     double precision :: clawpatch_gradient_dot3
     integer :: refine
+    integer :: mq
+
+    mq = ivar_threshold
+
 
     if (is_ghost) then
 !!      # quad may have uninitialized values.  Test is inconclusive
@@ -45,9 +50,10 @@ integer function fclaw3dx_clawpatch_gradient_exceeds_th(blockno,&
     dy2 = 2*dy
     dz2 = 2*dz
 
-    dqx = (quad(1,0,0) - quad(-1,0,0))/dx2
-    dqy = (quad(0,1,0) - quad(0,-1,0))/dy2
-    dqz = (quad(0,0,1) - quad(0,0,-1))/dz2
+    !! Only compute gradients for non-mapped grids
+    dqx = (quad(1,0,0,mq) - quad(-1,0,0,mq))/dx2
+    dqy = (quad(0,1,0,mq) - quad(0,-1,0,mq))/dy2
+    dqz = (quad(0,0,1,mq) - quad(0,0,-1,mq))/dz2
 
     refine = 0
     grad(1) = dqx

--- a/src/patches/clawpatch/fort3_user/fclaw3dx_clawpatch_minmax_exceeds_th.f90
+++ b/src/patches/clawpatch/fort3_user/fclaw3dx_clawpatch_minmax_exceeds_th.f90
@@ -17,23 +17,28 @@
 !! @param[in] is_ghost true if cell is a ghost cell
 !! @return 1 if exceeds threshold, 0 if not, -1 if inconclusive.
 !  --------------------------------------------------------------
-integer function fclaw3dx_clawpatch_minmax_exceeds_th(blockno,& 
+integer function fclaw3dx_clawpatch_minmax_exceeds_th(blockno, meqn, & 
                                      qval,qmin,qmax,quad, & 
-                                     dx,dy,dz, xc,yc,zc, threshold, &
-                                     init_flag, is_ghost)
+                                     dx,dy,dz, xc,yc,zc, ivar_threshold, & 
+                                     threshold, init_flag, is_ghost)
     implicit none
     
-    double precision :: qval,qmin,qmax,threshold
-    double precision :: quad(-1:1,-1:1,-1:1)
+    integer :: meqn, ivar_threshold
+    double precision :: qval(meqn),qmin(meqn),qmax(meqn),threshold
+    double precision :: quad(-1:1,-1:1,-1:1,meqn)
     double precision :: dx,dy, dz, xc, yc, zc
     integer :: blockno, init_flag
     logical(kind=4) :: is_ghost
 
+    integer :: mq
+
     integer :: refine
+
+    mq = ivar_threshold
 
     refine = 0
 
-    if (qmax-qmin .gt. threshold) then
+    if (qmax(mq)-qmin(mq) .gt. threshold) then
         refine = 1
     endif
 

--- a/src/patches/clawpatch/fort3_user/fclaw3dx_clawpatch_tag_criteria.c
+++ b/src/patches/clawpatch/fort3_user/fclaw3dx_clawpatch_tag_criteria.c
@@ -5,12 +5,10 @@
 #endif
 
 #ifndef PATCH_DIM
-#define PATCH_DIM 2
+#define PATCH_DIM 3
 #endif
 
-
-#include<fclaw2d_global.h>
-
+#if 0
 #if REFINE_DIM == 2 && PATCH_DIM == 2
 
 #include "../fclaw2d_clawpatch.h"
@@ -29,51 +27,72 @@
 #include <_fclaw2d_to_fclaw3dx.h>
 
 #endif
+#endif
+
+#include <fclaw2d_global.h>
+
+#include "../fclaw3dx_clawpatch.h"
+
+#include "../fclaw3dx_clawpatch_options.h"
+// #include "../fclaw2d_clawpatch_fort.h"
+#include "../fclaw3dx_clawpatch_fort.h"
+
+
 
 
 /* ------------------------------------------------------------------------------------ */
 
-int FCLAW2D_CLAWPATCH_EXCEEDS_THRESHOLD(const int* blockno,
+int FCLAW3DX_CLAWPATCH_TAG_CRITERIA(const int* blockno,
                                         const double *qval, 
                                         const double* qmin, 
                                         const double *qmax,
                                         const double quad[], 
                                         const double *dx, 
                                         const double *dy, 
+                                        const double *dz, 
                                         const double *xc, 
                                         const double *yc, 
+                                        const double *zc, 
                                         const double *tag_threshold,
                                         const int* init_flag,
                                         const int* is_ghost)
 {
     struct fclaw2d_global* glob = fclaw2d_global_get_global();
-    fclaw2d_clawpatch_vtable_t* clawpatch_vt = fclaw2d_clawpatch_vt(glob);
-    clawpatch_fort_exceeds_threshold_t user_exceeds_threshold = 
+    fclaw3dx_clawpatch_vtable_t* clawpatch_vt = fclaw3dx_clawpatch_vt(glob);
+    fclaw3dx_clawpatch_fort_exceeds_threshold_t user_exceeds_threshold = 
                                 clawpatch_vt->fort_user_exceeds_threshold;
 
+    fclaw3dx_clawpatch_options_t *clawpatch_opt = fclaw3dx_clawpatch_get_options(glob);    
+    int meqn_val = clawpatch_opt->meqn, *meqn = &meqn_val;
+    int ivar_val = clawpatch_opt->threshold_variable, *ivar_variable=&ivar_val;
+
     int exceeds_th = 1;
-    int refinement_criteria = fclaw2d_clawpatch_get_options(glob)->refinement_criteria;
+    int refinement_criteria = fclaw3dx_clawpatch_get_options(glob)->refinement_criteria;
     switch(refinement_criteria)
     {
         case FCLAW_REFINE_CRITERIA_VALUE:
-            exceeds_th = FCLAW2D_CLAWPATCH_VALUE_EXCEEDS_TH(blockno,
-                    qval,qmin,qmax,quad, dx, dy, xc, yc, 
+            exceeds_th = FCLAW3DX_CLAWPATCH_VALUE_EXCEEDS_TH(blockno,meqn,
+                    qval,qmin,qmax,quad, dx, dy, dz, xc, yc, zc, 
+                    ivar_variable,
                     tag_threshold,init_flag,is_ghost);
             break;
         case FCLAW_REFINE_CRITERIA_DIFFERENCE:
-            exceeds_th = FCLAW2D_CLAWPATCH_DIFFERENCE_EXCEEDS_TH(blockno,
-                    qval,qmin,qmax,quad, dx, dy, xc, yc, 
+            exceeds_th = FCLAW3DX_CLAWPATCH_DIFFERENCE_EXCEEDS_TH(blockno,meqn,
+                    qval,qmin,qmax,quad, dx, dy, dz, xc, yc, zc, 
+                    ivar_variable,
                     tag_threshold,init_flag,is_ghost);
             break;
         case FCLAW_REFINE_CRITERIA_MINMAX:
-            exceeds_th = FCLAW2D_CLAWPATCH_MINMAX_EXCEEDS_TH(blockno,
-                    qval,qmin,qmax,quad, dx, dy, xc, yc, 
+            exceeds_th = FCLAW3DX_CLAWPATCH_MINMAX_EXCEEDS_TH(blockno,meqn,
+                    qval,qmin,qmax,quad, dx, dy, dz, xc, yc, zc, 
+                    ivar_variable,
                     tag_threshold,init_flag,is_ghost);
 
             break;
         case FCLAW_REFINE_CRITERIA_GRADIENT:
-            exceeds_th = FCLAW2D_CLAWPATCH_GRADIENT_EXCEEDS_TH(blockno,
-                    qval,qmin,qmax,quad, dx, dy, xc, yc,     
+            exceeds_th = FCLAW3DX_CLAWPATCH_GRADIENT_EXCEEDS_TH(blockno,meqn,
+                    qval,qmin,qmax,quad, dx, dy, dz, xc, yc, zc, 
+                    ivar_variable,
                     tag_threshold,init_flag,is_ghost);
             break;
 
@@ -87,12 +106,13 @@ int FCLAW2D_CLAWPATCH_EXCEEDS_THRESHOLD(const int* blockno,
                                         "defined\n function was found.\n\n");
             }
             FCLAW_ASSERT(user_exceeds_threshold != NULL);
-            exceeds_th = user_exceeds_threshold(blockno, qval,qmin,qmax,quad, 
-                                                dx, dy, xc, yc,
+            exceeds_th = user_exceeds_threshold(blockno, meqn,qval,qmin,qmax,quad, 
+                                                dx, dy, dz, xc, yc, zc, 
+                                                ivar_variable,
                                                 tag_threshold,init_flag,is_ghost);
             break;
         default:
-            fclaw_global_essentialf("fclaw2d_clawpatch_exceeds_threshold.c): " \
+            fclaw_global_essentialf("fclaw3dx_clawpatch_exceeds_threshold.c): " \
                                     "No valid refinement criteria specified\n");
             exit(0);
             break;

--- a/src/patches/clawpatch/fort3_user/fclaw3dx_clawpatch_value_exceeds_th.f90
+++ b/src/patches/clawpatch/fort3_user/fclaw3dx_clawpatch_value_exceeds_th.f90
@@ -16,22 +16,26 @@
 !! @param[in] is_ghost true if cell is a ghost cell
 !! @return 1 if exceeds threshold, 0 if not, -1 if inconclusive.
 !  --------------------------------------------------------------
-integer function fclaw3dx_clawpatch_value_exceeds_th(blockno,& 
+integer function fclaw3dx_clawpatch_value_exceeds_th(blockno, meqn, & 
                                   qval,qmin,qmax,quad, & 
-                                  dx,dy,dz, xc,yc,zc, threshold, &
+                                  dx,dy,dz, xc,yc,zc, ivar_threshold, threshold, &
                                   init_flag, is_ghost)
     implicit none
     
-    double precision :: qval,qmin,qmax,threshold
-    double precision :: quad(-1:1,-1:1,-1:1)
+    integer :: meqn, ivar_threshold
+    double precision :: qval(meqn),qmin(meqn),qmax(meqn),threshold
+    double precision :: quad(-1:1,-1:1,-1:1, meqn)
     double precision :: dx,dy, dz, xc, yc, zc
     integer :: blockno, init_flag
     logical(kind=4) :: is_ghost
 
     integer :: refine
+    integer :: mq
+
+    mq = ivar_threshold
 
     refine = 0
-    if (qval .gt. threshold) then
+    if (qval(mq) .gt. threshold) then
         refine = 1
     endif
 

--- a/src/patches/clawpatch/fort_4.6/fclaw2d_clawpatch46_tag4coarsening.f
+++ b/src/patches/clawpatch/fort_4.6/fclaw2d_clawpatch46_tag4coarsening.f
@@ -23,7 +23,7 @@ c--------------------------------------------------------------------
       double precision q3(1-mbc:mx+mbc,1-mbc:my+mbc,meqn)
 
       integer mq
-      double precision qmin, qmax
+      double precision qmin(meqn), qmax(meqn)
 
 c     # Don't coarsen when initializing the mesh
       if (initflag .ne. 0) then
@@ -34,27 +34,28 @@ c     # Don't coarsen when initializing the mesh
 c     # Assume that we will coarsen a family unless we find a grid
 c     # that doesn't pass the coarsening test.
       tag_patch = 1
-      mq = 1
-      qmin = q0(1,1,mq)
-      qmax = q0(1,1,mq)
+      do mq = 1,meqn
+         qmin(mq) = q0(1,1,mq)
+         qmax(mq) = q0(1,1,mq)
+      end do
 
       call fclaw2d_clawpatch46_test_refine(blockno,mx,my,mbc,meqn,
-     &      mq,q0,qmin,qmax, dx,dy,xlower(0), ylower(0), 
+     &      q0,qmin,qmax, dx,dy,xlower(0), ylower(0), 
      &      coarsen_threshold,initflag, tag_patch)
       if (tag_patch == 0) return
 
       call fclaw2d_clawpatch46_test_refine(blockno,mx,my,mbc,meqn,
-     &      mq,q1,qmin,qmax,dx,dy,xlower(1), ylower(1), 
+     &      q1,qmin,qmax,dx,dy,xlower(1), ylower(1), 
      &      coarsen_threshold,initflag, tag_patch)
       if (tag_patch == 0) return
 
       call fclaw2d_clawpatch46_test_refine(blockno,mx,my,mbc,meqn,
-     &      mq,q2,qmin,qmax,dx,dy,xlower(2), ylower(2),
+     &      q2,qmin,qmax,dx,dy,xlower(2), ylower(2),
      &      coarsen_threshold,initflag, tag_patch)
       if (tag_patch == 0) return
 
       call fclaw2d_clawpatch46_test_refine(blockno,mx,my,mbc,meqn,
-     &      mq,q3,qmin,qmax,dx,dy,xlower(3), ylower(3),
+     &      q3,qmin,qmax,dx,dy,xlower(3), ylower(3),
      &      coarsen_threshold,initflag, tag_patch)
 
       end
@@ -78,38 +79,42 @@ c> @param[in,out] tag_patch passed in as [1] may be set to [0] if it
 c>                should not be coarsened
 c--------------------------------------------------------------------
       subroutine fclaw2d_clawpatch46_test_refine(blockno,mx,my,mbc,
-     &      meqn,mq,q, qmin,qmax,dx,dy,xlower,ylower,
+     &      meqn,q, qmin,qmax,dx,dy,xlower,ylower, 
      &      coarsen_threshold,init_flag,tag_patch)
 
       implicit none
-      integer mx,my,mbc,meqn,mq,tag_patch, init_flag, blockno
+      integer mx,my,mbc,meqn,tag_patch, init_flag, blockno
       double precision coarsen_threshold
-      double precision qmin,qmax, dx, dy, xlower, ylower
+      double precision qmin(meqn),qmax(meqn), dx, dy, xlower, ylower
       double precision q(1-mbc:mx+mbc,1-mbc:my+mbc,meqn)
 
-      double precision xc,yc,quad(-1:1,-1:1),qval
+      double precision xc,yc,quad(-1:1,-1:1,meqn),qval(meqn)
 
-      integer i,j, ii, jj
+      integer :: i,j, ii, jj, mq
 
-      integer exceeds_th, fclaw2d_clawpatch_exceeds_threshold
+      integer exceeds_th, fclaw2d_clawpatch_tag_criteria
       logical(kind=4) :: is_ghost, fclaw2d_clawpatch46_is_ghost
 
       do i = 1-mbc,mx+mbc
          do j = 1-mbc,my+mbc
             xc = xlower + (i-0.5)*dx
             yc = ylower + (j-0.5)*dy
-            qmin = min(q(i,j,mq),qmin)
-            qmax = max(q(i,j,mq),qmax)
-            qval = q(i,j,mq)
+            do mq = 1,meqn
+               qval(mq) = q(i,j,mq)
+               qmin(mq) = min(q(i,j,mq),qmin(mq))
+               qmax(mq) = max(q(i,j,mq),qmax(mq))
+            end do
             is_ghost = fclaw2d_clawpatch46_is_ghost(i,j,mx,my)
             if (.not. is_ghost) then
                do ii = -1,1               
                   do jj = -1,1
-                     quad(ii,jj) = q(i+ii,j+jj,mq)
+                     do mq = 1,meqn
+                        quad(ii,jj,mq) = q(i+ii,j+jj,mq)
+                     end do
                   end do
                end do
             endif
-            exceeds_th = fclaw2d_clawpatch_exceeds_threshold(
+            exceeds_th = fclaw2d_clawpatch_tag_criteria(
      &             blockno, qval,qmin,qmax,quad, dx,dy,xc,yc,
      &             coarsen_threshold, init_flag, is_ghost)
             

--- a/src/patches/clawpatch/fort_5.0/fclaw2d_clawpatch5_tag4coarsening.f
+++ b/src/patches/clawpatch/fort_5.0/fclaw2d_clawpatch5_tag4coarsening.f
@@ -23,7 +23,7 @@ c--------------------------------------------------------------------
       double precision q3(meqn,1-mbc:mx+mbc,1-mbc:my+mbc)
 
       integer mq
-      double precision qmin, qmax
+      double precision qmin(meqn), qmax(meqn)
 
 c     # Don't coarsen when initializing the mesh
       if (initflag .ne. 0) then
@@ -34,31 +34,32 @@ c     # Don't coarsen when initializing the mesh
 c     # Assume that we will coarsen a family unless we find a grid
 c     # that doesn't pass the coarsening test.
       tag_patch = 1
-      mq = 1
-      qmin = q0(mq,1,1)
-      qmax = q0(mq,1,1)
+      do mq = 1,meqn
+         qmin(mq) = q0(mq,1,1)
+         qmax(mq) = q0(mq,1,1)
+      end do
 
 c     # If we find that (qmax-qmin > coarsen_threshold) on any
 c     # grid, we return immediately, since the family will then
 c     # not be coarsened.
 
       call fclaw2d_clawpatch5_test_refine(blockno,mx,my,mbc,meqn,
-     &      mq,q0,qmin,qmax, dx,dy,xlower(0), ylower(0), 
+     &      q0,qmin,qmax, dx,dy,xlower(0), ylower(0), 
      &      coarsen_threshold,initflag, tag_patch)
       if (tag_patch == 0) return
 
       call fclaw2d_clawpatch5_test_refine(blockno,mx,my,mbc,meqn,
-     &      mq,q1,qmin,qmax,dx,dy,xlower(1), ylower(1), 
+     &      q1,qmin,qmax,dx,dy,xlower(1), ylower(1), 
      &      coarsen_threshold,initflag, tag_patch)
       if (tag_patch == 0) return
 
       call fclaw2d_clawpatch5_test_refine(blockno,mx,my,mbc,meqn,
-     &              mq,q2,qmin,qmax,dx,dy,xlower(2), ylower(2),
+     &              q2,qmin,qmax,dx,dy,xlower(2), ylower(2),
      &              coarsen_threshold,initflag, tag_patch)
       if (tag_patch == 0) return
 
       call fclaw2d_clawpatch5_test_refine(blockno,mx,my,mbc,meqn,
-     &      mq,q3,qmin,qmax,dx,dy,xlower(3), ylower(3),
+     &      q3,qmin,qmax,dx,dy,xlower(3), ylower(3),
      &      coarsen_threshold,initflag, tag_patch)
 
       end
@@ -82,17 +83,17 @@ c> @param[in,out] tag_patch passed in as [1] may be set to [0] if it
 c>                should not be coarsened
 c--------------------------------------------------------------------
       subroutine fclaw2d_clawpatch5_test_refine(blockno, mx,my,mbc,
-     &                meqn,mq,q, qmin,qmax,dx,dy,xlower,ylower,
+     &                meqn,q, qmin,qmax,dx,dy,xlower,ylower,
      &                coarsen_threshold,init_flag,tag_patch)
 
       implicit none
       integer mx,my,mbc,meqn,mq,tag_patch,init_flag,blockno
       double precision coarsen_threshold
-      double precision qmin,qmax, dx, dy, xlower, ylower
+      double precision qmin(mq),qmax(mq), dx, dy, xlower, ylower
       double precision q(meqn,1-mbc:mx+mbc,1-mbc:my+mbc)
 
-      double precision xc,yc,quad(-1:1,-1:1), qval
-      integer exceeds_th, fclaw2d_clawpatch_exceeds_threshold
+      double precision xc,yc,quad(-1:1,-1:1,meqn), qval(meqn)
+      integer exceeds_th, fclaw2d_clawpatch_tag_criteria
 
       integer i,j, ii, jj
 
@@ -102,18 +103,22 @@ c--------------------------------------------------------------------
          do j = 1-mbc,my+mbc
             xc = xlower + (i-0.5)*dx
             yc = ylower + (j-0.5)*dy
-            qmin = min(q(mq,i,j),qmin)
-            qmax = max(q(mq,i,j),qmax)
-            qval = q(mq,i,j)
+            do mq=1,meqn
+               qval(mq) = q(mq,i,j)
+               qmin(mq) = min(q(mq,i,j),qmin(mq))
+               qmax(mq) = max(q(mq,i,j),qmax(mq))
+            end do
             is_ghost = fclaw2d_clawpatch5_is_ghost(i,j,mx,my)
             if (.not. is_ghost) then
                do ii = -1,1
                   do jj = -1,1
-                     quad(ii,jj) = q(mq,i+ii,j+jj)
+                     do mq = 1,meqn
+                        quad(ii,jj,mq) = q(mq,i+ii,j+jj)
+                     end do                     
                   end do
                end do
             endif
-            exceeds_th = fclaw2d_clawpatch_exceeds_threshold(
+            exceeds_th = fclaw2d_clawpatch_tag_criteria(
      &             blockno, qval,qmin,qmax,quad, dx,dy,xc,yc,
      &             coarsen_threshold, init_flag, is_ghost)
 

--- a/src/patches/clawpatch/fort_5.0/fclaw2d_clawpatch5_tag4coarsening.f
+++ b/src/patches/clawpatch/fort_5.0/fclaw2d_clawpatch5_tag4coarsening.f
@@ -22,8 +22,8 @@ c--------------------------------------------------------------------
       double precision q2(meqn,1-mbc:mx+mbc,1-mbc:my+mbc)
       double precision q3(meqn,1-mbc:mx+mbc,1-mbc:my+mbc)
 
-      integer mq
       double precision qmin(meqn), qmax(meqn)
+      integer mq
 
 c     # Don't coarsen when initializing the mesh
       if (initflag .ne. 0) then
@@ -87,15 +87,15 @@ c--------------------------------------------------------------------
      &                coarsen_threshold,init_flag,tag_patch)
 
       implicit none
-      integer mx,my,mbc,meqn,mq,tag_patch,init_flag,blockno
+      integer mx,my,mbc,meqn,tag_patch,init_flag,blockno
       double precision coarsen_threshold
-      double precision qmin(mq),qmax(mq), dx, dy, xlower, ylower
+      double precision qmin(meqn),qmax(meqn), dx, dy, xlower, ylower
       double precision q(meqn,1-mbc:mx+mbc,1-mbc:my+mbc)
 
       double precision xc,yc,quad(-1:1,-1:1,meqn), qval(meqn)
       integer exceeds_th, fclaw2d_clawpatch_tag_criteria
 
-      integer i,j, ii, jj
+      integer i,j, ii, jj, mq
 
       logical(kind=4) is_ghost, fclaw2d_clawpatch5_is_ghost
 

--- a/src/patches/clawpatch/fort_5.0/fclaw2d_clawpatch5_tag4refinement.f
+++ b/src/patches/clawpatch/fort_5.0/fclaw2d_clawpatch5_tag4refinement.f
@@ -21,7 +21,7 @@ c--------------------------------------------------------------------
 
       integer i,j, mq, ii, jj
       double precision qmin, qmax, xc,yc,quad(-1:1,-1:1)
-      integer :: fclaw2d_clawpatch_exceeds_threshold, exceeds_th
+      integer :: fclaw2d_clawpatch_tag_criteria, exceeds_th
 
       logical(kind=4) :: is_ghost, fclaw2d_clawpatch5_is_ghost
 
@@ -45,7 +45,7 @@ c     # Refine based only on first variable in system.
                   end do
                end do
             endif
-            exceeds_th = fclaw2d_clawpatch_exceeds_threshold(
+            exceeds_th = fclaw2d_clawpatch_tag_criteria(
      &             blockno, q(mq,i,j),qmin,qmax,quad, dx,dy,xc,yc,
      &             tag_threshold,init_flag,is_ghost)
             

--- a/src/patches/clawpatch/fort_user/fclaw2d_clawpatch_difference_exceeds_th.f90
+++ b/src/patches/clawpatch/fort_user/fclaw2d_clawpatch_difference_exceeds_th.f90
@@ -16,20 +16,25 @@
 !! @param[in] is_ghost true if cell is a ghost cell
 !! @return 1 if exceeds threshold, 0 if not, -1 if inconclusive.
 !  --------------------------------------------------------------
-integer function fclaw2d_clawpatch_difference_exceeds_th(blockno,& 
+integer function fclaw2d_clawpatch_difference_exceeds_th(blockno,meqn,& 
                                      qval,qmin,qmax,quad, & 
-                                     dx,dy,xc,yc,threshold,&
-                                     init_flag, is_ghost)
+                                     dx,dy,xc,yc, ivar_threshold, &
+                                     threshold, init_flag, is_ghost)
     implicit none
     
-    double precision :: qval,qmin,qmax,threshold
-    double precision :: quad(-1:1,-1:1)
+    integer :: meqn
+    double precision :: qval(meqn),qmin(meqn),qmax(meqn),threshold
+    double precision :: quad(-1:1,-1:1,meqn)
     double precision :: dx,dy, xc, yc
     integer :: blockno, init_flag
+    integer :: ivar_threshold
     logical(kind=4) :: is_ghost
 
     double precision :: dqx, dqy, dq
     integer :: refine
+    integer :: mq
+
+    mq = ivar_threshold
 
     if (is_ghost) then
 !!      # quad may have uninitialized values;  test inconclusive
@@ -37,8 +42,8 @@ integer function fclaw2d_clawpatch_difference_exceeds_th(blockno,&
         return
     endif
 
-    dqx = abs(quad(1,0) - quad(-1,0))
-    dqy = abs(quad(0,1) - quad(0,-1))
+    dqx = abs(quad(1,0,mq) - quad(-1,0,mq))
+    dqy = abs(quad(0,1,mq) - quad(0,-1,mq))
     dq  = max(dqx, dqy)
 
     refine = 0

--- a/src/patches/clawpatch/fort_user/fclaw2d_clawpatch_gradient_exceeds_th.f90
+++ b/src/patches/clawpatch/fort_user/fclaw2d_clawpatch_gradient_exceeds_th.f90
@@ -16,14 +16,15 @@
 !! @param[in] is_ghost true if cell is a ghost cell
 !! @return 1 if exceeds threshold, 0 if not, -1 if inconclusive.
 !  --------------------------------------------------------------
-integer function fclaw2d_clawpatch_gradient_exceeds_th(blockno,& 
+integer function fclaw2d_clawpatch_gradient_exceeds_th(blockno, meqn, & 
                                      qval,qmin,qmax,quad, & 
-                                     dx,dy,xc,yc,threshold, &
-                                     init_flag, is_ghost)
+                                     dx,dy,xc,yc,ivar_threshold, &
+                                     threshold, init_flag, is_ghost)
     implicit none
     
-    double precision :: qval,qmin,qmax,threshold
-    double precision :: quad(-1:1,-1:1)
+    integer :: meqn, ivar_threshold
+    double precision :: qval(meqn),qmin(meqn),qmax(meqn),threshold
+    double precision :: quad(-1:1,-1:1,meqn)
     double precision :: dx,dy, xc, yc
     integer :: blockno, init_flag
     logical(kind=4) :: is_ghost
@@ -40,7 +41,9 @@ integer function fclaw2d_clawpatch_gradient_exceeds_th(blockno,&
 
     double precision :: clawpatch_gradient_dot
     integer :: refine
-    integer :: m
+    integer :: m, mq
+
+    mq = ivar_threshold
 
     if (is_ghost) then
 !!      # quad may have uninitialized values.  Test is inconclusive
@@ -53,8 +56,9 @@ integer function fclaw2d_clawpatch_gradient_exceeds_th(blockno,&
     dx2 = 2*dx
     dy2 = 2*dy
 
-    dqx = (quad(1,0) - quad(-1,0))/dx2
-    dqy = (quad(0,1) - quad(0,-1))/dy2
+    dqx = (quad(1,0,mq) - quad(-1,0,mq))/dx2
+    dqy = (quad(0,1,mq) - quad(0,-1,mq))/dy2
+
 
     refine = 0
     if (fclaw2d_map_is_used(cont) .ne. 0) THEN

--- a/src/patches/clawpatch/fort_user/fclaw2d_clawpatch_minmax_exceeds_th.f90
+++ b/src/patches/clawpatch/fort_user/fclaw2d_clawpatch_minmax_exceeds_th.f90
@@ -17,23 +17,28 @@
 !! @param[in] is_ghost true if cell is a ghost cell
 !! @return 1 if exceeds threshold, 0 if not, -1 if inconclusive.
 !  --------------------------------------------------------------
-integer function fclaw2d_clawpatch_minmax_exceeds_th(blockno,& 
+integer function fclaw2d_clawpatch_minmax_exceeds_th(blockno,meqn, & 
                                      qval,qmin,qmax,quad, & 
-                                     dx,dy,xc,yc,threshold, &
-                                     init_flag, is_ghost)
+                                     dx,dy,xc,yc,ivar_threshold, & 
+                                     threshold, init_flag, is_ghost)
     implicit none
     
-    double precision :: qval,qmin,qmax,threshold
-    double precision :: quad(-1:1,-1:1)
+    integer :: meqn
+    double precision :: qval(meqn),qmin(meqn),qmax(meqn),threshold
+    double precision :: quad(-1:1,-1:1,meqn)
     double precision :: dx,dy, xc, yc
     integer :: blockno, init_flag
+    integer :: ivar_threshold
     logical(kind=4) :: is_ghost
 
     integer :: refine
+    integer :: mq
+
+    mq = ivar_threshold
 
     refine = 0
 
-    if (qmax-qmin .gt. threshold) then
+    if (qmax(mq)-qmin(mq) .gt. threshold) then
         refine = 1
     endif
 

--- a/src/patches/clawpatch/fort_user/fclaw2d_clawpatch_tag_criteria.c
+++ b/src/patches/clawpatch/fort_user/fclaw2d_clawpatch_tag_criteria.c
@@ -5,10 +5,12 @@
 #endif
 
 #ifndef PATCH_DIM
-#define PATCH_DIM 3
+#define PATCH_DIM 2
 #endif
 
-#if 0
+
+#include<fclaw2d_global.h>
+
 #if REFINE_DIM == 2 && PATCH_DIM == 2
 
 #include "../fclaw2d_clawpatch.h"
@@ -27,64 +29,65 @@
 #include <_fclaw2d_to_fclaw3dx.h>
 
 #endif
-#endif
-
-#include <fclaw2d_global.h>
-
-#include "../fclaw3dx_clawpatch.h"
-
-#include "../fclaw3dx_clawpatch_options.h"
-// #include "../fclaw2d_clawpatch_fort.h"
-#include "../fclaw3dx_clawpatch_fort.h"
-
-
 
 
 /* ------------------------------------------------------------------------------------ */
 
-int FCLAW3DX_CLAWPATCH_EXCEEDS_THRESHOLD(const int* blockno,
-                                        const double *qval, 
-                                        const double* qmin, 
-                                        const double *qmax,
+/* This signature is not the same as the actual threshold functions called below 
+   This is because we can call the glob and get options. This is only called from 
+   the tagging/coarsening routines in patches/clawpatch.   If users copy these 
+   routines, they can then alter the call to this function in any way they wish.
+*/
+int FCLAW2D_CLAWPATCH_TAG_CRITERIA(const int* blockno,
+                                        const double qval[], 
+                                        const double qmin[], 
+                                        const double qmax[],
                                         const double quad[], 
                                         const double *dx, 
                                         const double *dy, 
-                                        const double *dz, 
                                         const double *xc, 
                                         const double *yc, 
-                                        const double *zc, 
                                         const double *tag_threshold,
                                         const int* init_flag,
                                         const int* is_ghost)
 {
     struct fclaw2d_global* glob = fclaw2d_global_get_global();
-    fclaw3dx_clawpatch_vtable_t* clawpatch_vt = fclaw3dx_clawpatch_vt(glob);
-    fclaw3dx_clawpatch_fort_exceeds_threshold_t user_exceeds_threshold = 
+    fclaw2d_clawpatch_vtable_t* clawpatch_vt = fclaw2d_clawpatch_vt(glob);
+
+    clawpatch_fort_exceeds_threshold_t user_exceeds_threshold = 
                                 clawpatch_vt->fort_user_exceeds_threshold;
 
+    fclaw2d_clawpatch_options_t *clawpatch_opt = fclaw2d_clawpatch_get_options(glob);
+    int meqn_val = clawpatch_opt->meqn, *meqn = &meqn_val;
+    int ivar_val = clawpatch_opt->threshold_variable, *ivar_threshold=&ivar_val;
+
     int exceeds_th = 1;
-    int refinement_criteria = fclaw3dx_clawpatch_get_options(glob)->refinement_criteria;
+    int refinement_criteria = fclaw2d_clawpatch_get_options(glob)->refinement_criteria;
     switch(refinement_criteria)
     {
         case FCLAW_REFINE_CRITERIA_VALUE:
-            exceeds_th = FCLAW3DX_CLAWPATCH_VALUE_EXCEEDS_TH(blockno,
-                    qval,qmin,qmax,quad, dx, dy, dz, xc, yc, zc, 
+            exceeds_th = FCLAW2D_CLAWPATCH_VALUE_EXCEEDS_TH(blockno,meqn,
+                    qval,qmin,qmax,quad, dx, dy, xc, yc, 
+                    ivar_threshold,
                     tag_threshold,init_flag,is_ghost);
             break;
         case FCLAW_REFINE_CRITERIA_DIFFERENCE:
-            exceeds_th = FCLAW3DX_CLAWPATCH_DIFFERENCE_EXCEEDS_TH(blockno,
-                    qval,qmin,qmax,quad, dx, dy, dz, xc, yc, zc, 
+            exceeds_th = FCLAW2D_CLAWPATCH_DIFFERENCE_EXCEEDS_TH(blockno,meqn,
+                    qval,qmin,qmax,quad, dx, dy, xc, yc, 
+                    ivar_threshold,
                     tag_threshold,init_flag,is_ghost);
             break;
         case FCLAW_REFINE_CRITERIA_MINMAX:
-            exceeds_th = FCLAW3DX_CLAWPATCH_MINMAX_EXCEEDS_TH(blockno,
-                    qval,qmin,qmax,quad, dx, dy, dz, xc, yc, zc, 
+            exceeds_th = FCLAW2D_CLAWPATCH_MINMAX_EXCEEDS_TH(blockno,meqn,
+                    qval,qmin,qmax,quad, dx, dy, xc, yc, 
+                    ivar_threshold,
                     tag_threshold,init_flag,is_ghost);
 
             break;
         case FCLAW_REFINE_CRITERIA_GRADIENT:
-            exceeds_th = FCLAW3DX_CLAWPATCH_GRADIENT_EXCEEDS_TH(blockno,
-                    qval,qmin,qmax,quad, dx, dy, dz, xc, yc, zc, 
+            exceeds_th = FCLAW2D_CLAWPATCH_GRADIENT_EXCEEDS_TH(blockno,meqn,
+                    qval,qmin,qmax,quad, dx, dy, xc, yc,     
+                    ivar_threshold,
                     tag_threshold,init_flag,is_ghost);
             break;
 
@@ -98,12 +101,13 @@ int FCLAW3DX_CLAWPATCH_EXCEEDS_THRESHOLD(const int* blockno,
                                         "defined\n function was found.\n\n");
             }
             FCLAW_ASSERT(user_exceeds_threshold != NULL);
-            exceeds_th = user_exceeds_threshold(blockno, qval,qmin,qmax,quad, 
-                                                dx, dy, dz, xc, yc, zc, 
+            exceeds_th = user_exceeds_threshold(blockno, meqn,qval,qmin,qmax,quad, 
+                                                dx, dy, xc, yc,
+                                                ivar_threshold,
                                                 tag_threshold,init_flag,is_ghost);
             break;
         default:
-            fclaw_global_essentialf("fclaw3dx_clawpatch_exceeds_threshold.c): " \
+            fclaw_global_essentialf("fclaw2d_clawpatch_exceeds_threshold.c): " \
                                     "No valid refinement criteria specified\n");
             exit(0);
             break;

--- a/src/patches/clawpatch/fort_user/fclaw2d_clawpatch_value_exceeds_th.f90
+++ b/src/patches/clawpatch/fort_user/fclaw2d_clawpatch_value_exceeds_th.f90
@@ -16,22 +16,26 @@
 !! @param[in] is_ghost true if cell is a ghost cell
 !! @return 1 if exceeds threshold, 0 if not, -1 if inconclusive.
 !  --------------------------------------------------------------
-integer function fclaw2d_clawpatch_value_exceeds_th(blockno,& 
+integer function fclaw2d_clawpatch_value_exceeds_th(blockno,meqn,& 
                                   qval,qmin,qmax,quad, & 
-                                  dx,dy,xc,yc,threshold, &
-                                  init_flag, is_ghost)
+                                  dx,dy,xc,yc,ivar_threshold, & 
+                                  threshold, init_flag, is_ghost)
     implicit none
     
-    double precision :: qval,qmin,qmax,threshold
-    double precision :: quad(-1:1,-1:1)
-    double precision :: dx,dy, xc, yc
-    integer :: blockno, init_flag
+    integer :: meqn
+    double precision :: qval(meqn),qmin(meqn),qmax(meqn)
+    double precision :: quad(-1:1,-1:1,meqn)
+    double precision :: dx,dy, xc, yc, threshold
+    integer :: blockno, init_flag, ivar_threshold
     logical(kind=4) :: is_ghost
 
     integer :: refine
+    integer :: mq
+
+    mq = ivar_threshold
 
     refine = 0
-    if (qval .gt. threshold) then
+    if (qval(mq) .gt. threshold) then
         refine = 1
     endif
 


### PR DESCRIPTION
This PR will pass in a full vector (1:meqn) of values at point (i,j) to tagging routines.  Input arguments are : 

```
qval(1:meqn)
quad(-1:1,-1:1,1:meqn)
qmin(1:min), qmax(1:meqn)
```

In addition, there is a new option `clawpatch:threshold-variable` to allow the user to specify which variable in `1:meqn` is used when specified `value`, `difference`, `gradient` etc as refinement options.  

This PR will be most useful for computing, for example, pressure, which depends on all state variables. 