### PR TITLE
Fixes and simplifactions in file_info_v1 and fix a compiler warning

### DIFF
--- a/src/fclaw2d_file.c
+++ b/src/fclaw2d_file.c
@@ -1854,11 +1854,11 @@ fclaw2d_file_section_metadata_v1_t;
  *
  * \param[in,out]  file     The MPI file that will be closed in case of an error.
  * \param[in]      eclass   The eclass that indicates if an error occured.
- *                          \b eclass is a MPI, libsc or fclaw2d_file_v1 error
+ *                          \b eclass is an MPI, libsc or fclaw2d_file_v1 error
  *                          code.
  * \param[out]     errcode  The error code that is obtained by converting
  *                          \b eclass to fclaw2d_file_v1 error code.
- * @return                  -1 if \b eclass indicates an error,
+ * \return                  -1 if \b eclass indicates an error,
  *                          0 otherwise.
  */
 static int

--- a/src/fclaw2d_file.c
+++ b/src/fclaw2d_file.c
@@ -3238,7 +3238,7 @@ fclaw2d_file_close (fclaw2d_file_context_t * fc, int *errcode)
     fclaw2d_file_translate_error_code_v1 (errcode_internal, errcode);
     if (*errcode != FCLAW2D_FILE_ERR_SUCCESS)
     {
-        FCLAW_ASSERT (retval != 0);
+        FCLAW_EXECUTE_ASSERT_TRUE (retval != 0);
         return -1;
     }
 


### PR DESCRIPTION
This PR contains fixes and simplifications in the currently deactivated function `fclaw2d_file_info_v1`.

In particular, this PR introduces the function `fclaw2d_file_info_cleanup_v1` to simplify and unify the error handling in `fclaw2d_file_info_v1`. Addtionally, there are some fixes of the error management in `fclaw2d_file_info_v1`.

Furthermore, a compiler warning without the debug mode in `fclaw2d_file_close` is fixed. In contrast to the changes in two preceding paragraphs, this change affects activated, i.e. compiled code.