### PR TITLE
Use collective writes for VTU files

### DIFF
--- a/src/patches/clawpatch/fclaw2d_clawpatch_output_vtk.c
+++ b/src/patches/clawpatch/fclaw2d_clawpatch_output_vtk.c
@@ -104,7 +104,7 @@ typedef struct fclaw2d_vtk_state
      * patches.
      * We track the number of buffered patches in \b num_buffered_patches and
      * if the buffer contains more than \b patch_threshold many patches, the
-     * patches are written to disk and buffer is flushed.
+     * patches are written to disk and the buffer is flushed.
      * The variable \b num_buffered_patches relates to the number of buffered
      * patches during one fclaw2d_vtk_write_field call.
      * If \b patch_threshold is -1, there are no intermediate writes but all

--- a/src/patches/clawpatch/fclaw2d_clawpatch_output_vtk.c
+++ b/src/patches/clawpatch/fclaw2d_clawpatch_output_vtk.c
@@ -200,17 +200,20 @@ static void
 write_position_cb (fclaw2d_domain_t * domain, fclaw2d_patch_t * patch,
                    int blockno, int patchno, void *user)
 {
+    int retval;
     fclaw2d_global_iterate_t *g = (fclaw2d_global_iterate_t*) user;
     fclaw2d_vtk_state_t *s = (fclaw2d_vtk_state_t *) g->user;
 
     s->coordinate_cb (g->glob, patch, blockno, patchno, s->buf);
-    sc_io_sink_write (s->sink, s->buf, s->psize_position);
+    retval = sc_io_sink_write (s->sink, s->buf, s->psize_position);
+    SC_CHECK_ABORT (retval == 0, "VTK buffer write failed");
 }
 
 static void
 write_connectivity_cb (fclaw2d_domain_t * domain, fclaw2d_patch_t * patch,
                        int blockno, int patchno, void *user)
 {
+    int retval;
     fclaw2d_global_iterate_t *g = (fclaw2d_global_iterate_t*) user;
     fclaw2d_vtk_state_t *s = (fclaw2d_vtk_state_t *) g->user;
     int i, j;
@@ -300,13 +303,15 @@ write_connectivity_cb (fclaw2d_domain_t * domain, fclaw2d_patch_t * patch,
         }
 #endif
     }
-    sc_io_sink_write (s->sink, s->buf, s->psize_connectivity);
+    retval = sc_io_sink_write (s->sink, s->buf, s->psize_connectivity);
+    SC_CHECK_ABORT (retval == 0, "VTK buffer write failed");
 }
 
 static void
 write_offsets_cb (fclaw2d_domain_t * domain, fclaw2d_patch_t * patch,
                   int blockno, int patchno, void *user)
 {
+    int retval;
     fclaw2d_global_iterate_t *g = (fclaw2d_global_iterate_t*) user;
     fclaw2d_vtk_state_t *s = (fclaw2d_vtk_state_t *) g->user;
     int c;
@@ -332,13 +337,15 @@ write_offsets_cb (fclaw2d_domain_t * domain, fclaw2d_patch_t * patch,
             *idata++ = k;
         }
     }
