### PR TITLE
Progress on map/connectivity separation.

### DIFF
--- a/applications/clawpack/acoustics/2d/interface/interface.cpp
+++ b/applications/clawpack/acoustics/2d/interface/interface.cpp
@@ -34,23 +34,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <fc2d_clawpack46.h>
 #include <fc2d_clawpack5.h>
 
-
-static
-fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm, 
-                                fclaw_options_t* fclaw_opt)
+static void
+store_domain_map (fclaw2d_global_t * glob, fclaw_options_t * fclaw_opt)
 {
-    p4est_connectivity_t     *conn = NULL;
-    fclaw2d_domain_t         *domain;
-    fclaw2d_map_context_t    *cont = NULL;
-
-    conn = p4est_connectivity_new_unitsquare();
-    cont = fclaw2d_map_new_nomap();
-
-    domain = fclaw2d_domain_new_conn_map (mpicomm, 
-                                          fclaw_opt->minlevel, conn, cont);
-    fclaw2d_domain_list_levels(domain, FCLAW_VERBOSITY_ESSENTIAL);
-    fclaw2d_domain_list_neighbors(domain, FCLAW_VERBOSITY_DEBUG);  
-    return domain;
+    fclaw2d_domain_t *domain = NULL;
+    domain =
+        fclaw2d_domain_new_unitsquare (glob->mpicomm, fclaw_opt->minlevel);
+    fclaw2d_domain_list_levels (domain, FCLAW_VERBOSITY_ESSENTIAL);
+    fclaw2d_domain_list_neighbors (domain, FCLAW_VERBOSITY_DEBUG);
+    fclaw2d_global_store_domain (glob, domain);
+    fclaw2d_global_store_map (glob, fclaw2d_map_new_nomap ());
 }
 
 static
@@ -103,10 +96,6 @@ main (int argc, char **argv)
     fc2d_clawpack46_options_t   *claw46_opt;
     fc2d_clawpack5_options_t    *claw5_opt;
 
-    fclaw2d_global_t            *glob;
-    fclaw2d_domain_t            *domain;
-    sc_MPI_Comm mpicomm;
-
     /* Initialize application */
     app = fclaw_app_new (&argc, &argv, NULL);
 
@@ -124,13 +113,13 @@ main (int argc, char **argv)
     if (!vexit)
     {
         /* Options have been checked and are valid */
-        
-        mpicomm = fclaw_app_get_mpi_size_rank (app, NULL, NULL);
-        domain = create_domain(mpicomm, fclaw_opt);
 
         /* Create global structure which stores the domain, timers, etc */
-        glob = fclaw2d_global_new();
-        fclaw2d_global_store_domain(glob, domain);
+        int size, rank;
+        sc_MPI_Comm mpicomm = fclaw_app_get_mpi_size_rank (app, &size, &rank);
+        fclaw2d_global_t *glob =
+            fclaw2d_global_new_comm (mpicomm, size, rank);
+        store_domain_map (glob, fclaw_opt);
 
         /* Store option packages in glob */
         fclaw2d_options_store           (glob, fclaw_opt);

--- a/applications/clawpack/advection/2d/annulus/annulus.cpp
+++ b/applications/clawpack/advection/2d/annulus/annulus.cpp
@@ -28,15 +28,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../all/advection_user.h"
 
 /* ------------- Create the domain --------------------- */
-static
-fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm, 
-                                fclaw_options_t* fclaw_opt, 
-                                user_options_t* user)
+static void
+store_domain_map (fclaw2d_global_t * glob, fclaw_options_t * fclaw_opt,
+                  user_options_t * user)
 {
     /* Mapped, multi-block domain */
-    p4est_connectivity_t     *conn = NULL;
-    fclaw2d_domain_t         *domain;
-    fclaw2d_map_context_t    *cont = NULL, *brick = NULL;
+    fclaw2d_domain_t *domain = NULL;
+    fclaw2d_map_context_t *cont = NULL, *brick = NULL;
 
     /* ---------------------------------------------------------------
        Mapping geometry
@@ -44,7 +42,7 @@ fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm,
     int mi = fclaw_opt->mi;
     int mj = fclaw_opt->mj;
     int a = fclaw_opt->periodic_x;
-    int b = 0;   /* No periodicity in radial direction */
+    int b = 0;                  /* No periodicity in radial direction */
 
     /* Used locally */
     double pi = M_PI;
@@ -54,19 +52,19 @@ fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm,
     rotate[1] = pi*fclaw_opt->phi/180.0;
 
     /* Annulus */
-    conn = p4est_connectivity_new_brick(mi,mj,a,b);
-    brick = fclaw2d_map_new_brick_conn (conn,mi,mj);
-    cont = fclaw2d_map_new_annulus(brick,
-                                   fclaw_opt->scale,
-                                   rotate,
-                                   user->beta, 
-                                   user->theta);
+    /* Construct and store domain */
+    domain = fclaw2d_domain_new_brick (glob->mpicomm, mi, mj, a, b,
+                                       fclaw_opt->minlevel);
+    fclaw2d_domain_list_levels (domain, FCLAW_VERBOSITY_ESSENTIAL);
+    fclaw2d_domain_list_neighbors (domain, FCLAW_VERBOSITY_DEBUG);
+    fclaw2d_global_store_domain (glob, domain);
 
-    domain = fclaw2d_domain_new_conn_map (mpicomm, fclaw_opt->minlevel, conn, cont);
-
-    fclaw2d_domain_list_levels(domain, FCLAW_VERBOSITY_ESSENTIAL);
-    fclaw2d_domain_list_neighbors(domain, FCLAW_VERBOSITY_DEBUG);
-    return domain;
+    /* Construct and store map */
+    brick = fclaw2d_map_new_brick (domain, mi, mj, a, b);
+    cont = fclaw2d_map_new_annulus (brick,
+                                    fclaw_opt->scale,
+                                    rotate, user->beta, user->theta);
+    fclaw2d_global_store_map (glob, cont);
 }
 
 static
