### PR TITLE
Avoid potential double extern C

### DIFF
--- a/applications/clawpack/advection/2d/filament_swirl/overlap.h
+++ b/applications/clawpack/advection/2d/filament_swirl/overlap.h
@@ -27,17 +27,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef OVERLAP_H
 #define OVERLAP_H
 
+#include <fclaw2d_options.h>
+
+#include <fclaw2d_domain.h>
+#include <fclaw2d_patch.h>
+#include <fclaw2d_global.h>
+
 #ifdef __cplusplus
 extern "C"
 {
 #endif
-
-#include <fclaw2d_options.h>
-
-#include <fclaw2d_domain.h>
-#include <fclaw2d_patch.h>    
-#include <fclaw2d_global.h>
-
 
 typedef struct overlap_prodata
 {


### PR DESCRIPTION
The includes in `overlap.h`  are currently after the `extern "C"`. This can cause problems if at least one of these includes also sets `extern "C"`. For example, I observed this with the follwowing compile error since `mpi.h` contains an `extern "C"` in the MPI implementation that I used.

```
In file included from /usr/include/mpich/mpi.h:2239,
                  from ../forestclaw/sc/src/sc.h:103,
                  from ../forestclaw/sc/src/sc_containers.h:39,
                  from ../forestclaw/p4est/src/p4est_base.h:48,
                  from ../forestclaw/src/fclaw_base.h:55,
                  from ../forestclaw/src/fclaw_options.h:35,
                  from ../forestclaw/src/fclaw2d_options.h:35,
                  from 
../forestclaw/applications/clawpack/advection/2d/filament_swirl/overlap.h:35,
                  from 
../forestclaw/applications/clawpack/advection/2d/filament_swirl/overlap.c:27:
/usr/include/mpich/mpicxx.h:2725:13: error: conflicting declaration of C 
function ‘void MPI::Init(int&, char**&)’
  2725 | extern void Init(int &, char **& );
       |             ^~~~
/usr/include/mpich/mpicxx.h:2724:13: note: previous declaration ‘void 
MPI::Init()’
  2724 | extern void Init(void);
       |             ^~~~
/usr/include/mpich/mpicxx.h:2727:12: error: conflicting declaration of C 
function ‘int MPI::Init_thread(int&, char**&, int)’
  2727 | extern int Init_thread(int &, char **&, int );
       |            ^~~~~~~~~~~
/usr/include/mpich/mpicxx.h:2726:12: note: previous declaration ‘int 
MPI::Init_thread(int)’
  2726 | extern int Init_thread(int);
       |            ^~~~~~~~~~~
``` 

Therefore, I moved the includes before the `extern "C"`. This also resolves the compilation error reported above. 