### PR TITLE
Progress on 3D - indirect corner neighbors

### DIFF
--- a/src/fclaw2d_face_neighbors.c
+++ b/src/fclaw2d_face_neighbors.c
@@ -513,7 +513,7 @@ void fclaw2d_face_neighbor_ghost(fclaw2d_global_t* glob,
 			   exchange face data before being thrown over proc fence.
 			*/
 			fclaw2d_patch_relation_t neighbor_type =
-				fclaw2d_domain_indirect_neighbors(domain,
+				fclaw2d_domain_indirect_face_neighbors(domain,
 												  ind,
 												  this_ghost_idx,
 												  iface,rproc,

--- a/src/fclaw2d_to_3d.h
+++ b/src/fclaw2d_to_3d.h
@@ -156,7 +156,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define fclaw2d_domain_num_orientations fclaw3d_num_orientations
 #define fclaw2d_domain_corner_faces     fclaw3d_domain_corner_faces
 #define fclaw2d_domain_indirect_begin   fclaw3d_domain_indirect_begin
-#define fclaw2d_domain_indirect_neighbors fclaw3d_domain_indirect_neighbors
+#define fclaw2d_domain_indirect_face_neighbors fclaw3d_domain_indirect_face_neighbors
 #define fclaw2d_domain_indirect_end     fclaw3d_domain_indirect_end
 #define fclaw2d_domain_indirect_destroy fclaw3d_domain_indirect_destroy
 #define fclaw2d_patch_corner_dimension  fclaw3d_patch_corner_dimension

--- a/src/fclaw2d_to_3d.h
+++ b/src/fclaw2d_to_3d.h
@@ -157,6 +157,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define fclaw2d_domain_corner_faces     fclaw3d_domain_corner_faces
 #define fclaw2d_domain_indirect_begin   fclaw3d_domain_indirect_begin
 #define fclaw2d_domain_indirect_face_neighbors fclaw3d_domain_indirect_face_neighbors
+#define fclaw2d_domain_indirect_corner_neighbor fclaw3d_domain_indirect_corner_neighbor
 #define fclaw2d_domain_indirect_end     fclaw3d_domain_indirect_end
 #define fclaw2d_domain_indirect_destroy fclaw3d_domain_indirect_destroy
 #define fclaw2d_patch_corner_dimension  fclaw3d_patch_corner_dimension

--- a/src/forestclaw2d.c
+++ b/src/forestclaw2d.c
@@ -1861,7 +1861,7 @@ indirect_match (int *pi,
     *rproc = pi;
     *rblockno = pi + P4EST_HALF;
     *rpatchno = pi + P4EST_HALF + 1;
-    *rfaceno = pi + P4EST_CHILDREN + 1; /* P4EST_CHILDREN == 2 * P4EST_HALF */
+    *rfaceno = pi + P4EST_HALF + 1 + P4EST_HALF;
 }
 
 
@@ -1883,7 +1883,7 @@ fclaw2d_domain_indirect_begin (fclaw2d_domain_t * domain)
     p4est_ghost_t *ghost = p4est_wrap_get_ghost (wrap);
 
     num_exc = domain->num_exchange_patches;
-    face_info_size = 2 + P4EST_CHILDREN;        /* P4EST_CHILDREN == 2 * P4EST_HALF */
+    face_info_size = 2 + 2 * P4EST_HALF;
     data_size = P4EST_FACES * face_info_size * sizeof (int);
 
     /* allocate internal state for this operation */
@@ -2076,7 +2076,7 @@ fclaw2d_domain_indirect_end (fclaw2d_domain_t * domain,
     fclaw2d_domain_ghost_exchange_end (domain, ind->e);
 
     /* go through ghosts a second time, now working on received data */
-    face_info_size = 2 + P4EST_CHILDREN;        /* P4EST_CHILDREN == 2 * P4EST_HALF */
+    face_info_size = 2 + 2 * P4EST_HALF;
     for (ng = 0, p = 0; p < domain->mpisize; ++p)
     {
         for (; ng < (int) ghost->proc_offsets[p + 1]; ++ng)
@@ -2161,7 +2161,7 @@ fclaw2d_domain_indirect_neighbors (fclaw2d_domain_t * domain,
     FCLAW_ASSERT (0 <= faceno && faceno < P4EST_FACES);
 
     /* check the type of neighbor situation */
-    pi = (int *) ind->e->ghost_data[ghostno] + (2 + P4EST_CHILDREN) * faceno;
+    pi = (int *) ind->e->ghost_data[ghostno] + (2 + 2 * P4EST_HALF) * faceno;
     indirect_match (pi, &grproc, &grblockno, &grpatchno, &grfaceno);
     *rblockno = *grblockno;
     FCLAW_ASSERT (0 <= *rblockno && *rblockno < domain->num_blocks);

--- a/src/forestclaw2d.c
+++ b/src/forestclaw2d.c
@@ -2143,11 +2143,11 @@ fclaw2d_domain_indirect_end (fclaw2d_domain_t * domain,
 }
 
 fclaw2d_patch_relation_t
-fclaw2d_domain_indirect_neighbors (fclaw2d_domain_t * domain,
-                                   fclaw2d_domain_indirect_t * ind,
-                                   int ghostno, int faceno,
-                                   int rproc[P4EST_HALF], int *rblockno,
-                                   int rpatchno[P4EST_HALF], int *rfaceno)
+fclaw2d_domain_indirect_face_neighbors (fclaw2d_domain_t * domain,
+                                        fclaw2d_domain_indirect_t * ind,
+                                        int ghostno, int faceno,
+                                        int rproc[P4EST_HALF], int *rblockno,
+                                        int rpatchno[P4EST_HALF], int *rfaceno)
 {
     int *pi;
     int *grproc, *grblockno, *grpatchno, *grfaceno;
@@ -2226,6 +2226,16 @@ fclaw2d_domain_indirect_neighbors (fclaw2d_domain_t * domain,
 
     /* and return */
     return prel;
+}
+
+fclaw2d_patch_relation_t
+fclaw2d_domain_indirect_corner_neighbor (fclaw2d_domain_t * domain,
+                                         fclaw2d_domain_indirect_t * ind,
+                                         int ghostno, int faceno, int *rproc,
+                                         int *rblockno, int *rpatchno,
+                                         int *rfaceno)
+{
+    return FCLAW2D_PATCH_BOUNDARY;
 }
 
 void

--- a/src/forestclaw2d.c
+++ b/src/forestclaw2d.c
@@ -1059,6 +1059,7 @@ fclaw2d_patch_corner_neighbors (fclaw2d_domain_t * domain,
         /* Currently we also return this for five- and more-corners */
         *neighbor_size = FCLAW2D_PATCH_BOUNDARY;
         *rcorner = -1;
+        *rblockno = blockno;
     }
     else
     {

--- a/src/forestclaw2d.h
+++ b/src/forestclaw2d.h
@@ -918,7 +918,9 @@ fclaw2d_domain_indirect_t
 /** End sending messages to determine neighbors of ghost patches.
  * This call must not be interleaved with any ghost_exchange calls.
  * When this function returns, the necessary information is complete
- * and \ref fclaw2d_domain_indirect_neighbors may be called any number of times.
+ * and \ref fclaw2d_domain_indirect_face_neighbors
+ * and \ref fclaw2d_domain_indirect_corner_neighbor
+ * may be called any number of times.
  * \param [in] domain           Must be the same domain used in the begin call.
  * \param [in,out] ind          Must be returned by an earlier call to
  *                              \ref fclaw2d_domain_indirect_begin
@@ -928,9 +930,9 @@ void fclaw2d_domain_indirect_end (fclaw2d_domain_t * domain,
                                   fclaw2d_domain_indirect_t * ind);
 
 /** Call this analogously to \ref fclaw2d_domain_face_neighbors.
- * We only return an indirect ghost neighbor patch:  This is defined as a ghost
- * patch that is neighbor to the calling ghost patch and belongs to a processor
- * that is neither the owner of that ghost patch nor our own processor.
+ * Return an indirect face neighbor patch:  It is defined as a ghost patch
+ * that is face neighbor to the calling ghost patch and belongs to a process
+ * that is neither the owner of that ghost patch nor our own process.
  * \param [in] domain           Must be the same domain used in begin and end.
  * \param [in] ind              Must have been initialized by \ref
  *                              fclaw2d_domain_indirect_end.
@@ -951,11 +953,21 @@ void fclaw2d_domain_indirect_end (fclaw2d_domain_t * domain,
  *                              \ref FCLAW2D_PATCH_BOUNDARY.
  */
 fclaw2d_patch_relation_t
-fclaw2d_domain_indirect_neighbors (fclaw2d_domain_t * domain,
-                                   fclaw2d_domain_indirect_t * ind,
-                                   int ghostno, int faceno, int rproc[2],
-                                   int *rblockno, int rpatchno[2],
-                                   int *rfaceno);
+fclaw2d_domain_indirect_face_neighbors (fclaw2d_domain_t * domain,
+                                        fclaw2d_domain_indirect_t * ind,
+                                        int ghostno, int faceno, int rproc[2],
+                                        int *rblockno, int rpatchno[2],
+                                        int *rfaceno);
+
+/** To do: add documentation analogous to \ref
+ * fclaw2d_domain_indirect_face_neighbors.
+ */
+fclaw2d_patch_relation_t
+fclaw2d_domain_indirect_corner_neighbor (fclaw2d_domain_t * domain,
+                                         fclaw2d_domain_indirect_t * ind,
+                                         int ghostno, int cornerno, int *rproc,
+                                         int *rblockno, int *rpatchno,
+                                         int *rcornerno);
 
 /** Destroy all context data for indirect ghost neighbor patches.
  * \param [in] domain           Must be the same domain used in begin and end.

--- a/src/forestclaw2d.h
+++ b/src/forestclaw2d.h
@@ -929,7 +929,7 @@ fclaw2d_domain_indirect_t
 void fclaw2d_domain_indirect_end (fclaw2d_domain_t * domain,
                                   fclaw2d_domain_indirect_t * ind);
 
-/** Call this analogously to \ref fclaw2d_domain_face_neighbors.
+/** Call this analogously to \ref fclaw2d_patch_face_neighbors.
  * Return an indirect face neighbor patch:  It is defined as a ghost patch
  * that is face neighbor to the calling ghost patch and belongs to a process
  * that is neither the owner of that ghost patch nor our own process.
@@ -947,7 +947,7 @@ void fclaw2d_domain_indirect_end (fclaw2d_domain_t * domain,
  * \param [out] rpatchno        Only for indirect ghost patches, we store
  *                              the number relative to our ghost patch array.
  *                              For all other patches, this is -1.
- * \param [out] faceno          The face number and orientation of the neighbor(s).
+ * \param [out] rfaceno         The face number and orientation of the neighbor(s).
  * \return                      Only for indirect ghost patches, the size of the
  *                              neighbor(s).  For all others, we set this to
  *                              \ref FCLAW2D_PATCH_BOUNDARY.
@@ -959,8 +959,25 @@ fclaw2d_domain_indirect_face_neighbors (fclaw2d_domain_t * domain,
                                         int *rblockno, int rpatchno[2],
                                         int *rfaceno);
 
-/** To do: add documentation analogous to \ref
- * fclaw2d_domain_indirect_face_neighbors.
+/** Call this analogously to \ref fclaw2d_patch_corner_neighbors.
+ * Return an indirect corner neighbor patch:  It is defined as a ghost patch
+ * that is corner neighbor to the calling ghost patch and belongs to a process
+ * that is neither the owner of that ghost patch nor our own process.
+ * \param [in] domain           Must be the same domain used in begin and end.
+ * \param [in] ind              Must have been initialized by \ref
+ *                              fclaw2d_domain_indirect_end.
+ * \param [in] ghostno          Number of the ghost patch whose neighbor we seek.
+ * \param [in] cornerno         Number of the ghost patch's corner to look across.
+ * \param [out] rproc           Processor number of neighbor patch.
+ *                              Exception: For non-indirect patches, set it to -1.
+ * \param [out] rblockno        The number of the neighbor block.
+ * \param [out] rpatchno        Only for indirect ghost patches, we store
+ *                              the number relative to our ghost patch array.
+ *                              For all other patches, this is -1.
+ * \param [out] rcornerno       The corner number of the neighbor.
+ * \return                      Only for indirect ghost patches, the size of the
+ *                              neighbor.  For all others, we set this to
+ *                              \ref FCLAW2D_PATCH_BOUNDARY.
  */
 fclaw2d_patch_relation_t
 fclaw2d_domain_indirect_corner_neighbor (fclaw2d_domain_t * domain,

--- a/src/forestclaw3d.h
+++ b/src/forestclaw3d.h
@@ -1081,7 +1081,32 @@ fclaw3d_domain_indirect_face_neighbors (fclaw3d_domain_t * domain,
                                         int *rblockno, int rpatchno[4],
                                         int *rfaceno);
 
-/* To do: add indirect_corner_neighbor for 3D. */
+/** Call this analogously to \ref fclaw3d_patch_corner_neighbors.
+ * Return an indirect corner neighbor patch:  It is defined as a ghost patch
+ * that is corner neighbor to the calling ghost patch and belongs to a process
+ * that is neither the owner of that ghost patch nor our own process.
+ * \param [in] domain           Must be the same domain used in begin and end.
+ * \param [in] ind              Must have been initialized by \ref
+ *                              fclaw3d_domain_indirect_end.
+ * \param [in] ghostno          Number of the ghost patch whose neighbor we seek.
+ * \param [in] cornerno         Number of the ghost patch's corner to look across.
+ * \param [out] rproc           Processor number of neighbor patch.
+ *                              Exception: For non-indirect patches, set it to -1.
+ * \param [out] rblockno        The number of the neighbor block.
+ * \param [out] rpatchno        Only for indirect ghost patches, we store
+ *                              the number relative to our ghost patch array.
+ *                              For all other patches, this is -1.
+ * \param [out] rcornerno       The corner number of the neighbor.
+ * \return                      Only for indirect ghost patches, the size of the
+ *                              neighbor.  For all others, we set this to
+ *                              \ref FCLAW2D_PATCH_BOUNDARY.
+ */
+fclaw3d_patch_relation_t
+fclaw3d_domain_indirect_corner_neighbor (fclaw3d_domain_t * domain,
+                                         fclaw3d_domain_indirect_t * ind,
+                                         int ghostno, int cornerno, int *rproc,
+                                         int *rblockno, int *rpatchno,
+                                         int *rcornerno);
 
 /** Destroy all context data for indirect ghost neighbor patches.
  * \param [in] domain           Must be the same domain used in begin and end.

--- a/src/forestclaw3d.h
+++ b/src/forestclaw3d.h
@@ -1040,7 +1040,9 @@ fclaw3d_domain_indirect_t
 /** End sending messages to determine neighbors of ghost patches.
  * This call must not be interleaved with any ghost_exchange calls.
  * When this function returns, the necessary information is complete
- * and \ref fclaw3d_domain_indirect_neighbors may be called any number of times.
+ * and \ref fclaw3d_domain_indirect_face neighbors
+ * and \ref fclaw3d_domain_indirect_corner_neighbor
+ * may be called any number of times.
  * \param [in] domain           Must be the same domain used in the begin call.
  * \param [in,out] ind          Must be returned by an earlier call to
  *                              \ref fclaw3d_domain_indirect_begin
@@ -1073,11 +1075,13 @@ void fclaw3d_domain_indirect_end (fclaw3d_domain_t * domain,
  *                              \ref FCLAW3D_PATCH_BOUNDARY.
  */
 fclaw3d_patch_relation_t
-fclaw3d_domain_indirect_neighbors (fclaw3d_domain_t * domain,
-                                   fclaw3d_domain_indirect_t * ind,
-                                   int ghostno, int faceno, int rproc[4],
-                                   int *rblockno, int rpatchno[4],
-                                   int *rfaceno);
+fclaw3d_domain_indirect_face_neighbors (fclaw3d_domain_t * domain,
+                                        fclaw3d_domain_indirect_t * ind,
+                                        int ghostno, int faceno, int rproc[4],
+                                        int *rblockno, int rpatchno[4],
+                                        int *rfaceno);
+
+/* To do: add indirect_corner_neighbor for 3D. */
 
 /** Destroy all context data for indirect ghost neighbor patches.
  * \param [in] domain           Must be the same domain used in begin and end.

--- a/src/forestclaw3d.h
+++ b/src/forestclaw3d.h
@@ -1060,7 +1060,7 @@ void fclaw3d_domain_indirect_end (fclaw3d_domain_t * domain,
  * \param [in] faceno           Number of the ghost patch's face to look across.
  * \param [out] rproc           Processor number of neighbor patches.  Exception 1:
  *                              If the neighbor is a bigger patch, rproc[1] contains
- *                              the number of the small patch as one of two half faces,
+ *                              the number of the small patch as one of four half faces,
  *                              but only if the neighbor fits the above criteria.
  *                              Exception 2: For non-indirect patches, set it to -1.
  * \param [out] rblockno        The number of the neighbor block.
@@ -1075,8 +1075,8 @@ void fclaw3d_domain_indirect_end (fclaw3d_domain_t * domain,
 fclaw3d_patch_relation_t
 fclaw3d_domain_indirect_neighbors (fclaw3d_domain_t * domain,
                                    fclaw3d_domain_indirect_t * ind,
-                                   int ghostno, int faceno, int rproc[2],
-                                   int *rblockno, int rpatchno[2],
+                                   int ghostno, int faceno, int rproc[4],
+                                   int *rblockno, int rpatchno[4],
                                    int *rfaceno);
 
 /** Destroy all context data for indirect ghost neighbor patches.

--- a/src/forestclaw3d.h
+++ b/src/forestclaw3d.h
@@ -1051,7 +1051,7 @@ fclaw3d_domain_indirect_t
 void fclaw3d_domain_indirect_end (fclaw3d_domain_t * domain,
                                   fclaw3d_domain_indirect_t * ind);
 
-/** Call this analogously to \ref fclaw3d_domain_face_neighbors.
+/** Call this analogously to \ref fclaw3d_patch_face_neighbors.
  * We only return an indirect ghost neighbor patch:  This is defined as a ghost
  * patch that is neighbor to the calling ghost patch and belongs to a processor
  * that is neither the owner of that ghost patch nor our own processor.
@@ -1069,7 +1069,7 @@ void fclaw3d_domain_indirect_end (fclaw3d_domain_t * domain,
  * \param [out] rpatchno        Only for indirect ghost patches, we store
  *                              the number relative to our ghost patch array.
  *                              For all other patches, this is -1.
- * \param [out] faceno          The face number and orientation of the neighbor(s).
+ * \param [out] rfaceno         The face number and orientation of the neighbor(s).
  * \return                      Only for indirect ghost patches, the size of the
  *                              neighbor(s).  For all others, we set this to
  *                              \ref FCLAW3D_PATCH_BOUNDARY.


### PR DESCRIPTION
We add `domain_indirect_corner_neighbor` both in 2D and in 3D. The function allows to query corner-neighboring ghost patches that reside on different processes, similar to `domain_indirect_neighbors`, which was renamed to `domain_indirect_face_neighbors`. 
The face and the corner information are communicated in a single ghost exchange in `domain_indirect_begin` and `domain_indirect_end`.