### PR TITLE
Progress on 3d

### DIFF
--- a/src/forestclaw2d.c
+++ b/src/forestclaw2d.c
@@ -1187,32 +1187,39 @@ fclaw2d_patch_transform_corner (fclaw2d_patch_t * ipatch,
         if ((icorner & 1) == 0)
         {
             /* This corner is on the left face of the patch */
+            /* verify the blocks are corner-neighbors with the next assertions */
+            FCLAW_ASSERT (fabs (opatch->xupper - 1.) < SC_1000_EPS);
             xshift = +1.;
         }
         else
         {
             /* This corner is on the right face of the patch */
+            FCLAW_ASSERT (fabs (opatch->xlower) < SC_1000_EPS);
             xshift = -1.;
         }
         if ((icorner & 2) == 0)
         {
             /* This corner is on the front face of the patch */
+            FCLAW_ASSERT (fabs (opatch->yupper - 1.) < SC_1000_EPS);
             yshift = +1.;
         }
         else
         {
             /* This corner is on the back face of the patch */
+            FCLAW_ASSERT (fabs (opatch->ylower) < SC_1000_EPS);
             yshift = -1.;
         }
 #ifdef P4_TO_P8
         if ((icorner & 4) == 0)
         {
             /* This corner is on the bottom face of the patch */
+            FCLAW_ASSERT (fabs (opatch->zupper - 1.) < SC_1000_EPS);
             zshift = +1.;
         }
         else
         {
             /* This corner is on the top face of the patch */
+            FCLAW_ASSERT (fabs (opatch->zlower) < SC_1000_EPS);
             zshift = -1.;
         }
 #endif
@@ -1294,32 +1301,39 @@ fclaw2d_patch_transform_corner2 (fclaw2d_patch_t * ipatch,
         if ((icorner & 1) == 0)
         {
             /* This corner is on the left face of the patch */
+            /* verify the blocks are corner-neighbors with the next assertions */
+            FCLAW_ASSERT (fabs (opatch->xupper - 1.) < SC_1000_EPS);
             xshift = +1.;
         }
         else
         {
             /* This corner is on the right face of the patch */
+            FCLAW_ASSERT (fabs (opatch->xlower) < SC_1000_EPS);
             xshift = -1.;
         }
         if ((icorner & 2) == 0)
         {
             /* This corner is on the front face of the patch */
+            FCLAW_ASSERT (fabs (opatch->yupper - 1.) < SC_1000_EPS);
             yshift = +1.;
         }
         else
         {
             /* This corner is on the back face of the patch */
+            FCLAW_ASSERT (fabs (opatch->ylower) < SC_1000_EPS);
             yshift = -1.;
         }
 #ifdef P4_TO_P8
         if ((icorner & 4) == 0)
         {
             /* This corner is on the bottom face of the patch */
+            FCLAW_ASSERT (fabs (opatch->zupper - 1.) < SC_1000_EPS);
             zshift = +1.;
         }
         else
         {
             /* This corner is on the top face of the patch */
+            FCLAW_ASSERT (fabs (opatch->zlower) < SC_1000_EPS);
             zshift = -1.;
         }
 #endif

--- a/src/forestclaw2d.h
+++ b/src/forestclaw2d.h
@@ -591,6 +591,8 @@ void fclaw2d_patch_corner_swap (int *cornerno, int *rcornerno);
  * This function assumes that the two patches are of the SAME size and that the
  * patches lie in coordinate systems with the same orientation.
  * It is LEGAL to call this function for both local and ghost patches.
+ * It is ILLEGAL to call this function for patches from face-neighboring blocks.
+ * Use \ref fclaw2d_patch_transform_face for such patches instead.
  * \param [in] ipatch       The patch that the input coordinates are relative to.
  * \param [in] opatch       The patch that the output coordinates are relative to.
  * \param [in] icorner      Corner number of this patch to transform across.
@@ -613,6 +615,8 @@ void fclaw2d_patch_transform_corner (fclaw2d_patch_t * ipatch,
  * This function assumes that the neighbor patch is smaller (HALF size) and that
  * the patches lie in coordinate systems with the same orientation.
  * It is LEGAL to call this function for both local and ghost patches.
+ * It is ILLEGAL to call this function for patches from face-neighboring blocks.
+ * Use \ref fclaw2d_patch_transform_face2 for such patches instead.
  * \param [in] ipatch       The patch that the input coordinates are relative to.
  * \param [in] opatch       The patch that the output coordinates are relative to.
  * \param [in] icorner      Corner number of this patch to transform across.

--- a/src/forestclaw3d.c
+++ b/src/forestclaw3d.c
@@ -234,20 +234,36 @@ fclaw3d_patch_transform_edge (fclaw2d_patch_t * ipatch,
         /* shift in previously determined dimensions based on edge number */
         if ((iedge & 1) == 0)
         {
-            xyzshift[shiftinds[0]] = +1;
+            xyzshift[shiftinds[0]] = +1.;
         }
         else
         {
-            xyzshift[shiftinds[0]] = -1;
+            xyzshift[shiftinds[0]] = -1.;
         }
         if ((iedge & 2) == 0)
         {
-            xyzshift[shiftinds[1]] = +1;
+            xyzshift[shiftinds[1]] = +1.;
         }
         else
         {
-            xyzshift[shiftinds[1]] = -1;
+            xyzshift[shiftinds[1]] = -1.;
         }
+        /* verify the blocks are edge-neighbors */
+        FCLAW_ASSERT ((xyzshift[0] == 0.) ||
+                      (xyzshift[0] == 1.
+                       && fabs (opatch->xupper - 1.) < SC_1000_EPS)
+                      || (xyzshift[0] == -1.
+                          && fabs (opatch->xlower) < SC_1000_EPS));
+        FCLAW_ASSERT ((xyzshift[1] == 0.)
+                      || (xyzshift[1] == 1.
+                          && fabs (opatch->yupper - 1.) < SC_1000_EPS)
+                      || (xyzshift[1] == -1.
+                          && fabs (opatch->ylower) < SC_1000_EPS));
+        FCLAW_ASSERT ((xyzshift[2] == 0.)
+                      || (xyzshift[2] == 1.
+                          && fabs (opatch->zupper - 1.) < SC_1000_EPS)
+                      || (xyzshift[2] == -1.
+                          && fabs (opatch->zlower) < SC_1000_EPS));
     }
 
     /* The two patches are in the same block, or in a different block
@@ -315,20 +331,36 @@ fclaw3d_patch_transform_edge2 (fclaw3d_patch_t * ipatch,
         /* shift in previously determined dimensions based on edge number */
         if ((iedge & 1) == 0)
         {
-            xyzshift[shiftinds[0]] = +1;
+            xyzshift[shiftinds[0]] = +1.;
         }
         else
         {
-            xyzshift[shiftinds[0]] = -1;
+            xyzshift[shiftinds[0]] = -1.;
         }
         if ((iedge & 2) == 0)
         {
-            xyzshift[shiftinds[1]] = +1;
+            xyzshift[shiftinds[1]] = +1.;
         }
         else
         {
-            xyzshift[shiftinds[1]] = -1;
+            xyzshift[shiftinds[1]] = -1.;
         }
+        /* verify the blocks are edge-neighbors */
+        FCLAW_ASSERT ((xyzshift[0] == 0.) ||
+                      (xyzshift[0] == 1.
+                       && fabs (opatch->xupper - 1.) < SC_1000_EPS)
+                      || (xyzshift[0] == -1.
+                          && fabs (opatch->xlower) < SC_1000_EPS));
+        FCLAW_ASSERT ((xyzshift[1] == 0.)
+                      || (xyzshift[1] == 1.
+                          && fabs (opatch->yupper - 1.) < SC_1000_EPS)
+                      || (xyzshift[1] == -1.
+                          && fabs (opatch->ylower) < SC_1000_EPS));
+        FCLAW_ASSERT ((xyzshift[2] == 0.)
+                      || (xyzshift[2] == 1.
+                          && fabs (opatch->zupper - 1.) < SC_1000_EPS)
+                      || (xyzshift[2] == -1.
+                          && fabs (opatch->zlower) < SC_1000_EPS));
     }
 
     /* The two patches are in the same block, or in a different block

--- a/src/forestclaw3d.c
+++ b/src/forestclaw3d.c
@@ -259,3 +259,101 @@ fclaw3d_patch_transform_edge (fclaw2d_patch_t * ipatch,
     *k +=
         (int) ((ipatch->zlower - opatch->zlower + xyzshift[2]) * Rmxmymz[2]);
 }
+
+void
+fclaw3d_patch_transform_edge2 (fclaw3d_patch_t * ipatch,
+                               fclaw3d_patch_t * opatch,
+                               int iedge, int is_block_boundary,
+                               int mx, int my, int mz, int based,
+                               int i[], int j[], int k[])
+{
+    FCLAW_ASSERT (ipatch->level + 1 == opatch->level);
+    FCLAW_ASSERT (0 <= ipatch->level && opatch->level < P4EST_MAXLEVEL);
+    FCLAW_ASSERT (ipatch->xlower >= 0. && ipatch->xlower < 1.);
+    FCLAW_ASSERT (opatch->xlower >= 0. && opatch->xlower < 1.);
+    FCLAW_ASSERT (ipatch->ylower >= 0. && ipatch->ylower < 1.);
+    FCLAW_ASSERT (opatch->ylower >= 0. && opatch->ylower < 1.);
+    FCLAW_ASSERT (ipatch->zlower >= 0. && ipatch->zlower < 1.);
+    FCLAW_ASSERT (opatch->zlower >= 0. && opatch->zlower < 1.);
+
+    FCLAW_ASSERT (mx >= 1 && my >= 1 && mz >= 1);
+    FCLAW_ASSERT (based == 0 || based == 1);
+
+    int kt, kn, ks;
+    int di, dj, dk;
+    double Rmxmymz[P4EST_DIM], xyzshift[3];
+    int shiftinds[2];
+    Rmxmymz[0] = (double) (1 << opatch->level) * (double) mx;
+    Rmxmymz[1] = (double) (1 << opatch->level) * (double) my;
+    Rmxmymz[2] = (double) (1 << opatch->level) * (double) mz;
+
+    xyzshift[0] = xyzshift[1] = xyzshift[2] = 0.;
+    if (is_block_boundary)
+    {
+        /* We need to add/substract the shift due to translation of one block. */
+        /* determine in which dimensions we need to shift */
+        if ((iedge & 12) == 0)
+        {
+            /* This edge is parallel to the x-axis */
+            shiftinds[0] = 1;   /* first shift is in y-dimension */
+            shiftinds[1] = 2;   /* second shift is in z-dimension */
+        }
+        else if ((iedge & 12) == 4)
+        {
+            /* This edge is parallel to the y-axis */
+            shiftinds[0] = 0;   /* first shift is in x-dimension */
+            shiftinds[1] = 2;   /* second shift is in z-dimension */
+        }
+        else
+        {
+            /* This edge is parallel to the z-axis */
+            FCLAW_ASSERT ((iedge & 12) == 8);
+            shiftinds[0] = 0;   /* first shift is in x-dimension */
+            shiftinds[1] = 1;   /* second shift is in y-dimension */
+        }
+
+        /* shift in previously determined dimensions based on edge number */
+        if ((iedge & 1) == 0)
+        {
+            xyzshift[shiftinds[0]] = +1;
+        }
+        else
+        {
+            xyzshift[shiftinds[0]] = -1;
+        }
+        if ((iedge & 2) == 0)
+        {
+            xyzshift[shiftinds[1]] = +1;
+        }
+        else
+        {
+            xyzshift[shiftinds[1]] = -1;
+        }
+    }
+
+    /* The two patches are in the same block, or in a different block
+     * that has a coordinate system with the same orientation */
+    di = based +
+        (int) ((ipatch->xlower - opatch->xlower + xyzshift[0]) * Rmxmymz[0] +
+               2. * (*i - based));
+    dj = based +
+        (int) ((ipatch->ylower - opatch->ylower + xyzshift[1]) * Rmxmymz[1] +
+               2. * (*j - based));
+    dk = based +
+        (int) ((ipatch->zlower - opatch->zlower + xyzshift[2]) * Rmxmymz[2] +
+               2. * (*k - based));
+
+    /* Without any rotation, the order of child cells is canonical */
+    for (ks = 0; ks < 2; ++ks)
+    {
+        for (kt = 0; kt < 2; ++kt)
+        {
+            for (kn = 0; kn < 2; ++kn)
+            {
+                i[4 * ks + 2 * kt + kn] = di + kn;
+                j[4 * ks + 2 * kt + kn] = dj + kt;
+                k[4 * ks + 2 * kt + kn] = dk + ks;
+            }
+        }
+    }
+}

