### PR TITLE
Separate Mappings in Geoclaw, ThunderEgg, and CudaClaw examples

### DIFF
--- a/applications/cudaclaw/acoustics/2d/radial/radial.cpp
+++ b/applications/cudaclaw/acoustics/2d/radial/radial.cpp
@@ -31,23 +31,20 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /* ------------------------- Start of program ---------------------------- */
 
 static
-fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm, 
-                                fclaw_options_t* fclaw_opt,
-                                user_options_t* user)
+void create_domain(fclaw2d_global_t* glob)
 {
-    /* Mapped, multi-block domain */
-    p4est_connectivity_t     *conn = NULL;
-    fclaw2d_domain_t         *domain;
-    fclaw2d_map_context_t    *cont = NULL;
+	fclaw_options_t* fclaw_opt = fclaw2d_get_options(glob);
+	fclaw_opt->manifold = 0;
 
-    /* Use [ax,bx]x[ay,by] */
-    conn = p4est_connectivity_new_unitsquare();
-    cont = fclaw2d_map_new_nomap();
+	fclaw2d_domain_t *domain = fclaw2d_domain_new_unitsquare(glob->mpicomm, fclaw_opt->minlevel);
 
-    domain = fclaw2d_domain_new_conn_map (mpicomm, fclaw_opt->minlevel, conn, cont);
-    fclaw2d_domain_list_levels(domain, FCLAW_VERBOSITY_ESSENTIAL);
-    fclaw2d_domain_list_neighbors(domain, FCLAW_VERBOSITY_DEBUG);  
-    return domain;
+	fclaw2d_map_context_t *cont = fclaw2d_map_new_nomap();
+
+	fclaw2d_global_store_domain(glob, domain);
+	fclaw2d_global_store_map(glob, cont);
+
+	fclaw2d_domain_list_levels(domain, FCLAW_VERBOSITY_ESSENTIAL);
+	fclaw2d_domain_list_neighbors(domain, FCLAW_VERBOSITY_DEBUG);  
 }
 
 static
