### PR TITLE
Build with dependencies

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,6 +13,7 @@ endif
 # initialize empty variables
 AM_CPPFLAGS =
 AM_FFLAGS =
+AM_LDFLAGS =
 CLEANFILES =
 DISTCLEANFILES =
 EXTRA_DIST =

--- a/docs/fclaw-build-wdeps.sh
+++ b/docs/fclaw-build-wdeps.sh
@@ -19,7 +19,7 @@ source "$BLP4"                                          && \
 rm "$BLP4"                                              || exit 1
 
 # clone, build and install ForestClaw
-git clone https://github.com/forestclaw/forestclaw.git -b develop       && \
+git clone --depth 1 https://github.com/forestclaw/forestclaw.git -b develop && \
 cd forestclaw                                           && \
 ./bootstrap "$PREFIX/libsc/share/aclocal" "$PREFIX/p4est/share/aclocal" && \
 mkdir build                                             && \

--- a/docs/fclaw-build-wdeps.sh
+++ b/docs/fclaw-build-wdeps.sh
@@ -1,0 +1,33 @@
+#! /bin/bash
+
+# Build and install the latest ForestClaw develop branch including p4est,
+# libsc, zlib and jansson.  We first download and install a recent zlib to
+# a local directory, then do the same for the jansson library.  Then we
+# clone and install the current develop branches of p4est and libsc using
+# that zlib and jansson installation and finally clone and install the
+# current develop branch of ForestClaw, linking against all of the above.
+
+# This results in five installation directories that any higher
+# level software package may be compiled and linked against.
+# The options are similar to those used in this script.
+# In particular, the -rpath option may turn out useful.
+
+# let the p4est installation script set the stage
+BLP4="p4est-build-wdeps.sh"
+wget -N "https://github.com/cburstedde/p4est/raw/develop/doc/$BLP4"     && \
+source "$BLP4"                                          && \
+rm "$BLP4"                                              || exit 1
+
+# clone, build and install ForestClaw
+git clone https://github.com/forestclaw/forestclaw.git -b develop       && \
+cd forestclaw                                           && \
+./bootstrap "$PREFIX/libsc/share/aclocal" "$PREFIX/p4est/share/aclocal" && \
+mkdir build                                             && \
+cd build                                                && \
+../configure $CONFIG --with-sc="$PREFIX/libsc" --with-p4est="$PREFIX/p4est" \
+                     --prefix="$PREFIX/fclaw"           && \
+(make -j V=0 || make -j V=0 || make -j V=0)             && \
+make -j install V=0                                     && \
+cd ../../                                               && \
+rm -rf forestclaw.git                                   && \
+rm -r forestclaw                                        || bdie "ForestClaw"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -177,6 +177,10 @@ LDADD += src/libforestclaw.la \
 	@FCLAW_P4EST_LDADD@ \
 	@FCLAW_SC_LDADD@
 
+FCLAW_LDADD = src/libforestclaw.la \
+	@FCLAW_P4EST_LDADD@ \
+	@FCLAW_SC_LDADD@
+
 nodist_include_HEADERS += $(libforestclaw_generated_headers)
 include_HEADERS += $(libforestclaw_installed_headers)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -168,9 +168,6 @@ src_libforestclaw_la_LIBADD = @FCLAW_P4EST_LIBADD@ @FCLAW_SC_LIBADD@
 ## Explicitly depend on other libraries
 EXTRA_src_libforestclaw_la_DEPENDENCIES = @FCLAW_P4EST_EDEPS@ @FCLAW_SC_EDEPS@
 
-## Initialize AM_LDFLAGS variable
-AM_LDFLAGS =
-
 ## Code p4est and libsc installation path into ForestClaw executables
 AM_LDFLAGS += @FCLAW_P4EST_RPATH@ @FCLAW_SC_RPATH@
 LDADD += src/libforestclaw.la \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -168,6 +168,9 @@ src_libforestclaw_la_LIBADD = @FCLAW_P4EST_LIBADD@ @FCLAW_SC_LIBADD@
 ## Explicitly depend on other libraries
 EXTRA_src_libforestclaw_la_DEPENDENCIES = @FCLAW_P4EST_EDEPS@ @FCLAW_SC_EDEPS@
 
+## Initialize AM_LDFLAGS variable
+AM_LDFLAGS =
+
 ## Code p4est and libsc installation path into ForestClaw executables
 AM_LDFLAGS += @FCLAW_P4EST_RPATH@ @FCLAW_SC_RPATH@
 LDADD += src/libforestclaw.la \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -150,36 +150,38 @@ libforestclaw_compiled_sources = \
 	src/fortran_source2d/fdisc.f \
 	src/fortran_source2d/philim.f
 
