### PR TITLE
Add patch threshold to api and add user option

### DIFF
--- a/src/patches/clawpatch/fclaw2d_clawpatch_options.c
+++ b/src/patches/clawpatch/fclaw2d_clawpatch_options.c
@@ -106,7 +106,7 @@ clawpatch_register(fclaw2d_clawpatch_options_t *clawpatch_options,
     /* ---------------------- vtk options -------------------------- */
     sc_options_add_int(opt, 0, "vtk-patch-threshold", 
                        &clawpatch_options->vtk_patch_threshold, 0,
-                       "Patch threshold for writing vtk output. 0 means buffer all patches before writing [0]");
+                       "Number of patches to buffer before each write in vtk output. 0 means buffer all patches before writing [0]");
 
     /* Set verbosity level for reporting timing */
     sc_keyvalue_t *kv = clawpatch_options->kv_refinement_criteria = kv_refinement_criterea_new();

--- a/src/patches/clawpatch/fclaw2d_clawpatch_options.c
+++ b/src/patches/clawpatch/fclaw2d_clawpatch_options.c
@@ -103,6 +103,11 @@ clawpatch_register(fclaw2d_clawpatch_options_t *clawpatch_options,
                          &clawpatch_options->save_aux,0,
                          "Save aux variables when re-taking a time step [F]");
 
+    /* ---------------------- vtk options -------------------------- */
+    sc_options_add_int(opt, 0, "vtk-patch-threshold", 
+                       &clawpatch_options->vtk_patch_threshold, 0,
+                       "Patch threshold for writing vtk output. 0 means buffer all patches before writing [0]");
+
     /* Set verbosity level for reporting timing */
     sc_keyvalue_t *kv = clawpatch_options->kv_refinement_criteria = kv_refinement_criterea_new();
     sc_options_add_keyvalue (opt, 0, "refinement-criteria", 

--- a/src/patches/clawpatch/fclaw2d_clawpatch_options.c
+++ b/src/patches/clawpatch/fclaw2d_clawpatch_options.c
@@ -164,6 +164,13 @@ clawpatch_check(fclaw2d_clawpatch_options_t *clawpatch_opt)
         return FCLAW_EXIT_ERROR;            
     }
 
+    if (clawpatch_opt->vtk_patch_threshold < 0)
+    {
+        fclaw_global_essentialf("Clawpatch error : vtk-patch-threshold must be " \
+                                "non-negative.\n");
+        return FCLAW_EXIT_ERROR;            
+    }
+
     return FCLAW_NOEXIT;
 }
 

--- a/src/patches/clawpatch/fclaw2d_clawpatch_options.h
+++ b/src/patches/clawpatch/fclaw2d_clawpatch_options.h
@@ -86,6 +86,8 @@ struct fclaw2d_clawpatch_options
     int save_aux;             /**< Save the aux array when retaking a time step */
 
 
+    int vtk_patch_threshold; /**< The buffer threshold for vtk output */
+
     int is_registered; /**< true if options have been registered */
 
 };

--- a/src/patches/clawpatch/fclaw2d_clawpatch_output_vtk.c
+++ b/src/patches/clawpatch/fclaw2d_clawpatch_output_vtk.c
@@ -1030,7 +1030,7 @@ void fclaw2d_clawpatch_output_vtk (fclaw2d_global_t * glob, int iframe)
                                    clawpatch_opt->meqn,
                                    fclaw_opt->vtkspace, 0,
                                    fclaw2d_output_vtk_coordinate_cb,
-                                   fclaw2d_output_vtk_value_cb, 0);
+                                   fclaw2d_output_vtk_value_cb, clawpatch_opt->vtk_patch_threshold);
 }
 
 

--- a/src/patches/clawpatch/fclaw2d_clawpatch_output_vtk.c
+++ b/src/patches/clawpatch/fclaw2d_clawpatch_output_vtk.c
@@ -232,7 +232,7 @@ fclaw2d_vtk_write_header (fclaw2d_domain_t * domain, fclaw2d_vtk_state_t * s)
  *                                  stored in the buffer + 1 is greater than
  *                                  \b threshold, the buffer is flushed to disk.
  *                                  Then the new patch is added to the buffer.
- *                                  -1 means that there is no threshold and
+ *                                  0 means that there is no threshold and
  *                                  the data just added to \b s->sink.
  */
 static void
@@ -1030,7 +1030,7 @@ void fclaw2d_clawpatch_output_vtk (fclaw2d_global_t * glob, int iframe)
                                    clawpatch_opt->meqn,
                                    fclaw_opt->vtkspace, 0,
                                    fclaw2d_output_vtk_coordinate_cb,
-                                   fclaw2d_output_vtk_value_cb, -1);
+                                   fclaw2d_output_vtk_value_cb, 0);
 }
 
 

