### PR TITLE
Remove use of deprecated package container

### DIFF
--- a/applications/clawpack/acoustics/2d/interface/interface_options.c
+++ b/applications/clawpack/acoustics/2d/interface/interface_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,7 +24,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "interface_user.h"
-#include <fclaw_pointer_map.h>
 
 static void *
 interface_register (user_options_t* user, sc_options_t * opt)
@@ -106,16 +105,12 @@ user_options_t* interface_options_register (fclaw_app_t * app,
 
 void interface_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const user_options_t* interface_get_options(fclaw2d_global_t* glob)
 {
-    user_options_t* user = (user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }
 
 

--- a/applications/clawpack/acoustics/2d/radial/radial_options.c
+++ b/applications/clawpack/acoustics/2d/radial/radial_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,11 +24,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "radial_user.h"
-
-#include <fclaw2d_clawpatch.h>
-#include <fclaw2d_clawpatch_options.h>
-
-#include <fclaw_pointer_map.h>
 
 static void *
 radial_register (user_options_t *user, sc_options_t * opt)
@@ -166,16 +161,12 @@ user_options_t* radial_options_register (fclaw_app_t * app,
 
 void radial_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 user_options_t* radial_get_options(fclaw2d_global_t* glob)
 {
-    user_options_t* user = (user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }
 
 void radial_global_post_process(fclaw_options_t *fclaw_opt,

--- a/applications/clawpack/advection/2d/adv_order3/periodic_options.c
+++ b/applications/clawpack/advection/2d/adv_order3/periodic_options.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+  Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@
 */
 
 #include "periodic_user.h"
-
-#include <fclaw_pointer_map.h>
 
 static void *
 periodic_register (user_options_t *user, sc_options_t * opt)
@@ -162,14 +160,10 @@ user_options_t* periodic_options_register (fclaw_app_t * app,
 
 void periodic_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const user_options_t* periodic_get_options(fclaw2d_global_t* glob)
 {
-    user_options_t* user = (user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }

--- a/applications/clawpack/advection/2d/annulus/annulus_options.c
+++ b/applications/clawpack/advection/2d/annulus/annulus_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,10 +24,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "annulus_user.h"
-
-#include <fclaw2d_include_all.h>
-
-#include <fclaw_pointer_map.h>
 
 static void *
 annulus_register(user_options_t *user, sc_options_t * opt)
@@ -164,15 +160,11 @@ user_options_t* annulus_options_register (fclaw_app_t * app,
 
 void annulus_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const user_options_t* annulus_get_options(fclaw2d_global_t* glob)
 {
-    user_options_t* user = (user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }
 

--- a/applications/clawpack/advection/2d/correlatedcb/correlatedcb_options.c
+++ b/applications/clawpack/advection/2d/correlatedcb/correlatedcb_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "correlatedcb_user.h"
-
-#include <fclaw_pointer_map.h>
 
 static void *
 correlatedcb_register (user_options_t* user, sc_options_t * opt)
@@ -158,16 +156,12 @@ user_options_t* correlatedcb_options_register (fclaw_app_t * app,
 
 void correlatedcb_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const user_options_t* correlatedcb_get_options(fclaw2d_global_t* glob)
 {
-    user_options_t* user = (user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }
 /* ------------------------- ... and here ---------------------------- */
 

--- a/applications/clawpack/advection/2d/disk/disk_options.c
+++ b/applications/clawpack/advection/2d/disk/disk_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,11 +24,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "disk_user.h"
-
-#include <fclaw2d_clawpatch.h>
-#include <fclaw2d_clawpatch_options.h>
-
-#include <fclaw_pointer_map.h>
 
 static void *
 disk_register (user_options_t *user_opt, sc_options_t * opt)
@@ -164,16 +159,12 @@ user_options_t* disk_options_register (fclaw_app_t * app,
 
 void disk_options_store (fclaw2d_global_t* glob, user_options_t* user_opt)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user_opt, NULL);
+    fclaw2d_global_options_store(glob, "user", user_opt);
 }
 
 const user_options_t* disk_get_options(fclaw2d_global_t* glob)
 {
-    user_options_t* user = (user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (user_options_t*) fclaw2d_global_get_options(glob,"user");
 }
 
 void disk_global_post_process(fclaw_options_t *fclaw_opt,

--- a/applications/clawpack/advection/2d/filament/filament_options.c
+++ b/applications/clawpack/advection/2d/filament/filament_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,10 +24,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "filament_user.h"
-
-#include <fclaw2d_clawpatch_options.h>
-
-#include <fclaw_pointer_map.h>
 
 static void *
 filament_register (user_options_t *user, sc_options_t * opt)
@@ -168,14 +164,10 @@ user_options_t* filament_options_register (fclaw_app_t * app,
 
 void filament_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const user_options_t* filament_get_options(fclaw2d_global_t* glob)
 {
-    user_options_t* user = (user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }

--- a/applications/clawpack/advection/2d/filament_swirl/filament/filament_options.c
+++ b/applications/clawpack/advection/2d/filament_swirl/filament/filament_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,10 +24,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "filament_user.h"
-
-#include <fclaw2d_clawpatch_options.h>
-
-#include <fclaw_pointer_map.h>
 
 static void *
 filament_register (filament_options_t *user, sc_options_t * opt)
@@ -143,14 +139,10 @@ filament_options_t* filament_options_register (fclaw_app_t * app,
 
 void filament_options_store (fclaw2d_global_t* glob, filament_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"filament-user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "filament-user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const filament_options_t* filament_get_options(fclaw2d_global_t* glob)
 {
-    filament_options_t* user = (filament_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "filament-user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (filament_options_t*) fclaw2d_global_get_options(glob, "user");
 }

--- a/applications/clawpack/advection/2d/filament_swirl/swirl/swirl_options.c
+++ b/applications/clawpack/advection/2d/filament_swirl/swirl/swirl_options.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+  Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@
 */
 
 #include "swirl_user.h"
-
-#include <fclaw_pointer_map.h>
 
 static void *
 swirl_register (swirl_options_t *user, sc_options_t * opt)
@@ -155,14 +153,10 @@ swirl_options_t* swirl_options_register (fclaw_app_t * app,
 
 void swirl_options_store (fclaw2d_global_t* glob, swirl_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"swirl-user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "swirl-user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const swirl_options_t* swirl_get_options(fclaw2d_global_t* glob)
 {
-    swirl_options_t* user = (swirl_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "swirl-user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (swirl_options_t*) fclaw2d_global_get_options(glob, "user");
 }

--- a/applications/clawpack/advection/2d/gaussian/gaussian_options.c
+++ b/applications/clawpack/advection/2d/gaussian/gaussian_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "gaussian_user.h"
-
-#include <fclaw_pointer_map.h>
 
 static void *
 gaussian_register (user_options_t* user, sc_options_t * opt)
@@ -158,16 +156,12 @@ user_options_t* gaussian_options_register (fclaw_app_t * app,
 
 void gaussian_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const user_options_t* gaussian_get_options(fclaw2d_global_t* glob)
 {
-    user_options_t* user = (user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }
 /* ------------------------- ... and here ---------------------------- */
 

--- a/applications/clawpack/advection/2d/hemisphere/hemisphere_options.c
+++ b/applications/clawpack/advection/2d/hemisphere/hemisphere_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "hemisphere_user.h"
-
-#include <fclaw_pointer_map.h>
 
 static void *
 hemisphere_register (user_options_t* user_opt, sc_options_t * opt)
@@ -134,15 +132,11 @@ user_options_t* hemisphere_options_register (fclaw_app_t * app,
 
 void hemisphere_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const user_options_t* hemisphere_get_options(fclaw2d_global_t* glob)
 {
-    user_options_t* user = (user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }
 

--- a/applications/clawpack/advection/2d/latlong/latlong_options.c
+++ b/applications/clawpack/advection/2d/latlong/latlong_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "latlong_user.h"
-
-#include <fclaw_pointer_map.h>
 
 static void *
 latlong_register (user_options_t *user, sc_options_t * opt)
@@ -174,16 +172,12 @@ user_options_t*  latlong_options_register (fclaw_app_t * app,
 
 void latlong_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const user_options_t* latlong_get_options(fclaw2d_global_t* glob)
 {
-    user_options_t* user = (user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }
 
 

--- a/applications/clawpack/advection/2d/periodic/periodic_options.c
+++ b/applications/clawpack/advection/2d/periodic/periodic_options.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+  Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@
 */
 
 #include "periodic_user.h"
-
-#include <fclaw_pointer_map.h>
 
 static void *
 periodic_register (user_options_t *user, sc_options_t * opt)
@@ -157,14 +155,10 @@ user_options_t* periodic_options_register (fclaw_app_t * app,
 
 void periodic_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const user_options_t* periodic_get_options(fclaw2d_global_t* glob)
 {
-    user_options_t* user = (user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }

--- a/applications/clawpack/advection/2d/replicated/replicated_options.c
+++ b/applications/clawpack/advection/2d/replicated/replicated_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "replicated_user.h"
-
-#include <fclaw_pointer_map.h>
 
 static void *
 replicated_register (user_options_t *user_opt, sc_options_t * opt)
@@ -152,16 +150,12 @@ user_options_t* replicated_options_register (fclaw_app_t * app,
 
 void replicated_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const user_options_t* replicated_get_options(fclaw2d_global_t* glob)
 {
-    user_options_t* user = (user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }
 
 void replicated_global_post_process(fclaw_options_t *fclaw_opt, 

--- a/applications/clawpack/advection/2d/slotted_disk/slotted_disk_options.c
+++ b/applications/clawpack/advection/2d/slotted_disk/slotted_disk_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "slotted_disk_user.h"
-
-#include <fclaw_pointer_map.h>
 
 static void *
 slotted_disk_register (user_options_t* user, sc_options_t * opt)
@@ -158,16 +156,12 @@ user_options_t* slotted_disk_options_register (fclaw_app_t * app,
 
 void slotted_disk_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const user_options_t* slotted_disk_get_options(fclaw2d_global_t* glob)
 {
-    user_options_t* user = (user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }
 /* ------------------------- ... and here ---------------------------- */
 

--- a/applications/clawpack/advection/2d/sphere/sphere_options.c
+++ b/applications/clawpack/advection/2d/sphere/sphere_options.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+  Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@
 */
 
 #include "sphere_user.h"
-
-#include <fclaw_pointer_map.h>
 
 static void *
     sphere_register (user_options_t* user , sc_options_t * opt)
@@ -164,15 +162,11 @@ user_options_t* sphere_options_register (fclaw_app_t * app,
 
 void sphere_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const user_options_t* sphere_get_options(fclaw2d_global_t* glob)
 {
-    user_options_t* user = (user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }
 

--- a/applications/clawpack/advection/2d/swirl/swirl_options.c
+++ b/applications/clawpack/advection/2d/swirl/swirl_options.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+  Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@
 */
 
 #include "swirl_user.h"
-
-#include <fclaw_pointer_map.h>
 
 static void *
 swirl_register (user_options_t *user, sc_options_t * opt)
@@ -154,14 +152,10 @@ user_options_t* swirl_options_register (fclaw_app_t * app,
 
 void swirl_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const user_options_t* swirl_get_options(fclaw2d_global_t* glob)
 {
-    user_options_t* user = (user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }

--- a/applications/clawpack/advection/2d/swirl_rays/swirl_options.c
+++ b/applications/clawpack/advection/2d/swirl_rays/swirl_options.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+  Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@
 */
 
 #include "swirl_user.h"
-
-#include <fclaw_pointer_map.h>
 
 static void *
 swirl_register (user_options_t *user, sc_options_t * opt)
@@ -154,14 +152,10 @@ user_options_t* swirl_options_register (fclaw_app_t * app,
 
 void swirl_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const user_options_t* swirl_get_options(fclaw2d_global_t* glob)
 {
-    user_options_t* user = (user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }

--- a/applications/clawpack/advection/2d/torus/torus_options.c
+++ b/applications/clawpack/advection/2d/torus/torus_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "torus_user.h"
-
-#include <fclaw_pointer_map.h>
 
 static void *
 torus_register (user_options_t *user_opt, sc_options_t * opt)
@@ -173,15 +171,11 @@ user_options_t* torus_options_register (fclaw_app_t * app,
 
 void torus_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const user_options_t* torus_get_options(fclaw2d_global_t* glob)
 {
-    user_options_t* user = (user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }
 

--- a/applications/clawpack/advection/3d/disk/disk_options.c
+++ b/applications/clawpack/advection/3d/disk/disk_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,11 +24,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "disk_user.h"
-
-#include <fclaw2d_clawpatch.h>
-#include <fclaw2d_clawpatch_options.h>
-
-static int s_user_options_package_id = -1;
 
 static void *
 disk_register (user_options_t *user_opt, sc_options_t * opt)
@@ -168,15 +163,12 @@ user_options_t* disk_options_register (fclaw_app_t * app,
 
 void disk_options_store (fclaw2d_global_t* glob, user_options_t* user_opt)
 {
-    FCLAW_ASSERT(s_user_options_package_id == -1);
-    int id = fclaw_package_container_add_pkg(glob,user_opt);
-    s_user_options_package_id = id;
+    fclaw2d_global_options_store(glob, "user", user_opt);
 }
 
 const user_options_t* disk_get_options(fclaw2d_global_t* glob)
 {
-    int id = s_user_options_package_id;
-    return (user_options_t*) fclaw_package_get_options(glob, id);    
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }
 
 void disk_global_post_process(fclaw_options_t *fclaw_opt,

--- a/applications/clawpack/advection/3d/filament/filament_options.c
+++ b/applications/clawpack/advection/3d/filament/filament_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,10 +24,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "filament_user.h"
-
-#include <fclaw2d_clawpatch_options.h>
-
-#include <fclaw_pointer_map.h>
 
 static void *
 filament_register (user_options_t *user, sc_options_t * opt)
@@ -174,14 +170,10 @@ user_options_t* filament_options_register (fclaw_app_t * app,
 
 void filament_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const user_options_t* filament_get_options(fclaw2d_global_t* glob)
 {
-    user_options_t* user = (user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }

--- a/applications/clawpack/advection/3d/latlong/latlong_options.c
+++ b/applications/clawpack/advection/3d/latlong/latlong_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012 Carsten Burstedde, Donna Calhoun
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "latlong_user.h"
-
-static int s_user_options_package_id = -1;
 
 static void *
 latlong_register (user_options_t *user, sc_options_t * opt)
@@ -176,16 +174,12 @@ user_options_t*  latlong_options_register (fclaw_app_t * app,
 
 void latlong_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(s_user_options_package_id == -1);
-    int id = fclaw_package_container_add_pkg(glob,user);
-    s_user_options_package_id = id;
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const user_options_t* latlong_get_options(fclaw2d_global_t* glob)
 {
-    int id = s_user_options_package_id;
-    return (user_options_t*) 
-            fclaw_package_get_options(glob, id);
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }
 
 

--- a/applications/clawpack/advection/3d/sphere/sphere_options.c
+++ b/applications/clawpack/advection/3d/sphere/sphere_options.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2012 Carsten Burstedde, Donna Calhoun
+  Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@
 */
 
 #include "sphere_user.h"
-
-static int s_user_options_package_id = -1;
 
 static void *
     sphere_register (user_options_t* user , sc_options_t * opt)
@@ -162,14 +160,11 @@ user_options_t* sphere_options_register (fclaw_app_t * app,
 
 void sphere_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(s_user_options_package_id == -1);
-    int id = fclaw_package_container_add_pkg(glob,user);
-    s_user_options_package_id = id;
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const user_options_t* sphere_get_options(fclaw2d_global_t* glob)
 {
-    int id = s_user_options_package_id;
-    return (user_options_t*) fclaw_package_get_options(glob, id);    
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }
 

--- a/applications/clawpack/advection/3d/swirl/swirl_options.c
+++ b/applications/clawpack/advection/3d/swirl/swirl_options.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+  Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@
 */
 
 #include "swirl_user.h"
-
-#include <fclaw_pointer_map.h>
 
 static void *
 swirl_register (user_options_t *user, sc_options_t * opt)
@@ -170,14 +168,10 @@ user_options_t* swirl_options_register (fclaw_app_t * app,
 
 void swirl_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const user_options_t* swirl_get_options(fclaw2d_global_t* glob)
 {
-    user_options_t* user = (user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }

--- a/applications/clawpack/burgers/2d/pwconst/pwconst_options.c
+++ b/applications/clawpack/burgers/2d/pwconst/pwconst_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "pwconst_user.h"
-
-#include <fclaw_pointer_map.h>
 
 static void *
 pwconst_register (user_options_t *user, sc_options_t * opt)
@@ -102,15 +100,11 @@ user_options_t* pwconst_options_register (fclaw_app_t * app,
 
 void pwconst_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const user_options_t* pwconst_get_options(fclaw2d_global_t* glob)
 {
-    user_options_t* user = (user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }
 

--- a/applications/clawpack/euler/2d/quadrants/quadrants_options.c
+++ b/applications/clawpack/euler/2d/quadrants/quadrants_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,11 +24,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "quadrants_user.h"
-
-#include <fclaw2d_clawpatch.h>
-#include <fclaw2d_clawpatch_options.h>
-
-#include <fclaw_pointer_map.h>
 
 static void *
 quadrants_register (user_options_t *user, sc_options_t * opt)
@@ -106,15 +101,11 @@ user_options_t* quadrants_options_register (fclaw_app_t * app,
 
 void quadrants_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 user_options_t* quadrants_get_options(fclaw2d_global_t* glob)
 {
-    user_options_t* user = (user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }
 

--- a/applications/clawpack/euler/2d/shockbubble/shockbubble_options.c
+++ b/applications/clawpack/euler/2d/shockbubble/shockbubble_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "shockbubble_user.h"
-
-#include <fclaw_pointer_map.h>
 
 static void *
 shockbubble_register (user_options_t* user, sc_options_t * opt)
@@ -113,16 +111,12 @@ user_options_t* shockbubble_options_register (fclaw_app_t * app,
 
 void shockbubble_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 user_options_t* shockbubble_get_options(fclaw2d_global_t* glob)
 {
-    user_options_t* user = (user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }
 
 

--- a/applications/clawpack/euler/3d/overpressure/overpressure_options.c
+++ b/applications/clawpack/euler/3d/overpressure/overpressure_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "overpressure_user.h"
-
-#include <fclaw_pointer_map.h>
 
 static void *
 overpressure_register (user_options_t* user, sc_options_t * opt)
@@ -199,16 +197,12 @@ user_options_t* overpressure_options_register (fclaw_app_t * app,
 
 void overpressure_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 user_options_t* overpressure_get_options(fclaw2d_global_t* glob)
 {
-    user_options_t* user = (user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }
 
 

--- a/applications/clawpack/shallow/2d/bump/bump_options.c
+++ b/applications/clawpack/shallow/2d/bump/bump_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "bump_user.h"
-
-#include <fclaw_pointer_map.h>
 
 static void *
 bump_register (user_options_t* user, sc_options_t * opt)
@@ -129,15 +127,11 @@ user_options_t* bump_options_register (fclaw_app_t * app,
 
 void bump_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 user_options_t* bump_get_options(fclaw2d_global_t* glob)
 {
-    user_options_t* user = (user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }
 

--- a/applications/clawpack/shallow/2d/radialdam/radialdam_options.c
+++ b/applications/clawpack/shallow/2d/radialdam/radialdam_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,10 +24,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "radialdam_user.h"
-
-#include <fclaw_pointer_map.h>
-#include <fclaw2d_clawpatch.h>
-#include <fclaw2d_clawpatch_options.h>
 
 static void *
 radialdam_register (user_options_t* user, sc_options_t * opt)
@@ -141,16 +137,12 @@ user_options_t* radialdam_options_register (fclaw_app_t * app,
 
 void radialdam_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 user_options_t* radialdam_get_options(fclaw2d_global_t* glob)
 {
-    user_options_t* user = (user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }
 
 void radialdam_global_post_process(fclaw_options_t *fclaw_opt,

--- a/applications/clawpack/transport/2d/sphere/sphere_options.c
+++ b/applications/clawpack/transport/2d/sphere/sphere_options.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+  Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -24,11 +24,6 @@
 */
 
 #include "sphere_user.h"
-
-#include <fclaw_options.h>
-
-
-#include <fclaw_pointer_map.h>
 
 static void *
 sphere_register (user_options_t *user, sc_options_t * opt)
@@ -165,14 +160,10 @@ user_options_t* sphere_options_register (fclaw_app_t * app,
 
 void sphere_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const user_options_t* sphere_get_options(fclaw2d_global_t* glob)
 {
-    user_options_t* user = (user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }

--- a/applications/clawpack/transport/2d/square/square_options.c
+++ b/applications/clawpack/transport/2d/square/square_options.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+  Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -24,11 +24,6 @@
 */
 
 #include "square_user.h"
-
-#include <fclaw_options.h>
-
-
-#include <fclaw_pointer_map.h>
 
 static void *
 square_register (user_options_t *user, sc_options_t * opt)
@@ -178,14 +173,10 @@ user_options_t* square_options_register (fclaw_app_t * app,
 
 void square_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const user_options_t* square_get_options(fclaw2d_global_t* glob)
 {
-    user_options_t* user = (user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }

--- a/applications/clawpack/transport/2d/torus/torus_options.c
+++ b/applications/clawpack/transport/2d/torus/torus_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "torus_user.h"
-
-#include <fclaw_pointer_map.h>
 
 static void *
 torus_register (user_options_t *user_opt, sc_options_t * opt)
@@ -173,15 +171,11 @@ user_options_t* torus_options_register (fclaw_app_t * app,
 
 void torus_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const user_options_t* torus_get_options(fclaw2d_global_t* glob)
 {
-    user_options_t* user = (user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }
 

--- a/applications/elliptic/allencahn/allencahn_options.c
+++ b/applications/elliptic/allencahn/allencahn_options.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2019-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton, Grady Wright
+  Copyright (c) 2019-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton, Grady Wright
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@
 */
 
 #include "allencahn_user.h"
-
-#include <fclaw_pointer_map.h>
 
 static void *
 allencahn_register (allencahn_options_t *user, sc_options_t * opt)
@@ -208,14 +206,10 @@ allencahn_options_t* allencahn_options_register (fclaw_app_t * app,
 
 void allencahn_options_store (fclaw2d_global_t* glob, allencahn_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const allencahn_options_t* allencahn_get_options(fclaw2d_global_t* glob)
 {
-    allencahn_options_t* user = (allencahn_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;
+    return (allencahn_options_t*) fclaw2d_global_get_options(glob, "user");
 }

--- a/applications/elliptic/heat/heat_options.c
+++ b/applications/elliptic/heat/heat_options.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2019-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton, Grady Wright
+  Copyright (c) 2019-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton, Grady Wright
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@
 */
 
 #include "heat_user.h"
-
-#include <fclaw_pointer_map.h>
 
 static void *
 heat_register (heat_options_t *user, sc_options_t * opt)
@@ -218,14 +216,10 @@ heat_options_t* heat_options_register (fclaw_app_t * app,
 
 void heat_options_store (fclaw2d_global_t* glob, heat_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const heat_options_t* heat_get_options(fclaw2d_global_t* glob)
 {
-    heat_options_t* user = (heat_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (heat_options_t*) fclaw2d_global_get_options(glob, "user");
 }

--- a/applications/elliptic/heat_phasefield/heat/heat_options.c
+++ b/applications/elliptic/heat_phasefield/heat/heat_options.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2019-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton, Grady Wright
+  Copyright (c) 2019-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton, Grady Wright
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@
 */
 
 #include "heat_user.h"
-
-#include <fclaw_pointer_map.h>
 
 static void *
 heat_register (heat_options_t *user, sc_options_t * opt)
@@ -218,14 +216,10 @@ heat_options_t* heat_options_register (fclaw_app_t * app,
 
 void heat_options_store (fclaw2d_global_t* glob, heat_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"heat-user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "heat-user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const heat_options_t* heat_get_options(fclaw2d_global_t* glob)
 {
-    heat_options_t* user = (heat_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "heat-user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (heat_options_t*) fclaw2d_global_get_options(glob, "user");
 }

--- a/applications/elliptic/heat_phasefield/phasefield/phasefield_options.c
+++ b/applications/elliptic/heat_phasefield/phasefield/phasefield_options.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2019-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton, Grady Wright
+  Copyright (c) 2019-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton, Grady Wright
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@
 */
 
 #include "phasefield_user.h"
-
-#include <fclaw_pointer_map.h>
 
 static void *
 phasefield_register (phasefield_options_t *user, sc_options_t * opt)
@@ -190,14 +188,10 @@ phasefield_options_t* phasefield_options_register (fclaw_app_t * app,
 
 void phasefield_options_store (fclaw2d_global_t* glob, phasefield_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"phasefield-user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "phasefield-user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const phasefield_options_t* phasefield_get_options(fclaw2d_global_t* glob)
 {
-    phasefield_options_t* user = (phasefield_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "phasefield-user");
-    FCLAW_ASSERT(user != NULL);
-    return user;
+    return (phasefield_options_t*) fclaw2d_global_get_options(glob, "user");
 }

--- a/applications/elliptic/phasefield/phasefield_options.c
+++ b/applications/elliptic/phasefield/phasefield_options.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2019-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton, Grady Wright
+  Copyright (c) 2019-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton, Grady Wright
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@
 */
 
 #include "phasefield_user.h"
-
-#include <fclaw_pointer_map.h>
 
 static void *
 phasefield_register (phasefield_options_t *user, sc_options_t * opt)
@@ -190,14 +188,10 @@ phasefield_options_t* phasefield_options_register (fclaw_app_t * app,
 
 void phasefield_options_store (fclaw2d_global_t* glob, phasefield_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const phasefield_options_t* phasefield_get_options(fclaw2d_global_t* glob)
 {
-    phasefield_options_t* user = (phasefield_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;
+    return (phasefield_options_t*) fclaw2d_global_get_options(glob, "user");
 }

--- a/applications/elliptic/poisson/poisson_options.c
+++ b/applications/elliptic/poisson/poisson_options.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2019-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton, Grady Wright
+  Copyright (c) 2019-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton, Grady Wright
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@
 */
 
 #include "poisson_user.h"
-
-#include <fclaw_pointer_map.h>
 
 static void *
 poisson_register (poisson_options_t *user, sc_options_t * opt)
@@ -218,14 +216,10 @@ poisson_options_t* poisson_options_register (fclaw_app_t * app,
 
 void poisson_options_store (fclaw2d_global_t* glob, poisson_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const poisson_options_t* poisson_get_options(fclaw2d_global_t* glob)
 {
-    poisson_options_t* user = (poisson_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;
+    return (poisson_options_t*) fclaw2d_global_get_options(glob, "user");
 }

--- a/applications/geoclaw/bowl_radial_slosh/radial/radial_options.c
+++ b/applications/geoclaw/bowl_radial_slosh/radial/radial_options.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+  Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@
 */
 
 #include "radial_user.h"
-
-#include <fclaw_pointer_map.h>
 
 static void *
 radial_register (radial_user_options_t *user, sc_options_t * opt)
@@ -97,15 +95,11 @@ radial_user_options_t* radial_options_register (fclaw_app_t * app,
 
 void radial_options_store (fclaw2d_global_t* glob, radial_user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"radial-user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "radial-user", user, NULL);
+    fclaw2d_global_options_store(glob, "radial-user", user);
 }
 
 radial_user_options_t* radial_get_options(fclaw2d_global_t* glob)
 {
-    radial_user_options_t* user = (radial_user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "radial-user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (radial_user_options_t*) fclaw2d_global_get_options(glob, "radial-user");
 }
 

--- a/applications/geoclaw/bowl_radial_slosh/slosh/slosh_options.c
+++ b/applications/geoclaw/bowl_radial_slosh/slosh/slosh_options.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+  Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@
 */
 
 #include "slosh_user.h"
-
-#include <fclaw_pointer_map.h>
 
 static void *
 slosh_register (slosh_user_options_t *user, sc_options_t * opt)
@@ -97,15 +95,11 @@ slosh_user_options_t* slosh_options_register (fclaw_app_t * app,
 
 void slosh_options_store (fclaw2d_global_t* glob, slosh_user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"slosh-user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "slosh-user", user, NULL);
+    fclaw2d_global_options_store(glob, "slosh-user", user);
 }
 
 slosh_user_options_t* slosh_get_options(fclaw2d_global_t* glob)
 {
-    slosh_user_options_t* user = (slosh_user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "slosh-user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (slosh_user_options_t*) fclaw2d_global_get_options(glob, "slosh-user");
 }
 

--- a/applications/geoclaw/bowl_slosh/slosh_options.c
+++ b/applications/geoclaw/bowl_slosh/slosh_options.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+  Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -24,8 +24,6 @@
 */
 
 #include "slosh_user.h"
-
-#include <fclaw_pointer_map.h>
 
 static void *
 slosh_register (user_options_t *user, sc_options_t * opt)
@@ -99,15 +97,11 @@ user_options_t* slosh_options_register (fclaw_app_t * app,
 
 void slosh_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 user_options_t* slosh_get_options(fclaw2d_global_t* glob)
 {
-    user_options_t* user = (user_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "user");
-    FCLAW_ASSERT(user != NULL);
-    return user;   
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }
 

--- a/applications/metric/2d/mesh/mesh.cpp
+++ b/applications/metric/2d/mesh/mesh.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+  Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -26,8 +26,6 @@
 #include "mesh_user.h"
 
 #include <fclaw2d_forestclaw.h>
-
-static int s_user_package_id = -1;
 
 static void *
 options_register_user (fclaw_app_t * app, void *package, sc_options_t * opt)
@@ -73,16 +71,12 @@ void register_user_options (fclaw_app_t * app,
 static 
 void user_set_options (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(s_user_package_id == -1);
-    int id = fclaw_package_container_add_pkg(glob,user);
-    s_user_package_id = id;
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const user_options_t* mesh_user_get_options(fclaw2d_global_t* glob)
 {
-    int id = s_user_package_id;
-    return (user_options_t*) 
-            fclaw_package_get_options(glob, id);    
+    return (user_options_t*) fclaw2d_global_get_options(glob, "user");
 }
 
 static

--- a/applications/paper/annulus/annulus_options.c
+++ b/applications/paper/annulus/annulus_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -189,14 +189,11 @@ user_options_t* annulus_options_register (fclaw_app_t * app,
 
 void annulus_options_store (fclaw2d_global_t* glob, user_options_t* user)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"user") == NULL);
-    fclaw_pointer_map_insert(glob->options, "user", user, NULL);
+    fclaw2d_global_options_store(glob, "user", user);
 }
 
 const user_options_t* annulus_get_options(fclaw2d_global_t* glob)
 {
-    int id = s_user_options_package_id;
-    return (user_options_t*) 
-            fclaw_package_get_options(glob, id);
+    return (user_options_t*) fclaw_pointer_map_get(glob->options,"user");
 }
 

--- a/src/fclaw2d_global.c
+++ b/src/fclaw2d_global.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -230,6 +230,21 @@ void fclaw2d_global_iterate_partitioned (fclaw2d_global_t * glob,
     g.glob = glob;
     g.user = user;
     fclaw2d_domain_iterate_partitioned (glob->domain,new_domain,tcb,&g);
+}
+
+void fclaw2d_global_options_store (fclaw2d_global_t* glob, const char* key, void* options)
+{
+    
+    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,key) == NULL);
+    fclaw_pointer_map_insert(glob->options, key, options, NULL);
+}
+
+void* fclaw2d_global_get_options (fclaw2d_global_t* glob, const char* key)
+{
+    
+    void* options = fclaw_pointer_map_get(glob->options, key);
+    FCLAW_ASSERT(options != NULL);
+    return options;   
 }
 
 static fclaw2d_global_t* fclaw2d_global_glob = NULL;

--- a/src/fclaw2d_global.h
+++ b/src/fclaw2d_global.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -148,6 +148,24 @@ void fclaw2d_global_iterate_partitioned (fclaw2d_global_t * glob,
                                          struct fclaw2d_domain * new_domain,
                                          fclaw2d_transfer_callback_t tcb,
                                          void *user);
+
+/**
+ * @brief Store an options structure in the glob
+ * 
+ * @param glob the global context
+ * @param key the key to store the options under
+ * @param options the options structure
+ */
+void fclaw2d_global_options_store (fclaw2d_global_t* glob, const char* key, void* options);
+
+/**
+ * @brief Get an options structure from the glob
+ * 
+ * @param glob the global context
+ * @param key the key to retrieve the options from
+ * @return void* the options
+ */
+void* fclaw2d_global_get_options (fclaw2d_global_t* glob, const char* key);
 
 /**
  * @brief Store a glob variable in static memory

--- a/src/fclaw2d_global.h.TEST.cpp
+++ b/src/fclaw2d_global.h.TEST.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -26,23 +26,58 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <fclaw2d_global.h>
 #include <test.hpp>
 
+TEST_CASE("fclaw2d_global_options_store and fclaw2d_global_get_options test") {
+    fclaw2d_global_t* glob = fclaw2d_global_new();
+
+    // Test with an integer
+    int option1 = 10;
+    const char* key1 = "option1";
+    fclaw2d_global_options_store(glob, key1, &option1);
+
+    int* retrieved_option1 = static_cast<int*>(fclaw2d_global_get_options(glob, key1));
+    CHECK_EQ(*retrieved_option1, option1);
+
+    // Test with a string
+    const char* option2 = "Test string";
+    const char* key2 = "option2";
+    fclaw2d_global_options_store(glob, key2, &option2);
+
+    const char** retrieved_option2 = static_cast<const char**>(fclaw2d_global_get_options(glob, key2));
+    CHECK_EQ(retrieved_option2, &option2);
+
+#ifdef FCLAW_ENABLE_DEBUG
+    // TEST inserting twice
+    CHECK_SC_ABORTED(fclaw2d_global_options_store(glob, key2, &option2));
+#endif
+    // Test with a non-existing key
+    const char* key3 = "non-existing key";
+#ifdef FCLAW_ENABLE_DEBUG
+    CHECK_SC_ABORTED(fclaw2d_global_get_options(glob, key3));
+#else
+    void* retrieved_option3 = fclaw2d_global_get_options(glob, key3);
+    CHECK_EQ(retrieved_option3, nullptr);
+#endif
+
+    fclaw2d_global_destroy(glob);
+}
+
 TEST_CASE("fclaw2d_global_set_global")
 {
-	fclaw2d_global_t* glob = (fclaw2d_global_t*)123;
-	fclaw2d_global_set_global(glob);
-	CHECK_EQ(fclaw2d_global_get_global(), glob);
-	fclaw2d_global_unset_global();
+    fclaw2d_global_t* glob = (fclaw2d_global_t*)123;
+    fclaw2d_global_set_global(glob);
+    CHECK_EQ(fclaw2d_global_get_global(), glob);
+    fclaw2d_global_unset_global();
 }
 
 TEST_CASE("fclaw2d_global_unset_global")
 {
-	fclaw2d_global_t* glob = (fclaw2d_global_t*)123;
-	fclaw2d_global_set_global(glob);
-	fclaw2d_global_unset_global();
+    fclaw2d_global_t* glob = (fclaw2d_global_t*)123;
+    fclaw2d_global_set_global(glob);
+    fclaw2d_global_unset_global();
 #ifdef FCLAW_ENABLE_DEBUG
-	CHECK_SC_ABORTED(fclaw2d_global_get_global());
+    CHECK_SC_ABORTED(fclaw2d_global_get_global());
 #else
-	CHECK_EQ(fclaw2d_global_get_global(), nullptr);
+    CHECK_EQ(fclaw2d_global_get_global(), nullptr);
 #endif
 }
 
@@ -50,20 +85,20 @@ TEST_CASE("fclaw2d_global_unset_global")
 
 TEST_CASE("fclaw2d_global_set_global twice fails")
 {
-	fclaw2d_global_t* glob = (fclaw2d_global_t*)123;
-	fclaw2d_global_set_global(glob);
-	CHECK_SC_ABORTED(fclaw2d_global_set_global(glob));
-	fclaw2d_global_unset_global();
+    fclaw2d_global_t* glob = (fclaw2d_global_t*)123;
+    fclaw2d_global_set_global(glob);
+    CHECK_SC_ABORTED(fclaw2d_global_set_global(glob));
+    fclaw2d_global_unset_global();
 }
 
 TEST_CASE("fclaw2d_global_unset_global assert fails when NULL")
 {
-	CHECK_SC_ABORTED(fclaw2d_global_unset_global());
+    CHECK_SC_ABORTED(fclaw2d_global_unset_global());
 }
 
 TEST_CASE("fclaw2d_global_get_global assert fails when NULL")
 {
-	CHECK_SC_ABORTED(fclaw2d_global_get_global());
+    CHECK_SC_ABORTED(fclaw2d_global_get_global());
 }
 
 #endif

--- a/src/fclaw2d_options.c
+++ b/src/fclaw2d_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -26,7 +26,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <fclaw2d_options.h>
 #include <fclaw2d_global.h>
 #include <fclaw_base.h>
-#include <fclaw_pointer_map.h>
 
 /* ---------------------------------------------------------
    Public interface to ForestClaw options
@@ -34,15 +33,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 void fclaw2d_options_store (fclaw2d_global_t *glob, fclaw_options_t* gparms)
 {
-	FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"fclaw2d") == NULL);
-	fclaw_pointer_map_insert(glob->options, "fclaw2d", gparms, NULL);
+    fclaw2d_global_options_store(glob, "fclaw2d", gparms);
 }
 
 fclaw_options_t* fclaw2d_get_options(fclaw2d_global_t* glob)
 {
-    fclaw_options_t* gparms = (fclaw_options_t*) 
-	   							fclaw_pointer_map_get(glob->options, "fclaw2d");
-	FCLAW_ASSERT(gparms != NULL);
-	return gparms;
+    return (fclaw_options_t*) fclaw2d_global_get_options(glob, "fclaw2d");
 }
 

--- a/src/fclaw2d_to_3d.h
+++ b/src/fclaw2d_to_3d.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012 Carsten Burstedde, Donna Calhoun
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -168,6 +168,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define fclaw2d_global_iterate_adapted  fclaw3d_global_iterate_adapted
 #define fclaw2d_global_iterate_level_mthread fclaw3d_global_iterate_level_mthread
 #define fclaw2d_global_iterate_partitioned fclaw3d_global_iterate_partitioned
+#define fclaw2d_global_options_store    fclaw3d_global_options_store
+#define fclaw2d_global_get_options      fclaw3d_global_get_options
 #define fclaw2d_global_set_global       fclaw3d_global_set_global
 #define fclaw2d_global_unset_global     fclaw3d_global_unset_global
 #define fclaw2d_global_get_global       fclaw3d_global_get_global

--- a/src/fclaw3d_global.h
+++ b/src/fclaw3d_global.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012 Carsten Burstedde, Donna Calhoun
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -136,6 +136,23 @@ void fclaw3d_global_iterate_partitioned (fclaw3d_global_t * glob,
                                          struct fclaw3d_domain * new_domain,
                                          fclaw3d_transfer_callback_t tcb,
                                          void *user);
+/**
+ * @brief Store an options structure in the glob
+ * 
+ * @param glob the global context
+ * @param key the key to store the options under
+ * @param options the options structure
+ */
+void fclaw3d_global_options_store (fclaw3d_global_t* glob, const char* key, void* options);
+
+/**
+ * @brief Get an options structure from the glob
+ * 
+ * @param glob the global context
+ * @param key the key to retrieve the options from
+ * @return void* the options
+ */
+void* fclaw3d_global_get_options (fclaw3d_global_t* glob, const char* key);
 
 /**
  * @brief Store a glob variable in static memory

--- a/src/patches/clawpatch/fclaw2d_clawpatch_options.c
+++ b/src/patches/clawpatch/fclaw2d_clawpatch_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -46,7 +46,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #endif
 #include <fclaw2d_global.h>
-#include <fclaw_pointer_map.h>
 
 static void *
 clawpatch_register(fclaw2d_clawpatch_options_t *clawpatch_options,
@@ -261,15 +260,12 @@ void
 fclaw2d_clawpatch_options_store (fclaw2d_global_t *glob, 
                                  fclaw2d_clawpatch_options_t* clawpatch_options)
 {
-	FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,CLAWPATCH_OPTION_NAME) == NULL);
-	fclaw_pointer_map_insert(glob->options, CLAWPATCH_OPTION_NAME, clawpatch_options, NULL);
+    fclaw2d_global_options_store(glob, CLAWPATCH_OPTION_NAME, clawpatch_options);
 }
 
 fclaw2d_clawpatch_options_t* 
 fclaw2d_clawpatch_get_options(fclaw2d_global_t* glob)
 {
-    fclaw2d_clawpatch_options_t* clawptch_options = (fclaw2d_clawpatch_options_t*) 
-	   							fclaw_pointer_map_get(glob->options, CLAWPATCH_OPTION_NAME);
-	FCLAW_ASSERT(clawptch_options != NULL);
-	return clawptch_options;
+    return (fclaw2d_clawpatch_options_t*) 
+            fclaw2d_global_get_options(glob, CLAWPATCH_OPTION_NAME);
 }

--- a/src/solvers/fc2d_clawpack4.6/fc2d_clawpack46_options.c
+++ b/src/solvers/fc2d_clawpack4.6/fc2d_clawpack46_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -28,7 +28,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <fclaw2d_clawpatch_options.h>
 #include <fclaw2d_global.h>
 #include <fclaw_options.h>
-#include <fclaw_pointer_map.h>
 
 static void*
 clawpack46_register (fc2d_clawpack46_options_t* clawopt, sc_options_t * opt)
@@ -202,14 +201,10 @@ fc2d_clawpack46_options_t*  fc2d_clawpack46_options_register (fclaw_app_t * app,
 
 fc2d_clawpack46_options_t* fc2d_clawpack46_get_options(fclaw2d_global_t *glob)
 {
-	fc2d_clawpack46_options_t* clawopt = (fc2d_clawpack46_options_t*) 
-	   							fclaw_pointer_map_get(glob->options, "fc2d_clawpack46");
-	FCLAW_ASSERT(clawopt != NULL);
-	return clawopt;
+    return (fc2d_clawpack46_options_t*) fclaw2d_global_get_options(glob, "fc2d_clawpack46");
 }
 
 void fc2d_clawpack46_options_store (fclaw2d_global_t* glob, fc2d_clawpack46_options_t* clawopt)
 {
-	FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"fc2d_clawpack46") == NULL);
-	fclaw_pointer_map_insert(glob->options, "fc2d_clawpack46", clawopt, NULL);
+    fclaw2d_global_options_store(glob, "fc2d_clawpack46", clawopt);
 }

--- a/src/solvers/fc2d_clawpack5/fc2d_clawpack5_options.c
+++ b/src/solvers/fc2d_clawpack5/fc2d_clawpack5_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -28,7 +28,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <fclaw2d_clawpatch_options.h>
 #include <fclaw2d_global.h>
 #include <fclaw_options.h>
-#include <fclaw_pointer_map.h>
 
 static void*
 clawpack5_register (fc2d_clawpack5_options_t* clawopt, sc_options_t * opt)
@@ -206,14 +205,10 @@ fc2d_clawpack5_options_t*  fc2d_clawpack5_options_register (fclaw_app_t * app,
 
 fc2d_clawpack5_options_t* fc2d_clawpack5_get_options(fclaw2d_global_t *glob)
 {
-	fc2d_clawpack5_options_t* clawopt = (fc2d_clawpack5_options_t*) 
-	   							fclaw_pointer_map_get(glob->options, "fc2d_clawpack5");
-	FCLAW_ASSERT(clawopt != NULL);
-	return clawopt;
+    return (fc2d_clawpack5_options_t*) fclaw2d_global_get_options(glob,"fc2d_clawpack5");
 }
 
 void fc2d_clawpack5_options_store (fclaw2d_global_t* glob, fc2d_clawpack5_options_t* clawopt)
 {
-	FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"fc2d_clawpack5") == NULL);
-	fclaw_pointer_map_insert(glob->options, "fc2d_clawpack5", clawopt, NULL);
+    fclaw2d_global_options_store(glob,"fc2d_clawpack5",clawopt);
 }

--- a/src/solvers/fc2d_cudaclaw5/fc2d_cudaclaw5_options.c
+++ b/src/solvers/fc2d_cudaclaw5/fc2d_cudaclaw5_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012 Carsten Burstedde, Donna Calhoun
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -28,9 +28,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <fclaw2d_clawpatch_options.h>
 #include <fclaw2d_global.h>
 #include <fclaw_options.h>
-#include <fclaw_package.h>
-
-static int s_cudaclaw5_options_package_id = -1;
 
 static void*
 cudaclaw5_register (fc2d_cudaclaw5_options_t* clawopt, sc_options_t * opt)
@@ -236,12 +233,10 @@ fc2d_cudaclaw5_options_t*  fc2d_cudaclaw5_options_register (fclaw_app_t * app,
 
 fc2d_cudaclaw5_options_t* fc2d_cudaclaw5_get_options(fclaw2d_global_t *glob)
 {
-    int id = s_cudaclaw5_options_package_id;
-    return (fc2d_cudaclaw5_options_t*) fclaw_package_get_options(glob,id);
+    return (fc2d_cudaclaw5_options_t*) fclaw2d_global_get_options(glob, "cudaclaw5");
 }
 
 void fc2d_cudaclaw5_options_store (fclaw2d_global_t* glob, fc2d_cudaclaw5_options_t* clawopt)
 {
-    int id = fclaw_package_container_add_pkg(glob,clawopt);
-    s_cudaclaw5_options_package_id = id;
+    fclaw2d_global_options_store(glob, "cudaclaw5", clawopt);
 }

--- a/src/solvers/fc2d_geoclaw/fc2d_geoclaw_options.c
+++ b/src/solvers/fc2d_geoclaw/fc2d_geoclaw_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -25,7 +25,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "fc2d_geoclaw_options.h"
 #include <fclaw_options.h>
-#include <fclaw_pointer_map.h>
 
 #include <fclaw2d_clawpatch_options.h>
 #include <fclaw2d_global.h>
@@ -232,17 +231,13 @@ fc2d_geoclaw_options_register (fclaw_app_t * app,
 
 fc2d_geoclaw_options_t* fc2d_geoclaw_get_options(fclaw2d_global_t *glob)
 {
-    fc2d_geoclaw_options_t* geo_opt = (fc2d_geoclaw_options_t*) 
-	   							fclaw_pointer_map_get(glob->options, "fc2d_geoclaw");
-	FCLAW_ASSERT(geo_opt != NULL);
-	return geo_opt;
+    return (fc2d_geoclaw_options_t*) fclaw2d_global_get_options(glob, "fc2d_geoclaw");
 }
 
 void fc2d_geoclaw_options_store (fclaw2d_global_t* glob, 
                                fc2d_geoclaw_options_t* geo_opt)
 {
-	FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"fc2d_geoclaw") == NULL);
-	fclaw_pointer_map_insert(glob->options, "fc2d_geoclaw", geo_opt, NULL);
+    fclaw2d_global_options_store(glob, "fc2d_geoclaw", geo_opt);
 }
 
 

--- a/src/solvers/fc2d_thunderegg/fc2d_thunderegg_options.c
+++ b/src/solvers/fc2d_thunderegg/fc2d_thunderegg_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton, Grady Wright
+Copyright (c) 2019-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton, Grady Wright
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -25,10 +25,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "fc2d_thunderegg_options.h"
 
-#include <fclaw2d_clawpatch_options.h>
 #include <fclaw2d_global.h>
 #include <fclaw_options.h>
-#include <fclaw_pointer_map.h>
 
 static void*
 thunderegg_register (fc2d_thunderegg_options_t* mg_opt, sc_options_t * opt)
@@ -232,14 +230,10 @@ fc2d_thunderegg_options_t*  fc2d_thunderegg_options_register (fclaw_app_t * app,
 
 fc2d_thunderegg_options_t* fc2d_thunderegg_get_options(fclaw2d_global_t *glob)
 {
-    fc2d_thunderegg_options_t* user = (fc2d_thunderegg_options_t*) 
-                              fclaw_pointer_map_get(glob->options, "fc2d_thunderegg");
-    FCLAW_ASSERT(user != NULL);
-    return user;
+    return (fc2d_thunderegg_options_t*) fclaw2d_global_get_options(glob,"fc2d_thunderegg");
 }
 
 void fc2d_thunderegg_options_store (fclaw2d_global_t* glob, fc2d_thunderegg_options_t* mg_opt)
 {
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"fc2d_thunderegg") == NULL);
-    fclaw_pointer_map_insert(glob->options, "fc2d_thunderegg", mg_opt, NULL);
+    fclaw2d_global_options_store(glob, "fc2d_thunderegg", mg_opt);
 }

--- a/src/solvers/fc3d_clawpack46/fc3d_clawpack46_options.c
+++ b/src/solvers/fc3d_clawpack46/fc3d_clawpack46_options.c
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -28,7 +28,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <fclaw2d_clawpatch_options.h>
 #include <fclaw2d_global.h>
 #include <fclaw_options.h>
-#include <fclaw_pointer_map.h>
 
 static void*
 clawpack_register (fc3d_clawpack46_options_t* clawopt, sc_options_t * opt)
@@ -202,14 +201,10 @@ fc3d_clawpack46_options_t*  fc3d_clawpack46_options_register (fclaw_app_t * app,
 
 fc3d_clawpack46_options_t* fc3d_clawpack46_get_options(fclaw2d_global_t *glob)
 {
-    fc3d_clawpack46_options_t* clawopt = (fc3d_clawpack46_options_t*) 
-	   							fclaw_pointer_map_get(glob->options, "fc3d_clawpack46");
-	FCLAW_ASSERT(clawopt != NULL);
-	return clawopt;
+    return (fc3d_clawpack46_options_t*) fclaw2d_global_get_options(glob,"fc3d_clawpack46");
 }
 
 void fc3d_clawpack46_options_store (fclaw2d_global_t* glob, fc3d_clawpack46_options_t* clawopt)
 {
-	FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"fc3d_clawpack46") == NULL);
-	fclaw_pointer_map_insert(glob->options, "fc3d_clawpack46", clawopt, NULL);
+    fclaw2d_global_options_store(glob, "fc3d_clawpack46", clawopt);
 }

--- a/src/solvers/fc3d_clawpack5/fc3d_clawpack5.cpp
+++ b/src/solvers/fc3d_clawpack5/fc3d_clawpack5.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+Copyright (c) 2012-2023 Carsten Burstedde, Donna Calhoun, Scott Aiton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -31,8 +31,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "fc3d_clawpack5.h"
 #include "fc3d_clawpack5_options.h"
-
-static int s_clawpack5_package_id = -1;
 
 static fc3d_clawpack5_vtable_t classic_vt;
 // static fclaw2d_clawpatch_vtable_t clawpatch_vt;
@@ -127,8 +125,8 @@ void fc3d_clawpack5_set_vtable_defaults()
 
 fc3d_clawpack5_options_t* fc3d_clawpack5_get_options(fclaw2d_global_t *glob)
 {
-    int id = fc3d_clawpack5_get_package_id();
-    return (fc3d_clawpack5_options_t*) fclaw_package_get_options(glob,id);
+    return (fc3d_clawpack5_options_t*) fclaw2d_global_get_options(glob,
+                                                                  "fc3d_clawpack5");
 }
 
 /* -----------------------------------------------------------
@@ -156,13 +154,7 @@ void fc3d_clawpack5_register (fclaw_app_t* app, const char *configfile, fclaw2d_
 
 void fc3d_clawpack5_set_options (fclaw2d_global_t* glob, fc3d_clawpack5_options_t* clawopt)
 {
-    int id; 
-    /* Don't register a package more than once */
-    FCLAW_ASSERT(s_clawpack5_package_id == -1);
-
-    id = fclaw_package_container_add_pkg(glob,clawopt);
-
-    s_clawpack5_package_id = id;
+    fclaw2d_global_options_store(glob, "fc3d_clawpack5", clawopt);
 }
 
 void fc3d_clawpack5_aux_data(fclaw2d_global_t *glob,


### PR DESCRIPTION
Remove the use of deprecated package container and add `fclaw2d_global_options_store` and `fclaw2d_global_get_options` to `fclaw2d_global`. These functions simplifies the the storing of options so the options getter and setters go from looking like this:

```
void fclaw2d_options_store (fclaw2d_global_t *glob, fclaw_options_t* gparms)
{
    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,"fclaw2d") == NULL);
    fclaw_pointer_map_insert(glob->options, "fclaw2d", gparms, NULL);
}

fclaw_options_t* fclaw2d_get_options(fclaw2d_global_t* glob)
{
    fclaw_options_t* gparms = (fclaw_options_t*) 
                                 fclaw_pointer_map_get(glob->options, "fclaw2d");
    FCLAW_ASSERT(gparms != NULL);
    return gparms;
}
```

to this

```
void fclaw2d_options_store (fclaw2d_global_t *glob, fclaw_options_t* gparms)
{
    fclaw2d_global_options_store(glob, "fclaw2d", gparms);
}

fclaw_options_t* fclaw2d_get_options(fclaw2d_global_t* glob)
{
    return (fclaw_options_t*) fclaw2d_global_get_options(glob, "fclaw2d");
}
```