-# this variable is used for headers that are not publicly installed
-FCLAW_CPPFLAGS = \
-    -I@top_srcdir@/src \
-	-I@top_srcdir@/src/fortran_source2d
+## In case we like to build only the library and no programs
+justlibs-local: src/libforestclaw.la
 
-FCLAW_FFLAGS = $(FCLAW_CPPFLAGS)   # (orignally used for metric.i;  not needed now)
-
+## Using libtool to build the ForestClaw library
 lib_LTLIBRARIES += src/libforestclaw.la
 src_libforestclaw_la_SOURCES = \
 	$(libforestclaw_internal_headers) \
  	$(libforestclaw_compiled_sources)
-
 src_libforestclaw_la_CPPFLAGS = $(AM_CPPFLAGS) $(FCLAW_CPPFLAGS)
 
-FCLAW_LDADD = @top_builddir@/src/libforestclaw.la \
-	          @FCLAW_P4EST_LDADD@ \
-              @FCLAW_SC_LDADD@
+## This is the official API versioning scheme of libtool.  Please see:
+## Read https://www.gnu.org/software/libtool/manual/libtool.html#Versioning
+src_libforestclaw_la_LDFLAGS = -version-info 2:0:0
+src_libforestclaw_la_LIBADD = @FCLAW_P4EST_LIBADD@ @FCLAW_SC_LIBADD@
 
+## Explicitly depend on other libraries
+EXTRA_src_libforestclaw_la_DEPENDENCIES = @FCLAW_P4EST_EDEPS@ @FCLAW_SC_EDEPS@
 
-LDADD += @top_builddir@/src/libforestclaw.la \
-	     @FCLAW_P4EST_LDADD@ \
-	     @FCLAW_SC_LDADD@
-
-EXTRA_src_libforestclaw_la_DEPENDENCIES = @FCLAW_P4EST_LDADD@ @FCLAW_SC_LDADD@
+## Code p4est and libsc installation path into ForestClaw executables
+AM_LDFLAGS += @FCLAW_P4EST_RPATH@ @FCLAW_SC_RPATH@
+LDADD += src/libforestclaw.la \
+	@FCLAW_P4EST_LDADD@ \
+	@FCLAW_SC_LDADD@
 
 nodist_include_HEADERS += $(libforestclaw_generated_headers)
 include_HEADERS += $(libforestclaw_installed_headers)
 
-AM_CPPFLAGS += $(FCLAW_CPPFLAGS) @FCLAW_SC_CPPFLAGS@ @FCLAW_P4EST_CPPFLAGS@
-AM_FFLAGS += $(FCLAW_FFLAGS)
+## These flags are passed to populate the include path
+AM_CPPFLAGS += \
+	-I@top_srcdir@/src \
+	-I@top_srcdir@/src/fortran_source2d \
+	@FCLAW_SC_CPPFLAGS@ @FCLAW_P4EST_CPPFLAGS@
 
 ## UNIT TESTS
 check_PROGRAMS += src/forestclaw.TEST

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -150,6 +150,9 @@ libforestclaw_compiled_sources = \
 	src/fortran_source2d/fdisc.f \
 	src/fortran_source2d/philim.f
 
+## Extra flags that are not provided by general AM_CPPFLAGS
+FCLAW_CPPFLAGS =
+
 ## In case we like to build only the library and no programs
 justlibs-local: src/libforestclaw.la
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -170,10 +170,11 @@ EXTRA_src_libforestclaw_la_DEPENDENCIES = @FCLAW_P4EST_EDEPS@ @FCLAW_SC_EDEPS@
 
 ## Code p4est and libsc installation path into ForestClaw executables
 AM_LDFLAGS += @FCLAW_P4EST_RPATH@ @FCLAW_SC_RPATH@
+
+## Flags to support linking against ForestClaw and support libraries
 LDADD += src/libforestclaw.la \
 	@FCLAW_P4EST_LDADD@ \
 	@FCLAW_SC_LDADD@
-
 FCLAW_LDADD = src/libforestclaw.la \
 	@FCLAW_P4EST_LDADD@ \
 	@FCLAW_SC_LDADD@
@@ -208,5 +209,4 @@ src_forestclaw_TEST_CPPFLAGS = \
 src_forestclaw_TEST_LDADD = \
 	test/libtestutils.la \
 	$(test_libtestutils_la_LDADD) \
-    $(LDADD) \
-    $(FCLAW_LDADD)
+    $(LDADD)


### PR DESCRIPTION
This PR adds a script by @cburstedde to download, build and install the latest ForestClaw develop branch and its dependencies p4est, libsc, zlib and jansson. A more detailed description can be found in the documentation in `docs/fclaw-build-wdeps.sh`. Moreover, the libtool logic in `src/Makefile.am` is updated. 