### PR TITLE
3D improvements

### DIFF
--- a/src/fclaw2d_exchange.c
+++ b/src/fclaw2d_exchange.c
@@ -23,6 +23,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#ifndef P4_TO_P8
 #include <fclaw2d_exchange.h>
 
 #include <fclaw2d_global.h>
@@ -30,6 +31,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <fclaw2d_patch.h>
 
 #include <fclaw2d_options.h>
+#else
+#include <fclaw3d_exchange.h>
+
+#include <fclaw3d_global.h>
+#include <fclaw3d_domain.h>
+#include <fclaw3d_patch.h>
+
+#include <fclaw3d_options.h>
+#endif
 
 /* Also needed in fclaw2d_domain_reset */
 /* edit: right now this is not the case, switching to static */

--- a/src/fclaw2d_to_3d.h
+++ b/src/fclaw2d_to_3d.h
@@ -56,6 +56,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define fclaw2d_match_callback_t        fclaw3d_match_callback_t
 #define fclaw2d_transfer_callback_t     fclaw3d_transfer_callback_t
 #define fclaw2d_domain_exchange_t       fclaw3d_domain_exchange_t
+#define fclaw2d_domain_indirect         fclaw3d_domain_indirect
+#define fclaw2d_domain_indirect_t       fclaw3d_domain_indirect_t
 #define fclaw2d_integrate_ray_t         fclaw3d_integrate_ray_t
 #define fclaw2d_interpolate_point_t     fclaw3d_interpolate_point_t
 #define fclaw2d_build_mode_t            fclaw3d_build_mode_t
@@ -138,6 +140,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define fclaw2d_domain_num_face_corners     fclaw3d_domain_num_face_corners
 #define fclaw2d_domain_num_orientations fclaw3d_num_orientations
 #define fclaw2d_domain_corner_faces     fclaw3d_domain_corner_faces
+#define fclaw2d_domain_indirect_begin   fclaw3d_domain_indirect_begin
+#define fclaw2d_domain_indirect_neighbors fclaw3d_domain_indirect_neighbors
+#define fclaw2d_domain_indirect_end     fclaw3d_domain_indirect_end
+#define fclaw2d_domain_indirect_destroy fclaw3d_domain_indirect_destroy
 #define fclaw2d_patch_corner_dimension  fclaw3d_patch_corner_dimension
 #define fclaw2d_patch_childid           fclaw3d_patch_childid
 #define fclaw2d_patch_is_first_sibling  fclaw3d_patch_is_first_sibling

--- a/src/forestclaw2d.c
+++ b/src/forestclaw2d.c
@@ -1807,8 +1807,6 @@ fclaw2d_domain_free_after_exchange (fclaw2d_domain_t * domain,
     FCLAW_FREE (e);
 }
 
-#ifndef P4_TO_P8
-
 struct fclaw2d_domain_indirect
 {
     int ready;
@@ -1816,6 +1814,10 @@ struct fclaw2d_domain_indirect
     fclaw2d_domain_exchange_t *e;
 };
 
+/* These static functions are unused in 3D as long as the 3D case is not
+ * implemented.
+ */
+#ifndef P4_TO_P8
 static void
 indirect_encode (p4est_ghost_t * ghost, int mpirank,
                  int *rproc, int *rpatchno)
@@ -1851,10 +1853,12 @@ indirect_match (int *pi,
     *rpatchno = pi + 3;
     *rfaceno = pi + 5;
 }
+#endif
 
 fclaw2d_domain_indirect_t *
 fclaw2d_domain_indirect_begin (fclaw2d_domain_t * domain)
 {
+#ifndef P4_TO_P8
     int num_exc;
     int neall, nb, ne, np;
     int face;
@@ -1922,8 +1926,19 @@ fclaw2d_domain_indirect_begin (fclaw2d_domain_t * domain)
     FCLAW_FREE (pbdata);
 
     return ind;
+#else
+    FCLAW_ASSERT (domain != NULL);
+
+    /* The 3D case is currently not implemented. */
+
+    return NULL;
+#endif
 }
 
+/* These static functions are unused in 3D as long as the 3D case is not
+ * implemented.
+ */
+#ifndef P4_TO_P8
 static uint64_t
 pli_make_key (int p, int rpatchno)
 {
@@ -1996,11 +2011,13 @@ indirect_decode (sc_hash_t * pli_hash, uint64_t * pli_keys,
 
     return good;
 }
+#endif
 
 void
 fclaw2d_domain_indirect_end (fclaw2d_domain_t * domain,
                              fclaw2d_domain_indirect_t * ind)
 {
+#ifndef P4_TO_P8
     int ndgp;
     int good, good2;
     int p, ng;
@@ -2105,6 +2122,15 @@ fclaw2d_domain_indirect_end (fclaw2d_domain_t * domain,
 
     /* now we allow queries on the ghost data */
     ind->ready = 1;
+#else
+    FCLAW_ASSERT (domain != NULL);
+
+    /* The 3D case is currently not implemented. That is why we assert on ind
+     * beging NULL as it is currently always returned by
+     * fclaw3d_domain_indirect_begin.
+     */
+    FCLAW_ASSERT (ind == NULL);
+#endif
 }
 
 fclaw2d_patch_relation_t
@@ -2114,6 +2140,7 @@ fclaw2d_domain_indirect_neighbors (fclaw2d_domain_t * domain,
                                    int *rblockno, int rpatchno[2],
                                    int *rfaceno)
 {
+#ifndef P4_TO_P8
     int *pi;
     int *grproc, *grblockno, *grpatchno, *grfaceno;
     fclaw2d_patch_relation_t prel;
@@ -2185,20 +2212,37 @@ fclaw2d_domain_indirect_neighbors (fclaw2d_domain_t * domain,
 
     /* and return */
     return prel;
+#else
+    /* Since the 3D case is currently not implemented it is not valid to call
+     * this function.
+     */
+    SC_ABORT_NOT_REACHED ();
+
+    /* This code has no meaning. It is never reached. */
+    return FCLAW2D_PATCH_BOUNDARY;
+#endif
 }
 
 void
 fclaw2d_domain_indirect_destroy (fclaw2d_domain_t * domain,
                                  fclaw2d_domain_indirect_t * ind)
 {
+#ifndef P4_TO_P8
     FCLAW_ASSERT (ind != NULL && ind->ready);
     FCLAW_ASSERT (domain == ind->domain);
 
     fclaw2d_domain_free_after_exchange (domain, ind->e);
     FCLAW_FREE (ind);
-}
+#else
+    FCLAW_ASSERT (domain != NULL);
 
+    /* The 3D case is currently not implemented. That is why we assert on ind
+     * beging NULL as it is currently always returned by
+     * fclaw3d_domain_indirect_begin.
+     */
+    FCLAW_ASSERT (ind == NULL);
 #endif
+}
 
 void
 fclaw2d_domain_serialization_enter (fclaw2d_domain_t * domain)


### PR DESCRIPTION
This PR ensures that in `fclaw3d_exchange.c` only 3d headers are included and the PR translates the `domain_indirect` functions in `forestclaw2d.c` to 3d by providing non-functional implementations for now.