@@ -113,10 +111,6 @@ main (int argc, char **argv)
     fc2d_clawpack46_options_t   *claw46_opt;
     fc2d_clawpack5_options_t    *claw5_opt;
 
-    fclaw2d_global_t         *glob;
-    fclaw2d_domain_t         *domain;
-    sc_MPI_Comm mpicomm;
-
     /* Initialize application */
     app = fclaw_app_new (&argc, &argv, NULL);
 
@@ -134,11 +128,11 @@ main (int argc, char **argv)
     {
         
         /* Options have been checked and are valid */
-        mpicomm = fclaw_app_get_mpi_size_rank (app, NULL, NULL);
-        domain = create_domain(mpicomm, fclaw_opt, user_opt);
-
-        glob = fclaw2d_global_new();
-        fclaw2d_global_store_domain(glob, domain);
+        int size, rank;
+        sc_MPI_Comm mpicomm = fclaw_app_get_mpi_size_rank (app, &size, &rank);
+        fclaw2d_global_t *glob =
+            fclaw2d_global_new_comm (mpicomm, size, rank);
+        store_domain_map (glob, fclaw_opt, user_opt);
 
         fclaw2d_options_store            (glob, fclaw_opt);
         fclaw2d_clawpatch_options_store  (glob, clawpatch_opt);

--- a/applications/clawpack/advection/2d/disk/disk.cpp
+++ b/applications/clawpack/advection/2d/disk/disk.cpp
@@ -27,17 +27,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "../all/advection_user.h"
 
-static
-fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm, 
-                                fclaw_options_t* fclaw_opt, 
-                                user_options_t* user_opt,
-                                fclaw2d_clawpatch_options_t *clawpatch_opt)
+static void
+store_domain_map (fclaw2d_global_t * glob, fclaw_options_t * fclaw_opt,
+                  user_options_t * user_opt,
+                  fclaw2d_clawpatch_options_t * clawpatch_opt)
 {
     /* Mapped, multi-block domain */
-    p4est_connectivity_t     *conn = NULL;
-    fclaw2d_domain_t         *domain;
-    fclaw2d_map_context_t    *cont = NULL;
-    
+    fclaw2d_domain_t *domain = NULL;
+    fclaw2d_map_context_t *cont = NULL;
+
     /* Used locally */
     double pi = M_PI;
     double rotate[2];
@@ -49,10 +47,12 @@ fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm,
     {
     case 0:
         /* Map unit square to the pillow disk using mapc2m_pillowdisk.f */
-        conn = p4est_connectivity_new_unitsquare();
-        cont = fclaw2d_map_new_pillowdisk(fclaw_opt->scale,
-                                          fclaw_opt->shift,
-                                          rotate);
+        domain =
+            fclaw2d_domain_new_unitsquare (glob->mpicomm,
+                                           fclaw_opt->minlevel);
+        cont =
+            fclaw2d_map_new_pillowdisk (fclaw_opt->scale, fclaw_opt->shift,
+                                        rotate);
         break;
     case 1:
         /* Map five-patch square to pillow disk. */
@@ -61,22 +61,22 @@ fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm,
             fclaw_global_essentialf("The five patch mapping requires mx*2^minlevel >= 32\n");
             exit(0);
         }
-        conn = p4est_connectivity_new_disk (0, 0);
-        cont = fclaw2d_map_new_pillowdisk5 (fclaw_opt->scale,
-                                            fclaw_opt->shift,
-                                            rotate,
-                                            user_opt->alpha);
+        domain =
+            fclaw2d_domain_new_disk (glob->mpicomm, 0, 0,
+                                     fclaw_opt->minlevel);
+        cont =
+            fclaw2d_map_new_pillowdisk5 (fclaw_opt->scale, fclaw_opt->shift,
+                                         rotate, user_opt->alpha);
         break;
 
     default:
         SC_ABORT_NOT_REACHED ();
     }
