### PR TITLE
Introduce `local_max_patches` in domain

### DIFF
--- a/src/fclaw2d_convenience.c
+++ b/src/fclaw2d_convenience.c
@@ -97,11 +97,11 @@ fclaw2d_domain_new (p4est_wrap_t * wrap, sc_keyvalue_t * attributes)
     int nb, nm, mirror_quadrant_num;
     int block_nm_pre;
     int local_num_patches;
+    int current_local_num_patches;
     int tree_minlevel, local_minlevel;
     int tree_maxlevel, local_maxlevel;
     int levels[2], global_levels[2];
     p4est_topidx_t vnum;
-    p4est_gloidx_t current_local_num_patches;
     p4est_connectivity_t *conn = wrap->conn;
     p4est_ghost_t *ghost = wrap->match_aux ? wrap->ghost_aux : wrap->ghost;
 #ifdef FCLAW_ENABLE_DEBUG
@@ -281,12 +281,12 @@ fclaw2d_domain_new (p4est_wrap_t * wrap, sc_keyvalue_t * attributes)
     domain->local_max_patches = 0;
     for (i = 0; i < wrap->p4est->mpisize; ++i)
     {
-        current_local_num_patches =
-            wrap->p4est->global_first_quadrant[i + 1] -
-            wrap->p4est->global_first_quadrant[i];
+        current_local_num_patches = (int)
+            (wrap->p4est->global_first_quadrant[i + 1] -
+             wrap->p4est->global_first_quadrant[i]);
 
         domain->local_max_patches = SC_MAX (domain->local_max_patches,
-                                            (int) current_local_num_patches);
+                                            current_local_num_patches);
     }
 
     /* allocate ghost patches */

--- a/src/fclaw2d_convenience.c
+++ b/src/fclaw2d_convenience.c
@@ -101,6 +101,7 @@ fclaw2d_domain_new (p4est_wrap_t * wrap, sc_keyvalue_t * attributes)
     int tree_maxlevel, local_maxlevel;
     int levels[2], global_levels[2];
     p4est_topidx_t vnum;
+    p4est_gloidx_t current_local_num_patches;
     p4est_connectivity_t *conn = wrap->conn;
     p4est_ghost_t *ghost = wrap->match_aux ? wrap->ghost_aux : wrap->ghost;
 #ifdef FCLAW_ENABLE_DEBUG
@@ -280,11 +281,12 @@ fclaw2d_domain_new (p4est_wrap_t * wrap, sc_keyvalue_t * attributes)
     domain->local_max_patches = 0;
     for (i = 0; i < wrap->p4est->mpisize; ++i)
     {
+        current_local_num_patches =
+            wrap->p4est->global_first_quadrant[i + 1] -
+            wrap->p4est->global_first_quadrant[i];
+
         domain->local_max_patches = SC_MAX (domain->local_max_patches,
-                                            wrap->p4est->
-                                            global_first_quadrant[i + 1] -
-                                            wrap->p4est->
-                                            global_first_quadrant[i]);
+                                            (int) current_local_num_patches);
     }
 
     /* allocate ghost patches */

--- a/src/fclaw2d_convenience.c
+++ b/src/fclaw2d_convenience.c
@@ -276,6 +276,17 @@ fclaw2d_domain_new (p4est_wrap_t * wrap, sc_keyvalue_t * attributes)
     domain->local_minlevel = local_minlevel;
     domain->local_maxlevel = local_maxlevel;
 
+    /* determine maximum number of local patches */
+    domain->local_max_patches = 0;
+    for (i = 0; i < wrap->p4est->mpisize; ++i)
+    {
+        domain->local_max_patches = SC_MAX (domain->local_max_patches,
+                                            wrap->p4est->
+                                            global_first_quadrant[i + 1] -
+                                            wrap->p4est->
+                                            global_first_quadrant[i]);
+    }
+
     /* allocate ghost patches */
     domain->ghost_patches =
         FCLAW_ALLOC_ZERO (fclaw2d_patch_t, domain->num_ghost_patches);

--- a/src/forestclaw2d.h
+++ b/src/forestclaw2d.h
@@ -179,6 +179,7 @@ struct fclaw2d_domain
                                              one domain to a derived one. */
 
     int local_num_patches;      /**< sum of patches over all blocks on this proc */
+    int local_max_patches;      /**< maximum over all procs of local_num_patches */
     /** @{ */
     /** Local to proc.  If this proc doesn't
         store any patches at all, we set

--- a/src/forestclaw3d.h
+++ b/src/forestclaw3d.h
@@ -182,6 +182,7 @@ struct fclaw3d_domain
                                              one domain to a derived one. */
 
     int local_num_patches;      /**< sum of patches over all blocks on this proc */
+    int local_max_patches;      /**< maximum over all procs of local_num_patches */
     /** @{ */
     /** Local to proc.  If this proc doesn't
         store any patches at all, we set


### PR DESCRIPTION
This PR is adding `local_max_patches`, i.e. the maximum over all processes of `local_num_patches`, in `fclaw{2,3}d_domain_t`. It is sufficient to set the value of `local_max_patches` in `fclaw2d_domain_new` since the adaption and partition function as all other domain creation functions in `fclaw2d_convenience.c` call  `fclaw2d_domain_new`.
The value of  `local_max_patches` will be required for planned changes regarding writing VTU files using MPI I/O.