### PR TITLE
fclaw_filesystem fixes

### DIFF
--- a/src/fclaw_filesystem.cpp
+++ b/src/fclaw_filesystem.cpp
@@ -66,7 +66,7 @@ void fclaw_cd(const char* dir)
         output_path /= output_dir;
     }
 
-	std::filesystem::create_directory(output_path);
+	std::filesystem::create_directories(output_path);
 
 	std::filesystem::current_path(output_path);
 #endif

--- a/src/fclaw_filesystem.cpp
+++ b/src/fclaw_filesystem.cpp
@@ -41,7 +41,7 @@ char* fclaw_cwd()
     FCLAW_ASSERT(error != NULL);
     return c_current_path;
 #else
-    std::string current_path = std::filesystem::current_path();
+    std::string current_path = std::filesystem::current_path().generic_string();
     char* c_current_path = FCLAW_ALLOC(char, current_path.length()+1);
     strcpy(c_current_path,current_path.c_str());
     return c_current_path;
@@ -71,4 +71,3 @@ void fclaw_cd(const char* dir)
 	std::filesystem::current_path(output_path);
 #endif
 }
-


### PR DESCRIPTION
I am currently unable to build ForestClaw on Windows due to the bug fixed in the PR.

Dynamically check if C++ filesystem is available and use it, with POSIX fallback.