-    
-    domain = fclaw2d_domain_new_conn_map (mpicomm, fclaw_opt->minlevel, conn, cont);
-    fclaw2d_domain_list_levels(domain, FCLAW_VERBOSITY_ESSENTIAL);
-    fclaw2d_domain_list_neighbors(domain, FCLAW_VERBOSITY_DEBUG);
-    
-    return domain;    
+
+    fclaw2d_domain_list_levels (domain, FCLAW_VERBOSITY_ESSENTIAL);
+    fclaw2d_domain_list_neighbors (domain, FCLAW_VERBOSITY_DEBUG);
+    fclaw2d_global_store_domain (glob, domain);
+    fclaw2d_global_store_map (glob, cont);
 }
 
 static
@@ -128,10 +128,6 @@ main (int argc, char **argv)
     fc2d_clawpack46_options_t   *claw46_opt;
     fc2d_clawpack5_options_t    *claw5_opt;
 
-    fclaw2d_global_t            *glob;
-    fclaw2d_domain_t            *domain;
-    sc_MPI_Comm mpicomm;
-
     /* Initialize application */
     app = fclaw_app_new (&argc, &argv, NULL);
 
@@ -152,12 +148,13 @@ main (int argc, char **argv)
         fclaw_app_print_options(app);
 
         /* Options have been checked and are valid */
-        mpicomm = fclaw_app_get_mpi_size_rank (app, NULL, NULL);
-        domain = create_domain(mpicomm, fclaw_opt, user_opt, clawpatch_opt);
-    
+
         /* Create global structure which stores the domain, timers, etc */
-        glob = fclaw2d_global_new();
-        fclaw2d_global_store_domain(glob, domain);
+        int size, rank;
+        sc_MPI_Comm mpicomm = fclaw_app_get_mpi_size_rank (app, &size, &rank);
+        fclaw2d_global_t *glob =
+            fclaw2d_global_new_comm (mpicomm, size, rank);
+        store_domain_map (glob, fclaw_opt, user_opt, clawpatch_opt);
 
         /* Store option packages in glob */
         fclaw2d_options_store           (glob, fclaw_opt);


### PR DESCRIPTION
We continue separating maps from  the functionalities in fclaw2d_convenience by replacing `fclaw2d_domain_new_conn_map` in several applications.
Instead of `p4est_connecitivity_new_*` followed by `fclaw2d_domain_new_conn_map`, we now use `fclaw2d_domain_new_*` followed by  `fclaw2d_global_store_domain` and `fclaw2d_global_store_map`. Thereby, we separate map and domain creation and remove calls to p4est-internal functions in the applications.