### PR TITLE
Speed up transform

### DIFF
--- a/src/fclaw2d_face_neighbors.c
+++ b/src/fclaw2d_face_neighbors.c
@@ -499,6 +499,10 @@ void fclaw2d_face_neighbor_ghost(fclaw2d_global_t* glob,
 		int this_ghost_idx = i;
 
 		transform_data.this_patch = this_ghost_patch;
+		fclaw2d_patch_transform_init_data(glob,this_ghost_patch,
+		                              	  -1,
+		                                  i,
+		                                  &transform_data);
 
 		for (iface = 0; iface < FCLAW2D_NUMFACES; iface++)
 		{

--- a/src/fclaw2d_patch.h
+++ b/src/fclaw2d_patch.h
@@ -491,7 +491,7 @@ void fclaw2d_patch_destroy_user_data(struct fclaw2d_global* glob,
  * 
  * @param[in] glob the global context
  * @param[in] patch the patch context
- * @param[in] blockno the block number
+ * @param[in] blockno the block number, -1 if ghost patch
  * @param[in] patchno the patch number
  * @param[in,out] tdata the stransform data structure
  */

--- a/src/patches/clawpatch/fclaw2d_clawpatch_transform.c
+++ b/src/patches/clawpatch/fclaw2d_clawpatch_transform.c
@@ -60,7 +60,8 @@ void fclaw2d_clawpatch_transform_init_data(fclaw2d_global_t* glob,
     /* Cell centered data */
     transform->based = 1;
 
-    /* Nothing to do for transform->user */
+    /* Store clawpatch_options in transform->user */
+    transform->user = (void*) fclaw2d_clawpatch_get_options(glob);
 }
 
 void fclaw2d_clawpatch_face_transformation (int faceno, int rfaceno, int ftransform[])
@@ -83,7 +84,7 @@ FCLAW2D_CLAWPATCH_TRANSFORM_FACE (const int *i1, const int *j1,
 {
     fclaw2d_patch_transform_data_t *tdata = *ptdata;
     const fclaw2d_clawpatch_options_t *clawpatch_opt = 
-             fclaw2d_clawpatch_get_options(tdata->glob);
+        (fclaw2d_clawpatch_options_t*) tdata->user;
 
     *i2 = *i1;
     *j2 = *j1;
@@ -104,7 +105,7 @@ FCLAW2D_CLAWPATCH_TRANSFORM_FACE_HALF (const int *i1, const int *j1,
 {
     fclaw2d_patch_transform_data_t *tdata = *ptdata;
     const fclaw2d_clawpatch_options_t *clawpatch_opt = 
-                fclaw2d_clawpatch_get_options(tdata->glob);
+        (fclaw2d_clawpatch_options_t*) tdata->user;
 
     i2[0] = *i1;
     j2[0] = *j1;
@@ -125,7 +126,7 @@ FCLAW2D_CLAWPATCH_TRANSFORM_CORNER (const int *i1, const int *j1,
 {
     fclaw2d_patch_transform_data_t *tdata = *ptdata;
     const fclaw2d_clawpatch_options_t *clawpatch_opt = 
-                   fclaw2d_clawpatch_get_options(tdata->glob);
+        (fclaw2d_clawpatch_options_t*) tdata->user;
 
     *i2 = *i1;
     *j2 = *j1;
@@ -163,7 +164,7 @@ FCLAW2D_CLAWPATCH_TRANSFORM_CORNER_HALF (const int *i1, const int *j1,
 {
     fclaw2d_patch_transform_data_t *tdata = *ptdata;
     const fclaw2d_clawpatch_options_t *clawpatch_opt = 
-               fclaw2d_clawpatch_get_options(tdata->glob);
+        (fclaw2d_clawpatch_options_t*) tdata->user;
 
     i2[0] = *i1;
     j2[0] = *j1;


### PR DESCRIPTION
I looked into the problem @jbsnively was having with ghost filling and found that a lot of time was being spent in the `  fclaw2d_patch_transform` functions. The problem was that `fclaw2d_clawpatch_get_options` was being called on each ghost cell. Since we switched to using a key-value pair for storing options in the glob which is more expensive way of storing things, this caused the slowdown.

The solution was to just store the clwpatch options in `transform_data->user` to avoid calling `fclaw2d_clawpatch_get_options` on each ghost cell. 

The original ghost filling, before we were storing options in a key-value pair was:

```
[libsc] Statistics for   GHOSTFILL_COPY
[libsc]    Global number of values:       8
[libsc]    Mean value (std. dev.):           17.4065 (2 = 11.5%)
[libsc]    Minimum attained at rank       0: 14.2407
[libsc]    Maximum attained at rank       2: 20.1298
```

With the change to storing the options in a key-value pair the ghost filling increases significantly:

```
[libsc] Statistics for   GHOSTFILL_COPY
[libsc]    Global number of values:       8
[libsc]    Mean value (std. dev.):           38.6166 (4.51 = 11.7%)
[libsc]    Minimum attained at rank       7: 31.345
[libsc]    Maximum attained at rank       2: 44.3934
```

The new solution of storing the options pointer in `transform_data->user`:

```
[libsc] Statistics for   GHOSTFILL_COPY
[libsc]    Global number of values:       8
[libsc]    Mean value (std. dev.):           11.7372 (1.38 = 11.8%)
[libsc]    Minimum attained at rank       0: 9.73282
[libsc]    Maximum attained at rank       2: 13.748
```

So this should be even faster than the original code.