--- a/src/patches/clawpatch/fclaw2d_clawpatch_output_vtk.c
+++ b/src/patches/clawpatch/fclaw2d_clawpatch_output_vtk.c
@@ -728,7 +728,7 @@ fclaw2d_vtk_write_file (fclaw2d_global_t * glob, const char *basename,
 {
     fclaw2d_domain_t *domain = glob->domain;
 
-    FCLAW_ASSERT (patch_threshold == -1 || patch_threshold > 0);
+    FCLAW_ASSERT (patch_threshold >= 0);
 
     int retval, gretval;
     int mpiret;

--- a/src/patches/clawpatch/fclaw2d_clawpatch_output_vtk.h
+++ b/src/patches/clawpatch/fclaw2d_clawpatch_output_vtk.h
@@ -73,6 +73,9 @@ typedef void (*fclaw2d_vtk_patch_data_t) (struct fclaw2d_global * glob,
  *                         1 for MPI_File_write (less memory usage).
  * @param[in] coordniate_cb the callback to write a patch's coordinate binary data
  * @param[in] value_cb the callback to write a patch's value binary data
+ * @param[in] patch_threshold The maximal number of buffered patches.
+ *                            -1 means that an unlimited number of patches is
+ *                            buffered and flushed to disk at the end.
  * @return          0 if successful, negative otherwise.
  *                  Collective with identical value on all ranks.
  */
@@ -85,7 +88,8 @@ fclaw2d_vtk_write_file (struct fclaw2d_global * glob, const char *basename,
                         int meqn,
                         double vtkspace, int vtkwrite,
                         fclaw2d_vtk_patch_data_t coordinate_cb,
-                        fclaw2d_vtk_patch_data_t value_cb);
+                        fclaw2d_vtk_patch_data_t value_cb,
+                        int patch_threshold);
 
 /**
  * @brief Output vtu file

--- a/src/patches/clawpatch/fclaw2d_clawpatch_output_vtk.h
+++ b/src/patches/clawpatch/fclaw2d_clawpatch_output_vtk.h
@@ -74,7 +74,7 @@ typedef void (*fclaw2d_vtk_patch_data_t) (struct fclaw2d_global * glob,
  * @param[in] coordniate_cb the callback to write a patch's coordinate binary data
  * @param[in] value_cb the callback to write a patch's value binary data
  * @param[in] patch_threshold The maximal number of buffered patches.
- *                            -1 means that an unlimited number of patches is
+ *                            0 means that an unlimited number of patches is
  *                            buffered and flushed to disk at the end.
  * @return          0 if successful, negative otherwise.
  *                  Collective with identical value on all ranks.

--- a/src/patches/clawpatch/fclaw3dx_clawpatch_options.h
+++ b/src/patches/clawpatch/fclaw3dx_clawpatch_options.h
@@ -86,6 +86,8 @@ struct fclaw3dx_clawpatch_options
     int ghost_patch_pack_aux; /**< True if aux equations should be packed */
     int save_aux;             /**< Save the aux array when retaking a time step */
 
+    int vtk_patch_threshold; /**< The buffer threshold for vtk output */
+
     int is_registered; /**< true if options have been registered */
 
 };

--- a/src/patches/clawpatch/fclaw3dx_clawpatch_output_vtk.h
+++ b/src/patches/clawpatch/fclaw3dx_clawpatch_output_vtk.h
@@ -74,7 +74,7 @@ typedef void (*fclaw3dx_vtk_patch_data_t) (struct fclaw2d_global * glob,
  * @param[in] coordniate_cb the callback to write a patch's coordinate binary data
  * @param[in] value_cb the callback to write a patch's value binary data
  * @param[in] patch_threshold The maximal number of buffered patches.
- *                            -1 means that an unlimited number of patches is
+ *                            0 means that an unlimited number of patches is
  *                            buffered and flushed to disk at the end.
  * @return          0 if successful, negative otherwise.
  *                  Collective with identical value on all ranks.

--- a/src/patches/clawpatch/fclaw3dx_clawpatch_output_vtk.h
+++ b/src/patches/clawpatch/fclaw3dx_clawpatch_output_vtk.h
@@ -73,6 +73,9 @@ typedef void (*fclaw3dx_vtk_patch_data_t) (struct fclaw2d_global * glob,
  *                         1 for MPI_File_write (less memory usage).
  * @param[in] coordniate_cb the callback to write a patch's coordinate binary data
  * @param[in] value_cb the callback to write a patch's value binary data
+ * @param[in] patch_threshold The maximal number of buffered patches.
+ *                            -1 means that an unlimited number of patches is
+ *                            buffered and flushed to disk at the end.
  * @return          0 if successful, negative otherwise.
  *                  Collective with identical value on all ranks.
  */
@@ -82,7 +85,8 @@ fclaw3dx_vtk_write_file (struct fclaw2d_global * glob, const char *basename,
                         int meqn,
                         double vtkspace, int vtkwrite,
                         fclaw3dx_vtk_patch_data_t coordinate_cb,
-                        fclaw3dx_vtk_patch_data_t value_cb);
+                        fclaw3dx_vtk_patch_data_t value_cb,
+                        int patch_threshold);
 
 /**
  * @brief Output vtu file


### PR DESCRIPTION
Adds patch threshold to `fclaw*_vtk_write_file` function call and adds the `vtk-patch-threshold` option to clawpatch options, which is used in `fclaw*_clawpatch_output_vtk`.