-    sc_io_sink_write (s->sink, s->buf, s->psize_offsets);
+    retval = sc_io_sink_write (s->sink, s->buf, s->psize_offsets);
+    SC_CHECK_ABORT (retval == 0, "VTK buffer write failed");
 }
 
 static void
 write_types_cb (fclaw2d_domain_t * domain, fclaw2d_patch_t * patch,
                 int blockno, int patchno, void *user)
 {
+    int retval;
     fclaw2d_global_iterate_t *g = (fclaw2d_global_iterate_t*) user;
     fclaw2d_vtk_state_t *s = (fclaw2d_vtk_state_t *) g->user;
     int c;
@@ -352,13 +359,15 @@ write_types_cb (fclaw2d_domain_t * domain, fclaw2d_patch_t * patch,
         *cdata++ = 12;
 #endif
     }
-    sc_io_sink_write (s->sink, s->buf, s->psize_types);
+    retval = sc_io_sink_write (s->sink, s->buf, s->psize_types);
+    SC_CHECK_ABORT (retval == 0, "VTK buffer write failed");
 }
 
 static void
 write_mpirank_cb (fclaw2d_domain_t * domain, fclaw2d_patch_t * patch,
                   int blockno, int patchno, void *user)
 {
+    int retval;
     fclaw2d_global_iterate_t *g = (fclaw2d_global_iterate_t*) user;
     fclaw2d_vtk_state_t *s = (fclaw2d_vtk_state_t *) g->user;
     int c;
@@ -368,13 +377,15 @@ write_mpirank_cb (fclaw2d_domain_t * domain, fclaw2d_patch_t * patch,
     {
         *idata++ = domain->mpirank;
     }
-    sc_io_sink_write (s->sink, s->buf, s->psize_mpirank);
+    retval = sc_io_sink_write (s->sink, s->buf, s->psize_mpirank);
+    SC_CHECK_ABORT (retval == 0, "VTK buffer write failed");
 }
 
 static void
 write_blockno_cb (fclaw2d_domain_t * domain, fclaw2d_patch_t * patch,
                   int blockno, int patchno, void *user)
 {
+    int retval;
     fclaw2d_global_iterate_t *g = (fclaw2d_global_iterate_t*) user;
     fclaw2d_vtk_state_t *s = (fclaw2d_vtk_state_t *) g->user;
     int c;
@@ -384,13 +395,15 @@ write_blockno_cb (fclaw2d_domain_t * domain, fclaw2d_patch_t * patch,
     {
         *idata++ = blockno;
     }
-    sc_io_sink_write (s->sink, s->buf, s->psize_blockno);
+    retval = sc_io_sink_write (s->sink, s->buf, s->psize_blockno);
+    SC_CHECK_ABORT (retval == 0, "VTK buffer write failed");
 }
 
 static void
 write_patchno_cb (fclaw2d_domain_t * domain, fclaw2d_patch_t * patch,
                   int blockno, int patchno, void *user)
 {
+    int retval;
     fclaw2d_global_iterate_t *g = (fclaw2d_global_iterate_t*) user;
     fclaw2d_vtk_state_t *s = (fclaw2d_vtk_state_t *) g->user;
     int c;
@@ -415,19 +428,22 @@ write_patchno_cb (fclaw2d_domain_t * domain, fclaw2d_patch_t * patch,
             *idata++ = gpno;
         }
     }
-    sc_io_sink_write (s->sink, s->buf, s->psize_patchno);
+    retval = sc_io_sink_write (s->sink, s->buf, s->psize_patchno);
+    SC_CHECK_ABORT (retval == 0, "VTK buffer write failed");
 }
 
 static void
 write_meqn_cb (fclaw2d_domain_t * domain, fclaw2d_patch_t * patch,
                int blockno, int patchno, void *user)
 {
+    int retval;
     fclaw2d_global_iterate_t* g = (fclaw2d_global_iterate_t*) user;
 
     fclaw2d_vtk_state_t *s = (fclaw2d_vtk_state_t *) g->user;
 
     s->value_cb (g->glob, patch, blockno, patchno, s->buf);
-    sc_io_sink_write (s->sink, s->buf, s->psize_meqn);
+    retval = sc_io_sink_write (s->sink, s->buf, s->psize_meqn);
+    SC_CHECK_ABORT (retval == 0, "VTK buffer write failed");
 }
 
 static void

--- a/src/patches/clawpatch/fclaw2d_clawpatch_output_vtk.c
+++ b/src/patches/clawpatch/fclaw2d_clawpatch_output_vtk.c
@@ -41,7 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <fclaw2d_clawpatch_options.h>
 
 #define PATCH_CHILDREN 4
-#define FCLAW_VTK_BUF_THRESHOLD 6000
+#define FCLAW_VTK_BUF_THRESHOLD -1
 
 #elif REFINE_DIM == 2 && PATCH_DIM == 3
 
@@ -53,7 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <_fclaw2d_to_fclaw3dx.h>
 
 #define PATCH_CHILDREN 8
-#define FCLAW_VTK_BUF_THRESHOLD 6000
+#define FCLAW_VTK_BUF_THRESHOLD -1
 
 #else
 #error "This combination of REFINE_DIM and PATCH_DIM is unsupported"
@@ -201,22 +201,19 @@ fclaw2d_vtk_write_header (fclaw2d_domain_t * domain, fclaw2d_vtk_state_t * s)
 }
 
 /** This function add to a buffer and writes to file if a threshold is exceeded.
- * The writing is not yet implemented.
  *
  * \param [in,out]  s               The VTK state.
  * \param [in]      psize_field     The number of bytes, which are intended to
  *                                  add to the buffer.
- * \param [in]      threshold       If the sum of the bytes, which are already
- *                                  stored in the buffer and \b psize_field
- *                                  is greater than \b threshold, the buffer
- *                                  is flushed to disk. The \b psize_field
- *                                  many new bytes are added to the buffer.
+ * \param [in]      threshold       If the number of patches, which are already
+ *                                  stored in the buffer + 1 is greater than
+ *                                  \b threshold, the buffer is flushed to disk.
+ *                                  Then the new patch is added to the buffer.
  *                                  -1 means that there is no threshold and
  *                                  the data just added to \b s->sink.
  */
 static void
