### PR TITLE
Fix memory leak during ini parsing

### DIFF
--- a/src/fclaw_base.c
+++ b/src/fclaw_base.c
@@ -735,6 +735,7 @@ check_for_unused_options(fclaw_app_t* a, const char* savefile, sc_array_t* filen
                             fclaw_global_productionf("%s has unused option %s.\n", filename, keys[i_key]);
                         }
                     }
+                    free (keys);
                 }
                 else
                 {
@@ -751,6 +752,7 @@ check_for_unused_options(fclaw_app_t* a, const char* savefile, sc_array_t* filen
         iniparser_freedict(ini);
     }
     sc_array_destroy(ini_files);
+    iniparser_freedict (save_ini);
 }
 
 fclaw_exit_type_t


### PR DESCRIPTION
During testing of the ForestClaw restart code with valgrind I found a memory leak in the ini parsing. 
For swirl I am getting the following error report by valgrind.
```
==881976== 
==881976== HEAP SUMMARY:
==881976==     in use at exit: 5,615 bytes in 221 blocks
==881976==   total heap usage: 22,016 allocs, 21,795 frees, 31,015,194 bytes allocated
==881976== 
==881976== 488 bytes in 5 blocks are definitely lost in loss record 3 of 8
==881976==    at 0x483877F: malloc (vg_replace_malloc.c:307)
==881976==    by 0x221B6D: iniparser_getseckeys (in /home/griesbac/forestclaw_workspace/forestclaw-debug/applications/clawpack/advection/2d/swirl/swirl)
==881976==    by 0x13A109: fclaw_app_options_parse (in /home/griesbac/forestclaw_workspace/forestclaw-debug/applications/clawpack/advection/2d/swirl/swirl)
==881976==    by 0x10CCE0: main (in /home/griesbac/forestclaw_workspace/forestclaw-debug/applications/clawpack/advection/2d/swirl/swirl)
==881976== 
==881976== 5,127 (32 direct, 5,095 indirect) bytes in 1 blocks are definitely lost in loss record 8 of 8
==881976==    at 0x483AB65: calloc (vg_replace_malloc.c:760)
==881976==    by 0x223243: dictionary_new (in /home/griesbac/forestclaw_workspace/forestclaw-debug/applications/clawpack/advection/2d/swirl/swirl)
==881976==    by 0x221E74: iniparser_load (in /home/griesbac/forestclaw_workspace/forestclaw-debug/applications/clawpack/advection/2d/swirl/swirl)
==881976==    by 0x139F3C: fclaw_app_options_parse (in /home/griesbac/forestclaw_workspace/forestclaw-debug/applications/clawpack/advection/2d/swirl/swirl)
==881976==    by 0x10CCE0: main (in /home/griesbac/forestclaw_workspace/forestclaw-debug/applications/clawpack/advection/2d/swirl/swirl)
==881976== 
==881976== LEAK SUMMARY:
==881976==    definitely lost: 520 bytes in 6 blocks
==881976==    indirectly lost: 5,095 bytes in 215 blocks
==881976==      possibly lost: 0 bytes in 0 blocks
==881976==    still reachable: 0 bytes in 0 blocks
==881976==         suppressed: 0 bytes in 0 blocks
==881976== 
==881976== For lists of detected and suppressed errors, rerun with: -s
==881976== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 0 from 0)
```
I resolved the issue by adding the missing memory free calls in the static function `check_for_unused_options`.