@@ -95,22 +92,14 @@ void run_program(fclaw2d_global_t* glob)
 int
 main (int argc, char **argv)
 {
-    fclaw_app_t *app;
-    int first_arg;
-    fclaw_exit_type_t vexit;
+    /* Initialize application */
+    fclaw_app_t *app = fclaw_app_new (&argc, &argv, NULL);
 
     /* Options */
     user_options_t              *user_opt;
     fclaw_options_t             *fclaw_opt;
     fclaw2d_clawpatch_options_t *clawpatch_opt;
     fc2d_cudaclaw_options_t     *cuclaw_opt;
-
-    fclaw2d_global_t            *glob;
-    fclaw2d_domain_t            *domain;
-    sc_MPI_Comm mpicomm;
-
-    /* Initialize application */
-    app = fclaw_app_new (&argc, &argv, NULL);
 
     /* Create new options packages */
     fclaw_opt =                   fclaw_options_register(app,  NULL,       "fclaw_options.ini");
@@ -119,19 +108,19 @@ main (int argc, char **argv)
     user_opt =                   radial_options_register(app,              "fclaw_options.ini");  
 
     /* Read configuration file(s) and command line, and process options */
+    int first_arg;
+    fclaw_exit_type_t vexit;
     vexit =  fclaw_app_options_parse (app, &first_arg,"fclaw_options.ini.used");
 
     /* Run the program */
     if (!vexit)
     {
         /* Options have been checked and are valid */
-
-        mpicomm = fclaw_app_get_mpi_size_rank (app, NULL, NULL);
-        domain = create_domain(mpicomm, fclaw_opt,user_opt);
+        int size, rank;
+        sc_MPI_Comm mpicomm = fclaw_app_get_mpi_size_rank (app, &size, &rank);
     
         /* Create global structure which stores the domain, timers, etc */
-        glob = fclaw2d_global_new();
-        fclaw2d_global_store_domain(glob, domain);
+        fclaw2d_global_t *glob = fclaw2d_global_new_comm(mpicomm, size, rank);
 
         /* Store option packages in glob */
         fclaw2d_options_store           (glob, fclaw_opt);
@@ -139,6 +128,8 @@ main (int argc, char **argv)
         fc2d_cudaclaw_options_store     (glob, cuclaw_opt);
         radial_options_store            (glob, user_opt);
 
+        create_domain(glob);
+        
         run_program(glob);
 
         fclaw2d_global_destroy(glob);

--- a/applications/cudaclaw/advection/2d/swirl/swirl.cpp
+++ b/applications/cudaclaw/advection/2d/swirl/swirl.cpp
@@ -23,8 +23,6 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "fclaw2d_convenience.h"
-#include "fclaw2d_map.h"
 #include "swirl_user.h"
 
 #include <fc2d_cuda_profiler.h>

--- a/applications/cudaclaw/advection/2d/swirl/swirl.cpp
+++ b/applications/cudaclaw/advection/2d/swirl/swirl.cpp
@@ -23,27 +23,27 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "fclaw2d_convenience.h"
+#include "fclaw2d_map.h"
 #include "swirl_user.h"
 
 #include <fc2d_cuda_profiler.h>
 
 static
-fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm, fclaw_options_t* gparms)
+void create_domain(fclaw2d_global_t* glob)
 {
-	/* Mapped, multi-block domain */
-	p4est_connectivity_t     *conn = NULL;
-	fclaw2d_domain_t         *domain;
-	fclaw2d_map_context_t    *cont = NULL;
+	fclaw_options_t* fclaw_opt = fclaw2d_get_options(glob);
+	fclaw_opt->manifold = 0;
 
-	/* Map unit square to disk using mapc2m_disk.f */
-	gparms->manifold = 0;
-	conn = p4est_connectivity_new_unitsquare();
-	cont = fclaw2d_map_new_nomap();
+	fclaw2d_domain_t *domain = fclaw2d_domain_new_unitsquare(glob->mpicomm, fclaw_opt->minlevel);
 
-	domain = fclaw2d_domain_new_conn_map (mpicomm, gparms->minlevel, conn, cont);
+	fclaw2d_map_context_t *cont = fclaw2d_map_new_nomap();
+
+	fclaw2d_global_store_domain(glob, domain);
+	fclaw2d_global_store_map(glob, cont);
+
 	fclaw2d_domain_list_levels(domain, FCLAW_VERBOSITY_ESSENTIAL);
 	fclaw2d_domain_list_neighbors(domain, FCLAW_VERBOSITY_DEBUG);  
-	return domain;
 }
 
 	static
@@ -92,22 +92,14 @@ main (int argc, char **argv)
 
 	PROFILE_CUDA_GROUP("Swirl : Main",1);
 
-	fclaw_app_t *app;
-	int first_arg;
-	fclaw_exit_type_t vexit;
+	/* Initialize application */
+	fclaw_app_t *app = fclaw_app_new (&argc, &argv, NULL);
 
 	/* Options */
 	user_options_t              *user_opt;
 	fclaw_options_t             *fclaw_opt;
 	fclaw2d_clawpatch_options_t *clawpatch_opt;
 	fc2d_cudaclaw_options_t    *cuclaw_opt;
-
-	fclaw2d_global_t            *glob;
-	fclaw2d_domain_t            *domain;
-	sc_MPI_Comm mpicomm;
-
-	/* Initialize application */
-	app = fclaw_app_new (&argc, &argv, NULL);
 
 	/* Create new options packages */
 	fclaw_opt =                   fclaw_options_register(app,  NULL,       "fclaw_options.ini");
@@ -116,25 +108,27 @@ main (int argc, char **argv)
 	user_opt =                    swirl_options_register(app,              "fclaw_options.ini");  
 
 	/* Read configuration file(s) and command line, and process options */
+	int first_arg;
+	fclaw_exit_type_t vexit;
 	vexit =  fclaw_app_options_parse (app, &first_arg,"fclaw_options.ini.used");
 
 	/* Run the program */
 	if (!vexit)
 	{
 		/* Options have been checked and are valid */
-
-		mpicomm = fclaw_app_get_mpi_size_rank (app, NULL, NULL);
-		domain = create_domain(mpicomm, fclaw_opt);
+		int size, rank;
+		sc_MPI_Comm mpicomm = fclaw_app_get_mpi_size_rank (app, &size, &rank);
 
 		/* Create global structure which stores the domain, timers, etc */
-		glob = fclaw2d_global_new();
-		fclaw2d_global_store_domain(glob, domain);
+		fclaw2d_global_t *glob = fclaw2d_global_new_comm(mpicomm, size, rank);
 
 		/* Store option packages in glob */
 		fclaw2d_options_store           (glob, fclaw_opt);
 		fclaw2d_clawpatch_options_store (glob, clawpatch_opt);
 		fc2d_cudaclaw_options_store    (glob, cuclaw_opt);
 		swirl_options_store             (glob, user_opt);
+
+		create_domain(glob);
 
 		run_program(glob);
 

--- a/applications/cudaclaw/euler/2d/shockbubble/shockbubble.cpp
+++ b/applications/cudaclaw/euler/2d/shockbubble/shockbubble.cpp
@@ -23,19 +23,18 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#include "fclaw2d_convenience.h"
+#include "fclaw2d_global.h"
+#include "fclaw_options.h"
 #include "shockbubble_user.h"
 
 #include <fc2d_cuda_profiler.h>
 
 static
-fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm, 
-                                fclaw_options_t* fclaw_opt)
+void create_domain(fclaw2d_global_t* glob)
 {
     /* Mapped, multi-block domain */
-    p4est_connectivity_t     *conn = NULL;
-    fclaw2d_domain_t         *domain;
-    fclaw2d_map_context_t    *cont = NULL, *brick = NULL;
-
+    fclaw_options_t* fclaw_opt = fclaw2d_get_options(glob);
 
     int mi,mj,a,b;
     mi = fclaw_opt->mi;
@@ -43,17 +42,19 @@ fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm,
     a = fclaw_opt->periodic_x;
     b = fclaw_opt->periodic_y;
 
-    /* Use [ax,bx]x[ay,by] */
+    fclaw2d_domain_t* domain = 
+        fclaw2d_domain_new_brick(glob->mpicomm, mi, mj, a, b, fclaw_opt->minlevel);
 
-    conn = p4est_connectivity_new_brick(mi,mj,a,b);
-    brick = fclaw2d_map_new_brick_conn (conn,mi,mj);
+    /* Use [ax,bx]x[ay,by] */
+    fclaw2d_map_context_t    *cont = NULL, *brick = NULL;
+    brick = fclaw2d_map_new_brick (domain, mi, mj, a, b);
     cont = fclaw2d_map_new_nomap_brick(brick);
 
-    domain = fclaw2d_domain_new_conn_map (mpicomm, 
-                                          fclaw_opt->minlevel, conn, cont);
+    fclaw2d_global_store_domain(glob, domain);
+    fclaw2d_global_store_map(glob, cont);
+
     fclaw2d_domain_list_levels(domain, FCLAW_VERBOSITY_ESSENTIAL);
     fclaw2d_domain_list_neighbors(domain, FCLAW_VERBOSITY_DEBUG);  
-    return domain;    
 }
 
 static
@@ -100,22 +101,14 @@ void run_program(fclaw2d_global_t* glob)
 int
 main (int argc, char **argv)
 {
-    fclaw_app_t *app;
-    int first_arg;
-    fclaw_exit_type_t vexit;
+    /* Initialize application */
+    fclaw_app_t *app = fclaw_app_new (&argc, &argv, NULL);
 
     /* Options */
     user_options_t              *user_opt;
     fclaw_options_t             *fclaw_opt;
     fclaw2d_clawpatch_options_t *clawpatch_opt;
     fc2d_cudaclaw_options_t     *cuclaw_opt;
-
-    fclaw2d_global_t            *glob;
-    fclaw2d_domain_t            *domain;
-    sc_MPI_Comm mpicomm;
-
-    /* Initialize application */
-    app = fclaw_app_new (&argc, &argv, NULL);
 
     /* Create new options packages */
     fclaw_opt =                   fclaw_options_register(app,  NULL,       "fclaw_options.ini");
@@ -124,24 +117,26 @@ main (int argc, char **argv)
     user_opt =              shockbubble_options_register(app,              "fclaw_options.ini");  
 
     /* Read configuration file(s) and command line, and process options */
+    int first_arg;
+    fclaw_exit_type_t vexit;
     vexit =  fclaw_app_options_parse (app, &first_arg,"fclaw_options.ini.used");
 
     if (!vexit)
     {
         /* Options have been checked and are valid */
-
-        mpicomm = fclaw_app_get_mpi_size_rank (app, NULL, NULL);
-        domain = create_domain(mpicomm, fclaw_opt);
+        int size, rank;
+        sc_MPI_Comm mpicomm = fclaw_app_get_mpi_size_rank (app, &size, &rank);
     
         /* Create global structure which stores the domain, timers, etc */
-        glob = fclaw2d_global_new();
-        fclaw2d_global_store_domain(glob, domain);
+        fclaw2d_global_t *glob = fclaw2d_global_new_comm(mpicomm, size, rank);
 
         /* Store option packages in glob */
         fclaw2d_options_store           (glob, fclaw_opt);
         fclaw2d_clawpatch_options_store (glob, clawpatch_opt);
         fc2d_cudaclaw_options_store     (glob, cuclaw_opt);
         shockbubble_options_store       (glob, user_opt);
+
+        create_domain(glob);
 
         /* Run the program */
         run_program(glob);

--- a/applications/cudaclaw/euler/2d/shockbubble/shockbubble.cpp
+++ b/applications/cudaclaw/euler/2d/shockbubble/shockbubble.cpp
@@ -23,9 +23,6 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "fclaw2d_convenience.h"
-#include "fclaw2d_global.h"
-#include "fclaw_options.h"
 #include "shockbubble_user.h"
 
 #include <fc2d_cuda_profiler.h>

--- a/applications/cudaclaw/shallow/2d/bump/bump.cpp
+++ b/applications/cudaclaw/shallow/2d/bump/bump.cpp
@@ -28,23 +28,20 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <fc2d_cuda_profiler.h>
 
 static
-fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm, 
-                                fclaw_options_t* fclaw_opt,
-                                user_options_t* user)
+void create_domain(fclaw2d_global_t* glob)
 {
-    /* Mapped, multi-block domain */
-    p4est_connectivity_t     *conn = NULL;
-    fclaw2d_domain_t         *domain;
-    fclaw2d_map_context_t    *cont = NULL;
+	fclaw_options_t* fclaw_opt = fclaw2d_get_options(glob);
+	fclaw_opt->manifold = 0;
 
-    /* Use [ax,bx]x[ay,by] */
-    conn = p4est_connectivity_new_unitsquare();
-    cont = fclaw2d_map_new_nomap();
+	fclaw2d_domain_t *domain = fclaw2d_domain_new_unitsquare(glob->mpicomm, fclaw_opt->minlevel);
 
-    domain = fclaw2d_domain_new_conn_map (mpicomm, fclaw_opt->minlevel, conn, cont);
-    fclaw2d_domain_list_levels(domain, FCLAW_VERBOSITY_ESSENTIAL);
-    fclaw2d_domain_list_neighbors(domain, FCLAW_VERBOSITY_DEBUG);  
-    return domain;
+	fclaw2d_map_context_t *cont = fclaw2d_map_new_nomap();
+
+	fclaw2d_global_store_domain(glob, domain);
+	fclaw2d_global_store_map(glob, cont);
+
+	fclaw2d_domain_list_levels(domain, FCLAW_VERBOSITY_ESSENTIAL);
+	fclaw2d_domain_list_neighbors(domain, FCLAW_VERBOSITY_DEBUG);  
 }
 
 static
@@ -95,9 +92,8 @@ void run_program(fclaw2d_global_t* glob)
 int
 main (int argc, char **argv)
 {
-    fclaw_app_t *app;
-    int first_arg;
-    fclaw_exit_type_t vexit;
+    /* Initialize application */
+    fclaw_app_t *app = fclaw_app_new (&argc, &argv, NULL);
 
     /* Options */
     user_options_t              *user_opt;
@@ -105,12 +101,6 @@ main (int argc, char **argv)
     fclaw2d_clawpatch_options_t *clawpatch_opt;
     fc2d_cudaclaw_options_t     *cuclaw_opt;
 
-    fclaw2d_global_t            *glob;
-    fclaw2d_domain_t            *domain;
-    sc_MPI_Comm mpicomm;
-
-    /* Initialize application */
-    app = fclaw_app_new (&argc, &argv, NULL);
 
     /* Create new options packages */
     fclaw_opt =                   fclaw_options_register(app,  NULL,       "fclaw_options.ini");
@@ -119,25 +109,27 @@ main (int argc, char **argv)
     user_opt =                     bump_options_register(app,              "fclaw_options.ini");  
 
     /* Read configuration file(s) and command line, and process options */
+    int first_arg;
+    fclaw_exit_type_t vexit;
     vexit =  fclaw_app_options_parse (app, &first_arg,"fclaw_options.ini.used");
 
     /* Run the program */
     if (!vexit)
     {
         /* Options have been checked and are valid */
-
-        mpicomm = fclaw_app_get_mpi_size_rank (app, NULL, NULL);
-        domain = create_domain(mpicomm, fclaw_opt,user_opt);
+        int size, rank;
+        sc_MPI_Comm mpicomm = fclaw_app_get_mpi_size_rank (app, &size, &rank);
     
         /* Create global structure which stores the domain, timers, etc */
-        glob = fclaw2d_global_new();
-        fclaw2d_global_store_domain(glob, domain);
+        fclaw2d_global_t *glob = fclaw2d_global_new_comm(mpicomm, size, rank);
 
         /* Store option packages in glob */
         fclaw2d_options_store           (glob, fclaw_opt);
         fclaw2d_clawpatch_options_store (glob, clawpatch_opt);
         fc2d_cudaclaw_options_store     (glob, cuclaw_opt);
         bump_options_store              (glob, user_opt);
+
+        create_domain(glob);
 
         run_program(glob);
         

--- a/applications/elliptic/heat/heat.cpp
+++ b/applications/elliptic/heat/heat.cpp
@@ -40,12 +40,10 @@
 
 
 static
-fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm, fclaw_options_t* fclaw_opt)
+void create_domain(fclaw2d_global_t* glob)
 {
     /* Mapped, multi-block domain */
-    p4est_connectivity_t     *conn = NULL;
-    fclaw2d_domain_t         *domain;
-    fclaw2d_map_context_t    *cont = NULL, *brick = NULL;
+    fclaw_options_t *fclaw_opt = fclaw2d_get_options(glob);
  
     int mi = fclaw_opt->mi;
     int mj = fclaw_opt->mj;
@@ -53,15 +51,17 @@ fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm, fclaw_options_t* fclaw_opt)
     int a = fclaw_opt->periodic_x;
     int b = fclaw_opt->periodic_y;
 
-    /* Map unit square to disk using mapc2m_disk.f */
-    conn = p4est_connectivity_new_brick(mi,mj,a,b);
-    brick = fclaw2d_map_new_brick_conn (conn,mi,mj);
-    cont = fclaw2d_map_new_nomap_brick(brick);
+    fclaw2d_domain_t *domain = fclaw2d_domain_new_brick(glob->mpicomm, mi,mj,a,b, fclaw_opt->minlevel);
 
-    domain = fclaw2d_domain_new_conn_map (mpicomm, fclaw_opt->minlevel, conn, cont);
+    /* Map unit square to disk using mapc2m_disk.f */
+    fclaw2d_map_context_t *brick = fclaw2d_map_new_brick(domain, mi, mj, a, b);
+    fclaw2d_map_context_t *cont = fclaw2d_map_new_nomap_brick(brick);
+
+    fclaw2d_global_store_domain(glob, domain);
+    fclaw2d_global_store_map(glob, cont);
+
     fclaw2d_domain_list_levels(domain, FCLAW_VERBOSITY_ESSENTIAL);
     fclaw2d_domain_list_neighbors(domain, FCLAW_VERBOSITY_DEBUG);  
-    return domain;
 }
 
 static
@@ -104,23 +104,14 @@ void run_program(fclaw2d_global_t* glob)
 int
 main (int argc, char **argv)
 {
-    fclaw_app_t *app;
-    int first_arg;
-    fclaw_exit_type_t vexit;
+    /* Initialize application */
+    fclaw_app_t *app = fclaw_app_new (&argc, &argv, NULL);
 
     /* Options */
     fclaw_options_t             *fclaw_opt;
-
     fclaw2d_clawpatch_options_t *clawpatch_opt;
     fc2d_thunderegg_options_t    *mg_opt;
     heat_options_t              *user_opt;
-
-    fclaw2d_global_t            *glob;
-    fclaw2d_domain_t            *domain;
-    sc_MPI_Comm mpicomm;
-
-    /* Initialize application */
-    app = fclaw_app_new (&argc, &argv, NULL);
 
     /* Create new options packages */
     fclaw_opt =                   fclaw_options_register(app,  NULL,        "fclaw_options.ini");
@@ -129,25 +120,27 @@ main (int argc, char **argv)
     user_opt =                     heat_options_register(app,               "fclaw_options.ini");  
 
     /* Read configuration file(s) and command line, and process options */
+    int first_arg;
+    fclaw_exit_type_t vexit;
     vexit =  fclaw_app_options_parse (app, &first_arg,"fclaw_options.ini.used");
 
     /* Run the program */
     if (!vexit)
     {
         /* Options have been checked and are valid */
-
-        mpicomm = fclaw_app_get_mpi_size_rank (app, NULL, NULL);
-        domain = create_domain(mpicomm, fclaw_opt);
+        int size, rank;
+        sc_MPI_Comm mpicomm = fclaw_app_get_mpi_size_rank (app, &size, &rank);
     
         /* Create global structure which stores the domain, timers, etc */
-        glob = fclaw2d_global_new();
-        fclaw2d_global_store_domain(glob, domain);
+        fclaw2d_global_t *glob = fclaw2d_global_new_comm(mpicomm, size, rank);
 
         /* Store option packages in glob */
         fclaw2d_options_store           (glob, fclaw_opt);
         fclaw2d_clawpatch_options_store (glob, clawpatch_opt);
         fc2d_thunderegg_options_store    (glob, mg_opt);
         heat_options_store            (glob, user_opt);
+
+        create_domain(glob);
 
         run_program(glob);
 

--- a/applications/elliptic/heat_phasefield/heat/heat_user.h
+++ b/applications/elliptic/heat_phasefield/heat/heat_user.h
@@ -177,7 +177,7 @@ void HEAT_FORT_BC2(const int* meqn, const int* mbc,
                    double q[], double* t, double *dt, 
                    int intersects_bc[]);
 
-fclaw2d_domain_t* heat_create_domain(sc_MPI_Comm mpicomm, fclaw_options_t* fclaw_opt);
+void heat_create_domain(fclaw2d_global_t* glob);
 
 void heat_run_program(fclaw2d_global_t* glob);
 

--- a/applications/elliptic/heat_phasefield/heat_phasefield.cpp
+++ b/applications/elliptic/heat_phasefield/heat_phasefield.cpp
@@ -43,38 +43,24 @@
 int
 main (int argc, char **argv)
 {
-    fclaw_app_t *app;
-    int first_arg;
-    fclaw_exit_type_t vexit;
+    /* Initialize application */
+    fclaw_app_t *app = fclaw_app_new (&argc, &argv, NULL);
 
-    /* Options */
+    /* Create new options packages */
     fclaw_options_t             *heat_fclaw_opt;
-
     fclaw2d_clawpatch_options_t *heat_clawpatch_opt;
     fc2d_thunderegg_options_t   *heat_mg_opt;
     heat_options_t              *heat_user_opt;
 
-    fclaw2d_global_t            *heat_glob;
-    fclaw2d_domain_t            *heat_domain;
-
-    fclaw_options_t             *phasefield_fclaw_opt;
-
-    fclaw2d_clawpatch_options_t *phasefield_clawpatch_opt;
-    fc2d_thunderegg_options_t   *phasefield_mg_opt;
-    phasefield_options_t        *phasefield_user_opt;
-
-    fclaw2d_global_t            *phasefield_glob;
-    fclaw2d_domain_t            *phasefield_domain;
-    sc_MPI_Comm mpicomm;
-
-    /* Initialize application */
-    app = fclaw_app_new (&argc, &argv, NULL);
-
-    /* Create new options packages */
     heat_fclaw_opt =                   fclaw_options_register(app, "heat",            "fclaw_options.ini");
     heat_clawpatch_opt =   fclaw2d_clawpatch_options_register(app, "heat-clawpatch",  "fclaw_options.ini");
     heat_mg_opt =            fc2d_thunderegg_options_register(app, "heat-thunderegg", "fclaw_options.ini");
     heat_user_opt =                     heat_options_register(app, "heat-user",       "fclaw_options.ini");  
+
+    fclaw_options_t             *phasefield_fclaw_opt;
+    fclaw2d_clawpatch_options_t *phasefield_clawpatch_opt;
+    fc2d_thunderegg_options_t   *phasefield_mg_opt;
+    phasefield_options_t        *phasefield_user_opt;
 
     phasefield_fclaw_opt =                   fclaw_options_register(app, "phasefield",           "fclaw_options.ini");
     phasefield_clawpatch_opt =   fclaw2d_clawpatch_options_register(app, "phasefield-clawpatch",  "fclaw_options.ini");
@@ -82,19 +68,19 @@ main (int argc, char **argv)
     phasefield_user_opt =               phasefield_options_register(app, "phasefield-user",       "fclaw_options.ini");  
 
     /* Read configuration file(s) and command line, and process options */
+    int first_arg;
+    fclaw_exit_type_t vexit;
     vexit =  fclaw_app_options_parse (app, &first_arg,"fclaw_options.ini.used");
 
     /* Run the program */
     if (!vexit)
     {
         /* Options have been checked and are valid */
-
-        mpicomm = fclaw_app_get_mpi_size_rank (app, NULL, NULL);
-        heat_domain = heat_create_domain(mpicomm, heat_fclaw_opt);
+        int size, rank;
+        sc_MPI_Comm mpicomm = fclaw_app_get_mpi_size_rank (app, &size, &rank);
     
         /* Create global structure which stores the domain, timers, etc */
-        heat_glob = fclaw2d_global_new();
-        fclaw2d_global_store_domain(heat_glob, heat_domain);
+        fclaw2d_global_t *heat_glob = fclaw2d_global_new_comm(mpicomm, size, rank);
 
         /* Store option packages in glob */
         fclaw2d_options_store           (heat_glob, heat_fclaw_opt);
@@ -102,20 +88,23 @@ main (int argc, char **argv)
         fc2d_thunderegg_options_store    (heat_glob, heat_mg_opt);
         heat_options_store            (heat_glob, heat_user_opt);
 
+        heat_create_domain(heat_glob);
+
         heat_run_program(heat_glob);
 
         fclaw2d_global_destroy(heat_glob);        
-        phasefield_domain = phasefield_create_domain(mpicomm, phasefield_fclaw_opt);
+
     
         /* Create global structure which stores the domain, timers, etc */
-        phasefield_glob = fclaw2d_global_new();
-        fclaw2d_global_store_domain(phasefield_glob, phasefield_domain);
+        fclaw2d_global_t *phasefield_glob = fclaw2d_global_new_comm(mpicomm, size, rank);
 
         /* Store option packages in glob */
         fclaw2d_options_store           (phasefield_glob, phasefield_fclaw_opt);
         fclaw2d_clawpatch_options_store (phasefield_glob, phasefield_clawpatch_opt);
         fc2d_thunderegg_options_store    (phasefield_glob, phasefield_mg_opt);
         phasefield_options_store            (phasefield_glob, phasefield_user_opt);
+
+        phasefield_create_domain(heat_glob);
 
         phasefield_run_program(phasefield_glob);
 

--- a/applications/elliptic/heat_phasefield/heat_phasefield.cpp
+++ b/applications/elliptic/heat_phasefield/heat_phasefield.cpp
@@ -104,7 +104,7 @@ main (int argc, char **argv)
         fc2d_thunderegg_options_store    (phasefield_glob, phasefield_mg_opt);
         phasefield_options_store            (phasefield_glob, phasefield_user_opt);
 
-        phasefield_create_domain(heat_glob);
+        phasefield_create_domain(phasefield_glob);
 
         phasefield_run_program(phasefield_glob);
 

--- a/applications/elliptic/heat_phasefield/phasefield/phasefield.cpp
+++ b/applications/elliptic/heat_phasefield/phasefield/phasefield.cpp
@@ -42,13 +42,10 @@
 #include <fc2d_thunderegg.h>
 #include <fc2d_thunderegg_options.h>
 
-
-fclaw2d_domain_t* phasefield_create_domain(sc_MPI_Comm mpicomm, fclaw_options_t* fclaw_opt)
+void phasefield_create_domain(fclaw2d_global_t* glob)
 {
     /* Mapped, multi-block domain */
-    p4est_connectivity_t     *conn = NULL;
-    fclaw2d_domain_t         *domain;
-    fclaw2d_map_context_t    *cont = NULL, *brick = NULL;
+    fclaw_options_t *fclaw_opt = fclaw2d_get_options(glob);
  
     int mi = fclaw_opt->mi;
     int mj = fclaw_opt->mj;
@@ -56,15 +53,17 @@ fclaw2d_domain_t* phasefield_create_domain(sc_MPI_Comm mpicomm, fclaw_options_t*
     int a = fclaw_opt->periodic_x;
     int b = fclaw_opt->periodic_y;
 
-    /* Map unit square to disk using mapc2m_disk.f */
-    conn = p4est_connectivity_new_brick(mi,mj,a,b);
-    brick = fclaw2d_map_new_brick_conn (conn,mi,mj);
-    cont = fclaw2d_map_new_nomap_brick(brick);
+    fclaw2d_domain_t *domain = fclaw2d_domain_new_brick(glob->mpicomm, mi,mj,a,b, fclaw_opt->minlevel);
 
-    domain = fclaw2d_domain_new_conn_map (mpicomm, fclaw_opt->minlevel, conn, cont);
+    /* Map unit square to disk using mapc2m_disk.f */
+    fclaw2d_map_context_t *brick = fclaw2d_map_new_brick(domain, mi, mj, a, b);
+    fclaw2d_map_context_t *cont = fclaw2d_map_new_nomap_brick(brick);
+
+    fclaw2d_global_store_domain(glob, domain);
+    fclaw2d_global_store_map(glob, cont);
+
     fclaw2d_domain_list_levels(domain, FCLAW_VERBOSITY_ESSENTIAL);
     fclaw2d_domain_list_neighbors(domain, FCLAW_VERBOSITY_DEBUG);  
-    return domain;
 }
 
 void phasefield_run_program(fclaw2d_global_t* glob)

--- a/applications/elliptic/heat_phasefield/phasefield/phasefield_user.h
+++ b/applications/elliptic/heat_phasefield/phasefield/phasefield_user.h
@@ -48,7 +48,7 @@ void phasefield_link_solvers(fclaw2d_global_t *glob);
 
 void phasefield_run(fclaw2d_global_t *glob);
 
-fclaw2d_domain_t* phasefield_create_domain(sc_MPI_Comm mpicomm, fclaw_options_t* fclaw_opt);
+void phasefield_create_domain(fclaw2d_global_t* glob);
 
 void phasefield_run_program(fclaw2d_global_t* glob);
 

--- a/applications/elliptic/phasefield/phasefield.cpp
+++ b/applications/elliptic/phasefield/phasefield.cpp
@@ -38,14 +38,11 @@
 #include <fc2d_thunderegg.h>
 #include <fc2d_thunderegg_options.h>
 
-
 static
-fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm, fclaw_options_t* fclaw_opt)
+void create_domain(fclaw2d_global_t* glob)
 {
     /* Mapped, multi-block domain */
-    p4est_connectivity_t     *conn = NULL;
-    fclaw2d_domain_t         *domain;
-    fclaw2d_map_context_t    *cont = NULL, *brick = NULL;
+    fclaw_options_t *fclaw_opt = fclaw2d_get_options(glob);
  
     int mi = fclaw_opt->mi;
     int mj = fclaw_opt->mj;
@@ -53,15 +50,17 @@ fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm, fclaw_options_t* fclaw_opt)
     int a = fclaw_opt->periodic_x;
     int b = fclaw_opt->periodic_y;
 
-    /* Map unit square to disk using mapc2m_disk.f */
-    conn = p4est_connectivity_new_brick(mi,mj,a,b);
-    brick = fclaw2d_map_new_brick_conn (conn,mi,mj);
-    cont = fclaw2d_map_new_nomap_brick(brick);
+    fclaw2d_domain_t *domain = fclaw2d_domain_new_brick(glob->mpicomm, mi,mj,a,b, fclaw_opt->minlevel);
 
-    domain = fclaw2d_domain_new_conn_map (mpicomm, fclaw_opt->minlevel, conn, cont);
+    /* Map unit square to disk using mapc2m_disk.f */
+    fclaw2d_map_context_t *brick = fclaw2d_map_new_brick(domain, mi, mj, a, b);
+    fclaw2d_map_context_t *cont = fclaw2d_map_new_nomap_brick(brick);
+
+    fclaw2d_global_store_domain(glob, domain);
+    fclaw2d_global_store_map(glob, cont);
+
     fclaw2d_domain_list_levels(domain, FCLAW_VERBOSITY_ESSENTIAL);
     fclaw2d_domain_list_neighbors(domain, FCLAW_VERBOSITY_DEBUG);  
-    return domain;
 }
 
 static
@@ -104,23 +103,14 @@ void run_program(fclaw2d_global_t* glob)
 int
 main (int argc, char **argv)
 {
-    fclaw_app_t *app;
-    int first_arg;
-    fclaw_exit_type_t vexit;
+    /* Initialize application */
+    fclaw_app_t *app = fclaw_app_new (&argc, &argv, NULL);
 
     /* Options */
     fclaw_options_t             *fclaw_opt;
-
     fclaw2d_clawpatch_options_t *clawpatch_opt;
     fc2d_thunderegg_options_t    *mg_opt;
     phasefield_options_t              *user_opt;
-
-    fclaw2d_global_t            *glob;
-    fclaw2d_domain_t            *domain;
-    sc_MPI_Comm mpicomm;
-
-    /* Initialize application */
-    app = fclaw_app_new (&argc, &argv, NULL);
 
     /* Create new options packages */
     fclaw_opt =                   fclaw_options_register(app,  NULL,        "fclaw_options.ini");
@@ -129,25 +119,27 @@ main (int argc, char **argv)
     user_opt =               phasefield_options_register(app,               "fclaw_options.ini");  
 
     /* Read configuration file(s) and command line, and process options */
+    int first_arg;
+    fclaw_exit_type_t vexit;
     vexit =  fclaw_app_options_parse (app, &first_arg,"fclaw_options.ini.used");
 
     /* Run the program */
     if (!vexit)
     {
         /* Options have been checked and are valid */
-
-        mpicomm = fclaw_app_get_mpi_size_rank (app, NULL, NULL);
-        domain = create_domain(mpicomm, fclaw_opt);
+        int size, rank;
+        sc_MPI_Comm mpicomm = fclaw_app_get_mpi_size_rank (app, &size, &rank);
     
         /* Create global structure which stores the domain, timers, etc */
-        glob = fclaw2d_global_new();
-        fclaw2d_global_store_domain(glob, domain);
+        fclaw2d_global_t *glob = fclaw2d_global_new_comm(mpicomm, size, rank);
 
         /* Store option packages in glob */
         fclaw2d_options_store           (glob, fclaw_opt);
         fclaw2d_clawpatch_options_store (glob, clawpatch_opt);
         fc2d_thunderegg_options_store    (glob, mg_opt);
         phasefield_options_store            (glob, user_opt);
+
+        create_domain(glob);
 
         run_program(glob);
 

--- a/applications/elliptic/poisson/poisson.cpp
+++ b/applications/elliptic/poisson/poisson.cpp
@@ -40,12 +40,10 @@
 
 
 static
-fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm, fclaw_options_t* fclaw_opt)
+void create_domain(fclaw2d_global_t* glob)
 {
     /* Mapped, multi-block domain */
-    p4est_connectivity_t     *conn = NULL;
-    fclaw2d_domain_t         *domain;
-    fclaw2d_map_context_t    *cont = NULL, *brick = NULL;
+    fclaw_options_t *fclaw_opt = fclaw2d_get_options(glob);
  
     int mi = fclaw_opt->mi;
     int mj = fclaw_opt->mj;
@@ -53,15 +51,17 @@ fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm, fclaw_options_t* fclaw_opt)
     int a = fclaw_opt->periodic_x;
     int b = fclaw_opt->periodic_y;
 
-    /* Map unit square to disk using mapc2m_disk.f */
-    conn = p4est_connectivity_new_brick(mi,mj,a,b);
-    brick = fclaw2d_map_new_brick_conn (conn,mi,mj);
-    cont = fclaw2d_map_new_nomap_brick(brick);
+    fclaw2d_domain_t *domain = fclaw2d_domain_new_brick(glob->mpicomm, mi,mj,a,b, fclaw_opt->minlevel);
 
-    domain = fclaw2d_domain_new_conn_map (mpicomm, fclaw_opt->minlevel, conn, cont);
+    /* Map unit square to disk using mapc2m_disk.f */
+    fclaw2d_map_context_t *brick = fclaw2d_map_new_brick(domain, mi, mj, a, b);
+    fclaw2d_map_context_t *cont = fclaw2d_map_new_nomap_brick(brick);
+
+    fclaw2d_global_store_domain(glob, domain);
+    fclaw2d_global_store_map(glob, cont);
+
     fclaw2d_domain_list_levels(domain, FCLAW_VERBOSITY_ESSENTIAL);
     fclaw2d_domain_list_neighbors(domain, FCLAW_VERBOSITY_DEBUG);  
-    return domain;
 }
 
 static
@@ -121,23 +121,14 @@ void run_program(fclaw2d_global_t* glob)
 int
 main (int argc, char **argv)
 {
-    fclaw_app_t *app;
-    int first_arg;
-    fclaw_exit_type_t vexit;
+    /* Initialize application */
+    fclaw_app_t *app = fclaw_app_new (&argc, &argv, NULL);
 
     /* Options */
     fclaw_options_t             *fclaw_opt;
-
     fclaw2d_clawpatch_options_t *clawpatch_opt;
     fc2d_thunderegg_options_t    *mg_opt;
     poisson_options_t              *user_opt;
-
-    fclaw2d_global_t            *glob;
-    fclaw2d_domain_t            *domain;
-    sc_MPI_Comm mpicomm;
-
-    /* Initialize application */
-    app = fclaw_app_new (&argc, &argv, NULL);
 
     /* Create new options packages */
     fclaw_opt =                   fclaw_options_register(app,  NULL,        "fclaw_options.ini");
@@ -146,25 +137,27 @@ main (int argc, char **argv)
     user_opt =                  poisson_options_register(app,               "fclaw_options.ini");  
 
     /* Read configuration file(s) and command line, and process options */
+    int first_arg;
+    fclaw_exit_type_t vexit;
     vexit =  fclaw_app_options_parse (app, &first_arg,"fclaw_options.ini.used");
 
     /* Run the program */
     if (!vexit)
     {
         /* Options have been checked and are valid */
-
-        mpicomm = fclaw_app_get_mpi_size_rank (app, NULL, NULL);
-        domain = create_domain(mpicomm, fclaw_opt);
+        int size, rank;
+        sc_MPI_Comm mpicomm = fclaw_app_get_mpi_size_rank (app, &size, &rank);
     
         /* Create global structure which stores the domain, timers, etc */
-        glob = fclaw2d_global_new();
-        fclaw2d_global_store_domain(glob, domain);
+        fclaw2d_global_t *glob = fclaw2d_global_new_comm(mpicomm, size, rank);
 
         /* Store option packages in glob */
         fclaw2d_options_store           (glob, fclaw_opt);
         fclaw2d_clawpatch_options_store (glob, clawpatch_opt);
         fc2d_thunderegg_options_store    (glob, mg_opt);
         poisson_options_store            (glob, user_opt);
+
+        create_domain(glob);
 
         run_program(glob);
 

--- a/applications/geoclaw/bowl_radial/bowl.cpp
+++ b/applications/geoclaw/bowl_radial/bowl.cpp
@@ -34,22 +34,21 @@
 #include <fc2d_geoclaw_options.h>
 
 static
-fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm, 
-                                fclaw_options_t* gparms)
+void create_domain(fclaw2d_global_t* glob)
 {
-    p4est_connectivity_t     *conn = NULL;
-    fclaw2d_domain_t         *domain;
-    fclaw2d_map_context_t    *cont = NULL;
+    fclaw_options_t *fclaw_opts = fclaw2d_get_options(glob);
 
     /* Size is set by [ax,bx] x [ay, by], set in .ini file */
-    conn = p4est_connectivity_new_unitsquare();
-    cont = fclaw2d_map_new_nomap();
+    fclaw2d_domain_t *domain = 
+        fclaw2d_domain_new_unitsquare(glob->mpicomm, fclaw_opts->minlevel);
+    fclaw2d_map_context_t* cont = fclaw2d_map_new_nomap();
 
-    domain = fclaw2d_domain_new_conn_map (mpicomm, gparms->minlevel, conn, cont);
+    /* store domain and map in glob */
+    fclaw2d_global_store_domain(glob, domain);
+    fclaw2d_global_store_map(glob, cont);
+
     fclaw2d_domain_list_levels(domain, FCLAW_VERBOSITY_ESSENTIAL);
     fclaw2d_domain_list_neighbors(domain, FCLAW_VERBOSITY_DEBUG);
-
-    return domain;
 }
 
 static
@@ -78,40 +77,35 @@ void run_program(fclaw2d_global_t* glob)
 int
 main (int argc, char **argv)
 {
-    fclaw_app_t *app;
-    int first_arg;
-    fclaw_exit_type_t vexit;
+    /* Initialize application */
+    fclaw_app_t *app = fclaw_app_new (&argc, &argv, NULL);
 
     /* Options */
     fclaw_options_t             *gparms;
     fclaw2d_clawpatch_options_t *clawpatchopt;
     fc2d_geoclaw_options_t      *geoclawopt;
 
-    sc_MPI_Comm mpicomm;
-    fclaw2d_domain_t* domain;
-    fclaw2d_global_t* glob;
-
-    /* Initialize application */
-    app = fclaw_app_new (&argc, &argv, NULL);
-
     gparms                   = fclaw_options_register(app,  NULL,       "fclaw_options.ini");
     clawpatchopt = fclaw2d_clawpatch_options_register(app, "clawpatch", "fclaw_options.ini");
     geoclawopt        = fc2d_geoclaw_options_register(app, "geoclaw",   "fclaw_options.ini");
 
     /* Read configuration file(s) and command line, and process options */
+    int first_arg;
+    fclaw_exit_type_t vexit;
     vexit =  fclaw_app_options_parse (app, &first_arg,"fclaw_options.ini.used");
 
     if (!vexit)
     {
-        mpicomm = fclaw_app_get_mpi_size_rank (app, NULL, NULL);
-        domain = create_domain(mpicomm, gparms);
+        int size, rank;
+        sc_MPI_Comm mpicomm = fclaw_app_get_mpi_size_rank (app, &size, &rank);
     
-        glob = fclaw2d_global_new();
-        fclaw2d_global_store_domain(glob, domain);
+        fclaw2d_global_t *glob = fclaw2d_global_new_comm(mpicomm, size, rank);
 
         fclaw2d_options_store           (glob, gparms);
         fclaw2d_clawpatch_options_store (glob, clawpatchopt);
         fc2d_geoclaw_options_store      (glob, geoclawopt);
+
+        create_domain(glob);
 
         /* Run the program */
         run_program(glob);

--- a/applications/geoclaw/bowl_radial_slosh/radial/radial_user.cpp
+++ b/applications/geoclaw/bowl_radial_slosh/radial/radial_user.cpp
@@ -40,22 +40,21 @@ void radial_link_solvers(fclaw2d_global_t *glob)
 
 }
 
-fclaw2d_domain_t* radial_create_domain(sc_MPI_Comm mpicomm, 
-                                       fclaw_options_t* gparms)
+void radial_create_domain(fclaw2d_global_t* glob)
 {
-    p4est_connectivity_t     *conn = NULL;
-    fclaw2d_domain_t         *domain;
-    fclaw2d_map_context_t    *cont = NULL;
+    fclaw_options_t *fclaw_opts = fclaw2d_get_options(glob);
 
     /* Size is set by [ax,bx] x [ay, by], set in .ini file */
-    conn = p4est_connectivity_new_unitsquare();
-    cont = fclaw2d_map_new_nomap();
+    fclaw2d_domain_t *domain = 
+        fclaw2d_domain_new_unitsquare(glob->mpicomm, fclaw_opts->minlevel);
+    fclaw2d_map_context_t* cont = fclaw2d_map_new_nomap();
 
-    domain = fclaw2d_domain_new_conn_map (mpicomm, gparms->minlevel, conn, cont);
+    /* store domain and map in glob */
+    fclaw2d_global_store_domain(glob, domain);
+    fclaw2d_global_store_map(glob, cont);
+
     fclaw2d_domain_list_levels(domain, FCLAW_VERBOSITY_ESSENTIAL);
     fclaw2d_domain_list_neighbors(domain, FCLAW_VERBOSITY_DEBUG);
-
-    return domain;
 }
 
 void radial_run_program(fclaw2d_global_t* glob)

--- a/applications/geoclaw/bowl_radial_slosh/radial/radial_user.h
+++ b/applications/geoclaw/bowl_radial_slosh/radial/radial_user.h
@@ -51,8 +51,7 @@ void radial_options_store (fclaw2d_global_t* glob, radial_user_options_t* user);
 
 radial_user_options_t* radial_get_options(fclaw2d_global_t* glob);
 
-fclaw2d_domain_t* radial_create_domain(sc_MPI_Comm mpicomm, 
-                                       fclaw_options_t* gparms);
+void radial_create_domain(fclaw2d_global_t* glob);
 
 void radial_run_program(fclaw2d_global_t* glob);
 

--- a/applications/geoclaw/bowl_radial_slosh/slosh/slosh_user.cpp
+++ b/applications/geoclaw/bowl_radial_slosh/slosh/slosh_user.cpp
@@ -33,20 +33,21 @@ void slosh_link_solvers(fclaw2d_global_t *glob)
     geoclaw_vt->qinit       = &FC2D_GEOCLAW_QINIT;
 }
 
-fclaw2d_domain_t* slosh_create_domain(sc_MPI_Comm mpicomm, fclaw_options_t* gparms)
+void slosh_create_domain(fclaw2d_global_t* glob)
 {
-    /* Mapped, multi-block domain */
-    p4est_connectivity_t     *conn = NULL;
-    fclaw2d_domain_t         *domain;
-    fclaw2d_map_context_t    *cont = NULL;
+    fclaw_options_t *fclaw_opts = fclaw2d_get_options(glob);
 
-    conn = p4est_connectivity_new_unitsquare();
-    cont = fclaw2d_map_new_nomap();
+    /* Size is set by [ax,bx] x [ay, by], set in .ini file */
+    fclaw2d_domain_t *domain = 
+        fclaw2d_domain_new_unitsquare(glob->mpicomm, fclaw_opts->minlevel);
+    fclaw2d_map_context_t* cont = fclaw2d_map_new_nomap();
 
-    domain = fclaw2d_domain_new_conn_map (mpicomm, gparms->minlevel, conn, cont);
+    /* store domain and map in glob */
+    fclaw2d_global_store_domain(glob, domain);
+    fclaw2d_global_store_map(glob, cont);
+
     fclaw2d_domain_list_levels(domain, FCLAW_VERBOSITY_ESSENTIAL);
-    fclaw2d_domain_list_neighbors(domain, FCLAW_VERBOSITY_DEBUG);  
-    return domain;
+    fclaw2d_domain_list_neighbors(domain, FCLAW_VERBOSITY_DEBUG);
 }
 
 void slosh_run_program(fclaw2d_global_t* glob)

--- a/applications/geoclaw/bowl_radial_slosh/slosh/slosh_user.h
+++ b/applications/geoclaw/bowl_radial_slosh/slosh/slosh_user.h
@@ -60,7 +60,7 @@ void slosh_options_store (fclaw2d_global_t* glob, slosh_user_options_t* user);
 
 slosh_user_options_t* slosh_get_options(fclaw2d_global_t* glob);
 
-fclaw2d_domain_t* slosh_create_domain(sc_MPI_Comm mpicomm, fclaw_options_t* gparms);
+void slosh_create_domain(fclaw2d_global_t* glob);
 
 void slosh_run_program(fclaw2d_global_t* glob);
 

--- a/applications/geoclaw/bowl_slosh/slosh.cpp
+++ b/applications/geoclaw/bowl_slosh/slosh.cpp
@@ -26,20 +26,21 @@
 #include "slosh_user.h"
 
 static
-fclaw2d_domain_t* create_domain(sc_MPI_Comm mpicomm, fclaw_options_t* gparms)
+void create_domain(fclaw2d_global_t* glob)
 {
-    /* Mapped, multi-block domain */
-    p4est_connectivity_t     *conn = NULL;
-    fclaw2d_domain_t         *domain;
-    fclaw2d_map_context_t    *cont = NULL;
+    fclaw_options_t *fclaw_opts = fclaw2d_get_options(glob);
 
-    conn = p4est_connectivity_new_unitsquare();
-    cont = fclaw2d_map_new_nomap();
+    /* Size is set by [ax,bx] x [ay, by], set in .ini file */
+    fclaw2d_domain_t *domain = 
+        fclaw2d_domain_new_unitsquare(glob->mpicomm, fclaw_opts->minlevel);
+    fclaw2d_map_context_t* cont = fclaw2d_map_new_nomap();
 
-    domain = fclaw2d_domain_new_conn_map (mpicomm, gparms->minlevel, conn, cont);
+    /* store domain and map in glob */
+    fclaw2d_global_store_domain(glob, domain);
+    fclaw2d_global_store_map(glob, cont);
+
     fclaw2d_domain_list_levels(domain, FCLAW_VERBOSITY_ESSENTIAL);
-    fclaw2d_domain_list_neighbors(domain, FCLAW_VERBOSITY_DEBUG);  
-    return domain;
+    fclaw2d_domain_list_neighbors(domain, FCLAW_VERBOSITY_DEBUG);
 }
 
 static
@@ -73,22 +74,14 @@ void run_program(fclaw2d_global_t* glob)
 int
 main (int argc, char **argv)
 {
-    fclaw_app_t *app;
-    int first_arg;
-    fclaw_exit_type_t vexit;
+    /* Initialize application */
+    fclaw_app_t *app = fclaw_app_new (&argc, &argv, NULL);
 
     /* Options */
     user_options_t              *user_opt;
     fclaw_options_t             *fclaw_opt;
     fclaw2d_clawpatch_options_t *clawpatch_opt;
     fc2d_geoclaw_options_t      *geo_opt;
-
-    fclaw2d_global_t            *glob;
-    fclaw2d_domain_t            *domain;
-    sc_MPI_Comm mpicomm;
-
-    /* Initialize application */
-    app = fclaw_app_new (&argc, &argv, NULL);
 
     /* Create new options packages */
     fclaw_opt =                   fclaw_options_register(app,  NULL,       "fclaw_options.ini");
@@ -97,23 +90,26 @@ main (int argc, char **argv)
     user_opt =                    slosh_options_register(app,              "fclaw_options.ini");  
 
     /* Read configuration file(s) and command line, and process options */
+    int first_arg;
+    fclaw_exit_type_t vexit;
     vexit =  fclaw_app_options_parse (app, &first_arg,"fclaw_options.ini.used");
 
     /* Run the program */
     if (!vexit)
     {
-        mpicomm = fclaw_app_get_mpi_size_rank (app, NULL, NULL);
-        domain = create_domain(mpicomm, fclaw_opt);
+        int size, rank;
+        sc_MPI_Comm mpicomm = fclaw_app_get_mpi_size_rank (app, &size, &rank);
     
         /* Create global structure which stores the domain, timers, etc */
-        glob = fclaw2d_global_new();
-        fclaw2d_global_store_domain(glob, domain);
+        fclaw2d_global_t *glob = fclaw2d_global_new_comm(mpicomm, size, rank);
 
         /* Store option packages in glob */
         fclaw2d_options_store           (glob, fclaw_opt);
         fclaw2d_clawpatch_options_store (glob, clawpatch_opt);
         fc2d_geoclaw_options_store      (glob, geo_opt);
         slosh_options_store             (glob, user_opt);
+
+        create_domain(glob);
 
         run_program(glob);
         


### PR DESCRIPTION
Separate the mappings from the domain in the Geoclaw, ThunderEgg, and CudaClaw examples