-add_to_buffer (fclaw2d_vtk_state_t * s, int64_t psize_field,
-               int64_t threshold)
+add_to_buffer (fclaw2d_vtk_state_t * s, int64_t psize_field, int threshold)
 {
     FCLAW_ASSERT (s != NULL);
 
@@ -227,17 +224,24 @@ add_to_buffer (fclaw2d_vtk_state_t * s, int64_t psize_field,
 #else
     size_t retvalz;
 #endif
+    FCLAW_ASSERT (threshold == -1 || threshold > 0);
+    FCLAW_ASSERT (s->sink->buffer_bytes % psize_field == 0);
 
     if (threshold != -1
-        && (s->sink->buffer_bytes + (size_t) psize_field > threshold))
+        && ((s->sink->buffer_bytes / psize_field) + 1 > (size_t) threshold))
     {
+        FCLAW_ASSERT ((int) s->sink->buffer_bytes >= psize_field);
         /* buffer threshold exceeded */
         /* write the current buffer to disk */
 #ifdef P4EST_ENABLE_MPIIO
-        mpiret =
-            MPI_File_write_all (s->mpifile, s->sink->buffer->array,
-                                s->sink->buffer_bytes, MPI_BYTE, &mpistatus);
-        SC_CHECK_MPI (mpiret);
+        if (s->sink->buffer_bytes > 0)
+        {
+            mpiret =
+                MPI_File_write_all (s->mpifile, s->sink->buffer->array,
+                                    (int) s->sink->buffer_bytes, MPI_BYTE,
+                                    &mpistatus);
+            SC_CHECK_MPI (mpiret);
+        }
 #else
         retvalz =
             fwrite (s->sink->buffer->array, s->sink->buffer_bytes, 1,
@@ -505,6 +509,7 @@ fclaw2d_vtk_write_field (fclaw2d_global_t * glob, fclaw2d_vtk_state_t * s,
     int i;
     int max_num_writes, local_num_writes;
     int mpiret;
+    int threshold;
     MPI_Offset mpipos;
 #ifdef P4EST_ENABLE_DEBUG
     MPI_Offset mpinew;
@@ -548,7 +553,7 @@ fclaw2d_vtk_write_field (fclaw2d_global_t * glob, fclaw2d_vtk_state_t * s,
     fclaw2d_global_iterate_patches (glob, cb, s);
 
 #ifdef P4EST_ENABLE_MPIIO
-    if (s->sink->buffer_bytes > 0)
+    if (s->sink->buffer_bytes > 0 || FCLAW_VTK_BUF_THRESHOLD == -1)
     {
         /* write the remaining buffered bytes */
         mpiret =
@@ -557,27 +562,30 @@ fclaw2d_vtk_write_field (fclaw2d_global_t * glob, fclaw2d_vtk_state_t * s,
         SC_CHECK_MPI (mpiret);
     }
 
-    /* Ensure that the collective function MPI_File_write_all is called
-     * equally often on each rank.
-     */
-    max_num_writes =
-        FCLAW_VTK_CEIL (glob->domain->local_max_patches * psize_field,
-                        FCLAW_VTK_BUF_THRESHOLD);
-    local_num_writes =
-        FCLAW_VTK_CEIL (glob->domain->local_num_patches * psize_field,
-                        FCLAW_VTK_BUF_THRESHOLD);
-    FCLAW_ASSERT (max_num_writes - local_num_writes >= 0);
-
-    for (i = 0; i < max_num_writes - local_num_writes; ++i)
+    if (FCLAW_VTK_BUF_THRESHOLD != -1)
     {
-        /* This rank has less patches than the rank that holds the maximal
-         * number of patches. We compensate this by empty write calls to avoid
-         * a deadlock.
+        /* Ensure that the collective function MPI_File_write_all is called
+         * equally often on each rank.
          */
-        mpiret =
-            MPI_File_write_all (s->mpifile, buffer.array, 0, MPI_BYTE,
-                                &mpistatus);
-        SC_CHECK_MPI (mpiret);
+        max_num_writes =
+            FCLAW_VTK_CEIL (glob->domain->local_max_patches,
+                            FCLAW_VTK_BUF_THRESHOLD);
+        local_num_writes =
+            FCLAW_VTK_CEIL (glob->domain->local_num_patches,
+                            FCLAW_VTK_BUF_THRESHOLD);
+        FCLAW_ASSERT (max_num_writes - local_num_writes >= 0);
+
+        for (i = 0; i < max_num_writes - local_num_writes; ++i)
+        {
+            /* This rank has less patches than the rank that holds the maximal
+             * number of patches. We compensate this by empty write calls to avoid
+             * a deadlock.
+             */
+            mpiret =
+                MPI_File_write_all (s->mpifile, buffer.array, 0, MPI_BYTE,
+                                    &mpistatus);
+            SC_CHECK_MPI (mpiret);
+        }
     }
 #else
     retvalz = fwrite (buffer.array, s->sink->buffer_bytes, 1, s->file);

--- a/src/patches/clawpatch/fclaw2d_clawpatch_output_vtk.c
+++ b/src/patches/clawpatch/fclaw2d_clawpatch_output_vtk.c
@@ -31,7 +31,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define PATCH_DIM 2
 #endif
 
-#define FCLAW_VTK_CEIL(x, y) (((x) + (y) - 1) / (y)) /**< round x / y up */
+/** Round up quotient x / y. */
+#define FCLAW_VTK_CEIL(x, y) (((x) + (y) - 1) / (y)) /**< round up the quotient
+                                                        x / y; this is a local
+                                                        macro used for
+                                                        computations regarding
+                                                        the VTK patch buffering */
 
 #if REFINE_DIM == 2 && PATCH_DIM == 2
 

--- a/src/patches/clawpatch/fclaw2d_clawpatch_output_vtk.c
+++ b/src/patches/clawpatch/fclaw2d_clawpatch_output_vtk.c
@@ -202,7 +202,11 @@ fclaw2d_vtk_write_header (fclaw2d_domain_t * domain, fclaw2d_vtk_state_t * s)
     return retval ? -1 : 0;
 }
 
-/** This function add to a buffer and writes to file if a threshold is exceeded.
+/** This function adds to a buffer and writes to file if a threshold is exceeded.
+ *
+ * This function assumes that the buffer consists of patch data of the size
+ * \b psize_field. This means it must hold
+ * \b s->sink->buffer_bytes % \b s->sink->buffer_bytes == 0.
  *
  * \param [in,out]  s               The VTK state.
  * \param [in]      psize_field     The number of bytes, which are intended to

--- a/src/patches/clawpatch/fclaw2d_clawpatch_output_vtk.c
+++ b/src/patches/clawpatch/fclaw2d_clawpatch_output_vtk.c
@@ -196,30 +196,6 @@ fclaw2d_vtk_write_header (fclaw2d_domain_t * domain, fclaw2d_vtk_state_t * s)
     return retval ? -1 : 0;
 }
 
-/**
- * @brief Write the buffer to file
- *
- * @param s the vtk state
- * @param psize_field the size of the buffer
- */
-static void
-write_buffer (fclaw2d_vtk_state_t * s, int64_t psize_field)
-{
-#ifndef P4EST_ENABLE_MPIIO
-    size_t retvalz;
-
-    retvalz = fwrite (s->buf, psize_field, 1, s->file);
-    SC_CHECK_ABORT (retvalz == 1, "VTK file write failed");
-#else
-    int mpiret;
-    MPI_Status mpistatus;
-
-    mpiret = MPI_File_write (s->mpifile, s->buf, psize_field, MPI_BYTE,
-                             &mpistatus);
-    SC_CHECK_MPI (mpiret);
-#endif
-}
-
 static void
 write_position_cb (fclaw2d_domain_t * domain, fclaw2d_patch_t * patch,
                    int blockno, int patchno, void *user)


### PR DESCRIPTION
In the implementation of the parallel writing of VTU files ForestClaw used `MPI_File_write` for distributed data, e.g. coordinates. There is the optimized and collective function `MPI_File_write_all`, which is optimized for writing parallel distributed data.

This PR uses  the  function `MPI_File_write_all` in places where we write parallel distributed data. Moreover, we introduce a buffering mechanism for patches during writing VTU files. This is a side effect of ensuring that the collective function `MPI_File_write_all` is called equally many times on each rank. The buffering mechanism offers the variable `patch_threshold` in `fclaw2d_vtk_state_t`. By default `patch_threshold` is set to `-1`, i.e. we buffer all patch data for each `fclaw2d_vtk_write_field` call and then write the data to disk. Alternatively, one can change `patch_threshold` in the VTK state to a number strictly greater `0` and only `patch_threshold` many patches are buffered and if the threshold is exceeded the data is written to disk.

Before there was one writing operation per patch. Now this is not generally true anymore since the number of writing operations depends on the  `patch_threshold`.

We appreciate any feedback! In particular concerning the impact on the parallel writing performance.