--- a/src/forestclaw3d.c
+++ b/src/forestclaw3d.c
@@ -180,3 +180,82 @@ fclaw2d_patch_edge_swap (int *edgeno, int *redgeno)
     *edgeno = *redgeno;
     *redgeno = swap;
 }
+
+void
+fclaw3d_patch_transform_edge (fclaw2d_patch_t * ipatch,
+                              fclaw2d_patch_t * opatch,
+                              int iedge, int is_block_boundary,
+                              int mx, int my, int mz,
+                              int based, int *i, int *j, int *k)
+{
+    FCLAW_ASSERT (ipatch->level == opatch->level);
+    FCLAW_ASSERT (0 <= ipatch->level && ipatch->level < P4EST_MAXLEVEL);
+    FCLAW_ASSERT (ipatch->xlower >= 0. && ipatch->xlower < 1.);
+    FCLAW_ASSERT (opatch->xlower >= 0. && opatch->xlower < 1.);
+    FCLAW_ASSERT (ipatch->ylower >= 0. && ipatch->ylower < 1.);
+    FCLAW_ASSERT (opatch->ylower >= 0. && opatch->ylower < 1.);
+    FCLAW_ASSERT (ipatch->zlower >= 0. && ipatch->zlower < 1.);
+    FCLAW_ASSERT (opatch->zlower >= 0. && opatch->zlower < 1.);
+
+    FCLAW_ASSERT (mx >= 1 && my >= 1 && mz >= 1);
+    FCLAW_ASSERT (based == 0 || based == 1);
+
+    double Rmxmymz[P4EST_DIM], xyzshift[3];
+    int shiftinds[2];
+    Rmxmymz[0] = (double) (1 << ipatch->level) * (double) mx;
+    Rmxmymz[1] = (double) (1 << ipatch->level) * (double) my;
+    Rmxmymz[2] = (double) (1 << ipatch->level) * (double) mz;
+
+    xyzshift[0] = xyzshift[1] = xyzshift[2] = 0.;
+    if (is_block_boundary)
+    {
+        /* We need to add/substract the shift due to translation of one block. */
+        /* determine in which dimensions we need to shift */
+        if ((iedge & 12) == 0)
+        {
+            /* This edge is parallel to the x-axis */
+            shiftinds[0] = 1;   /* first shift is in y-dimension */
+            shiftinds[1] = 2;   /* second shift is in z-dimension */
+        }
+        else if ((iedge & 12) == 4)
+        {
+            /* This edge is parallel to the y-axis */
+            shiftinds[0] = 0;   /* first shift is in x-dimension */
+            shiftinds[1] = 2;   /* second shift is in z-dimension */
+        }
+        else
+        {
+            /* This edge is parallel to the z-axis */
+            FCLAW_ASSERT ((iedge & 12) == 8);
+            shiftinds[0] = 0;   /* first shift is in x-dimension */
+            shiftinds[1] = 1;   /* second shift is in y-dimension */
+        }
+
+        /* shift in previously determined dimensions based on edge number */
+        if ((iedge & 1) == 0)
+        {
+            xyzshift[shiftinds[0]] = +1;
+        }
+        else
+        {
+            xyzshift[shiftinds[0]] = -1;
+        }
+        if ((iedge & 2) == 0)
+        {
+            xyzshift[shiftinds[1]] = +1;
+        }
+        else
+        {
+            xyzshift[shiftinds[1]] = -1;
+        }
+    }
+
+    /* The two patches are in the same block, or in a different block
+     * that has a coordinate system with the same orientation */
+    *i +=
+        (int) ((ipatch->xlower - opatch->xlower + xyzshift[0]) * Rmxmymz[0]);
+    *j +=
+        (int) ((ipatch->ylower - opatch->ylower + xyzshift[1]) * Rmxmymz[1]);
+    *k +=
+        (int) ((ipatch->zlower - opatch->zlower + xyzshift[2]) * Rmxmymz[2]);
+}

