### PR TITLE
Feature 3d

### DIFF
--- a/src/forestclaw2d.c
+++ b/src/forestclaw2d.c
@@ -1137,7 +1137,7 @@ fclaw2d_patch_transform_corner (fclaw2d_patch_t * ipatch,
 #endif
                                )
 {
-    double Rmx, xshift, yshift;
+    double Rmxmymz[P4EST_DIM], xshift, yshift;
 #ifdef P4_TO_P8
     double zshift;
 #endif
@@ -1153,9 +1153,9 @@ fclaw2d_patch_transform_corner (fclaw2d_patch_t * ipatch,
     FCLAW_ASSERT (opatch->zlower >= 0. && opatch->zlower < 1.);
 #endif
 
-    FCLAW_ASSERT (mx >= 1 && mx == my);
+    FCLAW_ASSERT (mx >= 1 && my >= 1);
 #ifdef P4_TO_P8
-    FCLAW_ASSERT (mx == mz);
+    FCLAW_ASSERT (mz >= 1);
 #endif
     FCLAW_ASSERT (based == 0 || based == 1);
 
@@ -1168,7 +1168,11 @@ fclaw2d_patch_transform_corner (fclaw2d_patch_t * ipatch,
 #endif
 
     /* Work with doubles -- exact for integers up to 52 bits of precision */
-    Rmx = (double) mx * (double) (1 << ipatch->level);
+    Rmxmymz[0] = (double) (1 << ipatch->level) * (double) mx;
+    Rmxmymz[1] = (double) (1 << ipatch->level) * (double) my;
+#ifdef P4_TO_P8
+    Rmxmymz[2] = (double) (1 << ipatch->level) * (double) mz;
+#endif
     if (!is_block_boundary)
     {
         /* The lower left coordinates are with respect to the same origin */
@@ -1216,10 +1220,10 @@ fclaw2d_patch_transform_corner (fclaw2d_patch_t * ipatch,
 
     /* The two patches are in the same block, or in a different block
      * that has a coordinate system with the same orientation */
-    *i += (int) ((ipatch->xlower - opatch->xlower + xshift) * Rmx);
-    *j += (int) ((ipatch->ylower - opatch->ylower + yshift) * Rmx);
+    *i += (int) ((ipatch->xlower - opatch->xlower + xshift) * Rmxmymz[0]);
+    *j += (int) ((ipatch->ylower - opatch->ylower + yshift) * Rmxmymz[1]);
 #ifdef P4_TO_P8
-    *k += (int) ((ipatch->zlower - opatch->zlower + zshift) * Rmx);
+    *k += (int) ((ipatch->zlower - opatch->zlower + zshift) * Rmxmymz[2]);
 #endif
 }
 
@@ -1243,7 +1247,7 @@ fclaw2d_patch_transform_corner2 (fclaw2d_patch_t * ipatch,
     int dk;
     double zshift;
 #endif
-    double Rmx, xshift, yshift;
+    double Rmxmymz[P4EST_DIM], xshift, yshift;
 
     FCLAW_ASSERT (ipatch->level + 1 == opatch->level);
     FCLAW_ASSERT (0 <= ipatch->level && opatch->level < P4EST_MAXLEVEL);
@@ -1256,9 +1260,9 @@ fclaw2d_patch_transform_corner2 (fclaw2d_patch_t * ipatch,
     FCLAW_ASSERT (opatch->zlower >= 0. && opatch->zlower < 1.);
 #endif
 
-    FCLAW_ASSERT (mx >= 1 && mx == my);
+    FCLAW_ASSERT (mx >= 1 && my >= 1);
 #ifdef P4_TO_P8
-    FCLAW_ASSERT (mx == mz);
+    FCLAW_ASSERT (mz >= 1);
 #endif
     FCLAW_ASSERT (based == 0 || based == 1);
 
@@ -1271,7 +1275,11 @@ fclaw2d_patch_transform_corner2 (fclaw2d_patch_t * ipatch,
 #endif
 
     /* work with doubles -- exact for integers up to 52 bits of precision */
-    Rmx = (double) mx * (double) (1 << opatch->level);
+    Rmxmymz[0] = (double) (1 << opatch->level) * (double) mx;
+    Rmxmymz[1] = (double) (1 << opatch->level) * (double) my;
+#ifdef P4_TO_P8
+    Rmxmymz[2] = (double) (1 << opatch->level) * (double) mz;
+#endif
     if (!is_block_boundary)
     {
         /* The lower left coordinates are with respect to the same origin */
@@ -1320,14 +1328,14 @@ fclaw2d_patch_transform_corner2 (fclaw2d_patch_t * ipatch,
     /* The two patches are in the same block, or in a different block
      * that has a coordinate system with the same orientation */
     di = based
-        + (int) ((ipatch->xlower - opatch->xlower + xshift) * Rmx +
+        + (int) ((ipatch->xlower - opatch->xlower + xshift) * Rmxmymz[0] +
                  2. * (*i - based));
     dj = based
-        + (int) ((ipatch->ylower - opatch->ylower + yshift) * Rmx +
+        + (int) ((ipatch->ylower - opatch->ylower + yshift) * Rmxmymz[1] +
                  2. * (*j - based));
 #ifdef P4_TO_P8
     dk = based
-        + (int) ((ipatch->zlower - opatch->zlower + zshift) * Rmx +
+        + (int) ((ipatch->zlower - opatch->zlower + zshift) * Rmxmymz[2] +
                  2. * (*k - based));
 #else
     ks = 0;

--- a/src/forestclaw2d.h
+++ b/src/forestclaw2d.h
@@ -588,15 +588,17 @@ int fclaw2d_patch_corner_neighbors (fclaw2d_domain_t * domain,
 void fclaw2d_patch_corner_swap (int *cornerno, int *rcornerno);
 
 /** Transform a patch coordinate into a neighbor patch's coordinate system.
- * This function assumes that the two patches are of the SAME size.
+ * This function assumes that the two patches are of the SAME size and that the
+ * patches lie in coordinate systems with the same orientation.
  * It is LEGAL to call this function for both local and ghost patches.
  * \param [in] ipatch       The patch that the input coordinates are relative to.
  * \param [in] opatch       The patch that the output coordinates are relative to.
  * \param [in] icorner      Corner number of this patch to transform across.
+ *                          This function assumes ocorner == icorner ^ 3, so
+ *                          ocorner is the opposite corner of icorner.
  * \param [in] is_block_boundary      Set to true for a block corner.
  * \param [in] mx           Number of cells along x direction of patch.
  * \param [in] my           Number of cells along y direction of patch.
- *                          This function assumes \a mx == \a my.
  * \param [in] based        Indices are 0-based for corners and 1-based for cells.
  * \param [in,out] i        Integer coordinate along x-axis in \a based .. \a mx.
  * \param [in,out] j        Integer coordinate along y-axis in \a based .. \a my.
@@ -608,15 +610,17 @@ void fclaw2d_patch_transform_corner (fclaw2d_patch_t * ipatch,
                                      int based, int *i, int *j);
 
 /** Transform a patch coordinate into a neighbor patch's coordinate system.
- * This function assumes that the neighbor patch is smaller (HALF size).
+ * This function assumes that the neighbor patch is smaller (HALF size) and that
+ * the patches lie in coordinate systems with the same orientation.
  * It is LEGAL to call this function for both local and ghost patches.
  * \param [in] ipatch       The patch that the input coordinates are relative to.
  * \param [in] opatch       The patch that the output coordinates are relative to.
  * \param [in] icorner      Corner number of this patch to transform across.
+ *                          This function assumes ocorner == icorner ^ 3, so
+ *                          ocorner is the opposite corner of icorner.
  * \param [in] is_block_boundary      Set to true for a block corner.
  * \param [in] mx           Number of cells along x direction of patch.
  * \param [in] my           Number of cells along y direction of patch.
- *                          This function assumes \a mx == \a my.
  * \param [in] based        Indices are 0-based for corners and 1-based for cells.
  * \param [in,out] i        FOUR (4) integer coordinates along x-axis in
  *                          \a based .. \a mx.  On input, only the first is used.

--- a/src/forestclaw3d.h
+++ b/src/forestclaw3d.h
@@ -640,17 +640,18 @@ int fclaw3d_patch_corner_neighbors (fclaw3d_domain_t * domain,
 void fclaw3d_patch_corner_swap (int *cornerno, int *rcornerno);
 
 /** Transform a patch coordinate into a neighbor patch's coordinate system.
- * This function assumes that the two patches are of the SAME size.
+ * This function assumes that the two patches are of the SAME size and that the
+ * patches lie in coordinate systems with the same orientation.
  * It is LEGAL to call this function for both local and ghost patches.
  * \param [in] ipatch       The patch that the input coordinates are relative to.
  * \param [in] opatch       The patch that the output coordinates are relative to.
  * \param [in] icorner      Corner number of this patch to transform across.
+ *                          This function assumes ocorner == icorner ^ 7, so
+ *                          ocorner is the opposite corner of icorner.
  * \param [in] is_block_boundary      Set to true for a block corner.
  * \param [in] mx           Number of cells along x direction of patch.
  * \param [in] my           Number of cells along y direction of patch.
- *                          This function assumes \a mx == \a my.
  * \param [in] mz           Number of cells along z direction of patch.
- *                          This function assumes \a mx == \a mz.
  * \param [in] based        Indices are 0-based for corners and 1-based for cells.
  * \param [in,out] i        Integer coordinate along x-axis in \a based .. \a mx.
  * \param [in,out] j        Integer coordinate along y-axis in \a based .. \a my.
@@ -663,17 +664,18 @@ void fclaw3d_patch_transform_corner (fclaw3d_patch_t * ipatch,
                                      int based, int *i, int *j, int *k);
 
 /** Transform a patch coordinate into a neighbor patch's coordinate system.
- * This function assumes that the neighbor patch is smaller (HALF size).
+ * This function assumes that the neighbor patch is smaller (HALF size) and that
+ * the patches lie in coordinate systems with the same orientation.
  * It is LEGAL to call this function for both local and ghost patches.
  * \param [in] ipatch       The patch that the input coordinates are relative to.
  * \param [in] opatch       The patch that the output coordinates are relative to.
  * \param [in] icorner      Corner number of this patch to transform across.
+ *                          This function assumes ocorner == icorner ^ 7, so
+ *                          ocorner is the opposite corner of icorner.
  * \param [in] is_block_boundary      Set to true for a block corner.
  * \param [in] mx           Number of cells along x direction of patch.
  * \param [in] my           Number of cells along y direction of patch.
- *                          This function assumes \a mx == \a my.
  * \param [in] mz           Number of cells along z direction of patch.
- *                          This function assumes \a mx == \a mz.
  * \param [in] based        Indices are 0-based for corners and 1-based for cells.
  * \param [in,out] i        EIGHT (8) integer coordinates along x-axis in
  *                          \a based .. \a mx.  On input, only the first is used.

--- a/src/patches/clawpatch/fclaw2d_clawpatch_transform.c
+++ b/src/patches/clawpatch/fclaw2d_clawpatch_transform.c
@@ -118,7 +118,6 @@ FCLAW2D_CLAWPATCH_TRANSFORM_FACE_HALF (const int *i1, const int *j1,
 }
 
 
-/* TODO: Extend this for a block-block corner */
 void
 FCLAW2D_CLAWPATCH_TRANSFORM_CORNER (const int *i1, const int *j1,
                                     int *i2, int *j2,
@@ -143,7 +142,9 @@ FCLAW2D_CLAWPATCH_TRANSFORM_CORNER (const int *i1, const int *j1,
     }
     else
     {
-        /* corner within a block */
+        /* Corner within a block or a block-block corner. For block-block
+         * corners, we assume both patches lie in coordinate systems with the
+         * same orientation. */
         FCLAW_ASSERT (tdata->block_iface == -1);
         fclaw2d_patch_transform_corner (tdata->this_patch,
                                         tdata->neighbor_patch,
@@ -151,12 +152,8 @@ FCLAW2D_CLAWPATCH_TRANSFORM_CORNER (const int *i1, const int *j1,
                                         clawpatch_opt->mx, clawpatch_opt->my,
                                         tdata->based, i2, j2);
     }
-    /* Done. */
-    /* TODO: We need to permit that it's a block corner.  In this case,
-     * call fclaw2d_patch_transform_corner with is_block_boundary = 1 */
 }
 
-/* TODO: Extend this for a block-block corner */
 void
 FCLAW2D_CLAWPATCH_TRANSFORM_CORNER_HALF (const int *i1, const int *j1,
                                          int *i2, int *j2,
@@ -180,7 +177,9 @@ FCLAW2D_CLAWPATCH_TRANSFORM_CORNER_HALF (const int *i1, const int *j1,
     }
     else
     {
-        /* corner within a block */
+        /* Corner within a block or a block-block corner. For block-block
+         * corners, we assume both patches lie in coordinate systems with the
+         * same orientation. */
         FCLAW_ASSERT (tdata->block_iface == -1);
         fclaw2d_patch_transform_corner2 (tdata->this_patch,
                                          tdata->neighbor_patch,
@@ -188,7 +187,4 @@ FCLAW2D_CLAWPATCH_TRANSFORM_CORNER_HALF (const int *i1, const int *j1,
                                          clawpatch_opt->mx, clawpatch_opt->my,
                                          tdata->based, i2, j2);
     }
-    /* Done */
-    /* TODO: We need to permit that it's a block corner.  In this case,
-     * call fclaw2d_patch_transform_corner2 with is_block_boundary = 1 */
 }


### PR DESCRIPTION
We continue work from PR https://github.com/ForestClaw/forestclaw/pull/266
We change the assertions in `fclaw2d_patch_transform_corner(2)`, so that the cell counts `mx, my, mz` do not need to match. The function currently assumes that both patches lie in coordinate systems with the same orientation.