### PR TITLE
Remove map from convenience

### DIFF
--- a/src/fclaw2d_convenience.c
+++ b/src/fclaw2d_convenience.c
@@ -413,25 +413,6 @@ fclaw2d_domain_new_conn (sc_MPI_Comm mpicomm, int initial_level,
     return domain;
 }
 
-#ifndef P4_TO_P8
-
-/* function to be removed once no longer called by applications */
-
-fclaw2d_domain_t *
-fclaw2d_domain_new_conn_map (sc_MPI_Comm mpicomm, int initial_level,
-                             p4est_connectivity_t * conn,
-                             fclaw2d_map_context_t * cont)
-{
-    fclaw2d_domain_t *domain =
-      fclaw2d_domain_new_conn (mpicomm, initial_level, conn);
-
-    fclaw2d_domain_attribute_add (domain, "fclaw_map_context", cont);
-
-    return domain;
-}
-
-#endif
-
 void
 fclaw2d_domain_destroy (fclaw2d_domain_t * domain)
 {

--- a/src/fclaw2d_convenience.h
+++ b/src/fclaw2d_convenience.h
@@ -27,7 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define FCLAW2D_CONVENIENCE_H
 
 #include <forestclaw2d.h>
-#include <fclaw2d_map.h>
 #include <p4est_connectivity.h>
 
 #ifdef __cplusplus
@@ -80,18 +79,6 @@ fclaw2d_domain_t *fclaw2d_domain_new_brick (sc_MPI_Comm mpicomm,
 fclaw2d_domain_t *fclaw2d_domain_new_conn (sc_MPI_Comm mpicomm,
                                            int initial_level,
                                            p4est_connectivity_t * conn);
-
-/** Create a domain from a given forest connectivity and matching map.
- * \param [in] mpicomm          We expect sc_MPI_Init to be called earlier.
- * \param [in] initial_level    A non-negative integer <= P4EST_QMAXLEVEL.
- * \param [in] conn             We DO take ownership of the connectivity.
- * \param [in] cont             We do NOT take ownership of the mapping.
- * \return                      A fully initialized domain structure.
- */
-fclaw2d_domain_t *fclaw2d_domain_new_conn_map (sc_MPI_Comm mpicomm,
-                                               int initial_level,
-                                               p4est_connectivity_t * conn,
-                                               fclaw2d_map_context_t * cont);
 
 void fclaw2d_domain_destroy (fclaw2d_domain_t * domain);
 


### PR DESCRIPTION
Following up on the issue https://github.com/ForestClaw/forestclaw/issues/276.

After the changes in particular in the PRs https://github.com/ForestClaw/forestclaw/pull/285 and https://github.com/ForestClaw/forestclaw/pull/280 we remove the dependency of the files `fclaw2d_ convenience.{c,h}` on `fclaw2d_map.h` by removing the function `fclaw2d_domain_new_conn_map`.