--- a/src/forestclaw3d.h
+++ b/src/forestclaw3d.h
@@ -605,6 +605,8 @@ void fclaw3d_patch_edge_swap (int *edgeno, int *redgeno);
  * This function assumes that the two patches are of the SAME size and that the
  * patches lie in coordinate systems with the same orientation.
  * It is LEGAL to call this function for both local and ghost patches.
+ * It is ILLEGAL to call this function for patches from face-neighboring blocks.
+ * Use \ref fclaw3d_patch_transform_face for such patches instead.
  * \param [in] ipatch       The patch that the input coordinates are relative to.
  * \param [in] opatch       The patch that the output coordinates are relative to.
  * \param [in] iedge        Edge number of this patch to transform across.
@@ -629,6 +631,8 @@ void fclaw3d_patch_transform_edge (fclaw3d_patch_t * ipatch,
  * This function assumes that the neighbor patch is smaller (HALF size) and that
  * the patches lie in coordinate systems with the same orientation.
  * It is LEGAL to call this function for both local and ghost patches.
+ * It is ILLEGAL to call this function for patches from face-neighboring blocks.
+ * Use \ref fclaw3d_patch_transform_face for such patches instead.
  * \param [in] ipatch       The patch that the input coordinates are relative to.
  * \param [in] opatch       The patch that the output coordinates are relative to.
  * \param [in] iedge        Edge number of this patch to transform across.

--- a/src/forestclaw3d.h
+++ b/src/forestclaw3d.h
@@ -625,6 +625,39 @@ void fclaw3d_patch_transform_edge (fclaw3d_patch_t * ipatch,
                                    int mx, int my, int mz,
                                    int based, int *i, int *j, int *k);
 
+/** Transform a patch coordinate into a neighbor patch's coordinate system.
+ * This function assumes that the neighbor patch is smaller (HALF size) and that
+ * the patches lie in coordinate systems with the same orientation.
+ * It is LEGAL to call this function for both local and ghost patches.
+ * \param [in] ipatch       The patch that the input coordinates are relative to.
+ * \param [in] opatch       The patch that the output coordinates are relative to.
+ * \param [in] iedge        Edge number of this patch to transform across.
+ *                          This function assumes oedge == iedge ^ 3, so
+ *                          oedge is the edge opposite of iedge.
+ * \param [in] is_block_boundary      Set to true for a block edge.
+ * \param [in] mx           Number of cells along x direction of patch.
+ * \param [in] my           Number of cells along y direction of patch.
+ * \param [in] mz           Number of cells along z direction of patch.
+ * \param [in] based        Indices are 0-based for corners and 1-based for cells.
+ * \param [in,out] i        EIGHT (8) integer coordinates along x-axis in
+ *                          \a based .. \a mx.  On input, only the first is used.
+ *                          On output, they are relative to the fine patch and
+ *                          stored in order of the children of the coarse patch.
+ * \param [in,out] j        EIGHT (8) integer coordinates along y-axis in
+ *                          \a based .. \a my.  On input, only the first is used.
+ *                          On output, they are relative to the fine patch and
+ *                          stored in order of the children of the coarse patch.
+ * \param [in,out] k        EIGHT (8) integer coordinates along y-axis in
+ *                          \a based .. \a mz.  On input, only the first is used.
+ *                          On output, they are relative to the fine patch and
+ *                          stored in order of the children of the coarse patch.
+ */
+void fclaw3d_patch_transform_edge2 (fclaw3d_patch_t * ipatch,
+                                    fclaw3d_patch_t * opatch,
+                                    int iedge, int is_block_boundary,
+                                    int mx, int my, int mz, int based,
+                                    int i[], int j[], int k[]);
+
 /** Determine neighbor patch(es) and orientation across a given corner.
  * The current version only supports one neighbor, i.e., no true multi-block.
  * A query across a corner in the middle of a longer face returns the boundary.

--- a/src/forestclaw3d.h
+++ b/src/forestclaw3d.h
@@ -700,6 +700,9 @@ void fclaw3d_patch_corner_swap (int *cornerno, int *rcornerno);
  * This function assumes that the two patches are of the SAME size and that the
  * patches lie in coordinate systems with the same orientation.
  * It is LEGAL to call this function for both local and ghost patches.
+ * It is ILLEGAL to call this function for patches from face- or
+ * edge-neighboring blocks. Use \ref fclaw3d_patch_transform_face or
+ * \ref fclaw3d_patch_transform_edge for such patches instead.
  * \param [in] ipatch       The patch that the input coordinates are relative to.
  * \param [in] opatch       The patch that the output coordinates are relative to.
  * \param [in] icorner      Corner number of this patch to transform across.
@@ -724,6 +727,9 @@ void fclaw3d_patch_transform_corner (fclaw3d_patch_t * ipatch,
  * This function assumes that the neighbor patch is smaller (HALF size) and that
  * the patches lie in coordinate systems with the same orientation.
  * It is LEGAL to call this function for both local and ghost patches.
+ * It is ILLEGAL to call this function for patches from face- or
+ * edge-neighboring blocks. Use \ref fclaw3d_patch_transform_face2 or
+ * \ref fclaw3d_patch_transform_edge2 for such patches instead.
  * \param [in] ipatch       The patch that the input coordinates are relative to.
  * \param [in] opatch       The patch that the output coordinates are relative to.
  * \param [in] icorner      Corner number of this patch to transform across.

--- a/src/forestclaw3d.h
+++ b/src/forestclaw3d.h
@@ -601,6 +601,30 @@ int fclaw3d_patch_edge_neighbors (fclaw3d_domain_t * domain,
  */
 void fclaw3d_patch_edge_swap (int *edgeno, int *redgeno);
 
+/** Transform a patch coordinate into a neighbor patch's coordinate system.
+ * This function assumes that the two patches are of the SAME size and that the
+ * patches lie in coordinate systems with the same orientation.
+ * It is LEGAL to call this function for both local and ghost patches.
+ * \param [in] ipatch       The patch that the input coordinates are relative to.
+ * \param [in] opatch       The patch that the output coordinates are relative to.
+ * \param [in] iedge        Edge number of this patch to transform across.
+ *                          This function assumes oedge == iedge ^ 3, so
+ *                          oedge is the edge opposite of iedge.
+ * \param [in] is_block_boundary      Set to true for a block edge.
+ * \param [in] mx           Number of cells along x direction of patch.
+ * \param [in] my           Number of cells along y direction of patch.
+ * \param [in] mz           Number of cells along z direction of patch.
+ * \param [in] based        Indices are 0-based for corners and 1-based for cells.
+ * \param [in,out] i        Integer coordinate along x-axis in \a based .. \a mx.
+ * \param [in,out] j        Integer coordinate along y-axis in \a based .. \a my.
+ * \param [in,out] k        Integer coordinate along z-axis in \a based .. \a mz.
+ */
+void fclaw3d_patch_transform_edge (fclaw3d_patch_t * ipatch,
+                                   fclaw3d_patch_t * opatch,
+                                   int iedge, int is_block_boundary,
+                                   int mx, int my, int mz,
+                                   int based, int *i, int *j, int *k);
+
 /** Determine neighbor patch(es) and orientation across a given corner.
  * The current version only supports one neighbor, i.e., no true multi-block.
  * A query across a corner in the middle of a longer face returns the boundary.


### PR DESCRIPTION
We add `fclaw3d_patch_transform_edge(2)`.
The function is able to operate across block-boundaries. We assume that the orientation of the matching edges is identical, like e.g. in a brick.
The function does not yield correct results for patches in face-neighboring blocks, in which case `fclaw3d_patch_transform_face(2)` can be used instead. To ensure correct usage of the function, we add assertions that make sure the blocks are not face-neighbors. We make similar modifications in `fclaw3d_patch_transform_corner(2)`.