### PR TITLE
(3/5) 3d Support for Main ForestClaw Library

### DIFF
--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -116,7 +116,7 @@ jobs:
 
 
   mac:
-    runs-on: macos-12
+    runs-on: macos-14
     name: CMake build on MacOS
     env:
       HOMEBREW_NO_INSTALL_CLEANUP: 1

--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -116,7 +116,7 @@ jobs:
 
 
   mac:
-    runs-on: macos-11
+    runs-on: macos-12
     name: CMake build on MacOS
     env:
       HOMEBREW_NO_INSTALL_CLEANUP: 1

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(forestclaw_c OBJECT
   fclaw_finalize.c
   fclaw_time_sync.c
   fclaw_corner_neighbors.c
+  fclaw_edge_neighbors.c
   fclaw_face_neighbors.c
   fclaw_farraybox.cpp
   fclaw2d_convenience.c
@@ -140,6 +141,7 @@ install(FILES
 	fclaw_rays.h
 	fclaw_ghost_fill.h
 	fclaw_corner_neighbors.h
+	fclaw_edge_neighbors.h
 	fclaw_face_neighbors.h
 	fclaw_map.h
 	fclaw_timeinterp.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -36,6 +36,7 @@ libforestclaw_installed_headers = \
 	src/fclaw_rays.h \
 	src/fclaw_ghost_fill.h \
 	src/fclaw_corner_neighbors.h \
+	src/fclaw_edge_neighbors.h \
 	src/fclaw_face_neighbors.h \
 	src/fclaw_map.h \
 	src/fclaw_timeinterp.h \
@@ -103,6 +104,7 @@ libforestclaw_compiled_sources = \
 	src/fclaw_finalize.c \
 	src/fclaw_time_sync.c \
 	src/fclaw_corner_neighbors.c \
+	src/fclaw_edge_neighbors.c \
 	src/fclaw_face_neighbors.c \
 	src/fclaw_farraybox.cpp \
 	src/fclaw2d_convenience.c \

--- a/src/fclaw_block.c
+++ b/src/fclaw_block.c
@@ -26,24 +26,43 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <fclaw_block.h>
 #include <fclaw_global.h>
 #include <fclaw2d_defs.h>
+#include <fclaw3d_defs.h>
 
 #include <fclaw_patch.h>
-
+#include <fclaw2d_wrap.h>
+#include <fclaw3d_wrap.h>
 #include <forestclaw2d.h>
+#include <forestclaw3d.h>
 
 
 void fclaw_block_get_block_boundary(fclaw_global_t * glob,
                                       fclaw_patch_t * patch,
                                       int *intersects_block)
 {
-    int iside;
-
-    for (iside = 0; iside < FCLAW2D_NUMFACES; iside++)
+    if(glob->domain->refine_dim == 2)
     {
+        for (int iside = 0; iside < FCLAW2D_NUMFACES; iside++)
+        {
         int iface_flags = fclaw2d_patch_block_face_flags[iside];
         int is_block_face = (patch->d2->flags & iface_flags) != 0;
 
         /* True for physical and block boundaries across a face */
         intersects_block[iside] = is_block_face;
+        }
+    }
+    else if(glob->domain->refine_dim == 3)
+    {
+        for (int iside = 0; iside < FCLAW3D_NUMFACES; iside++)
+        {
+            int iface_flags = fclaw3d_patch_block_face_flags[iside];
+            int is_block_face = (patch->d3->flags & iface_flags) != 0;
+
+            /* True for physical and block boundaries across a face */
+            intersects_block[iside] = is_block_face;
+        }
+    }
+    else 
+    {
+        SC_ABORT_NOT_REACHED();
     }
 }

--- a/src/fclaw_corner_neighbors.c
+++ b/src/fclaw_corner_neighbors.c
@@ -29,72 +29,161 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <fclaw_ghost_fill.h>
 #include <fclaw_map_query.h>
 #include <fclaw_options.h>
-#include <fclaw2d_defs.h>
 #include <fclaw_global.h>
 #include <fclaw_physical_bc.h>
 #include <fclaw_patch.h>
 
 
 
-/* This is used to determine neighbor patch relative level (finer, coarser or samesize)
-   This enum is defined both here and in fclaw2d_face_neighbors.cpp.  Is that okay? */
-enum
+static
+int get_num_intersections(int dim,int intersects[], int faces[])
 {
-    COARSER_GRID = -1,
-    SAMESIZE_GRID,
-    FINER_GRID
-};
+    int num_intersections = 0;
+    for (int i = 0; i < dim; i++)
+    {
+        if (intersects[faces[i]])
+        {
+            num_intersections++;
+        }
+    }
+    return num_intersections;
+}
 
+static
+int find_face(int dim, int intersects[], int faces[])
+{
+    for (int i = 0; i < dim; i++)
+    {
+        if (intersects[faces[i]])
+        {
+            return faces[i];
+        }
+    }
+    return -1;
+}
 
+static
+int find_edge(int corner, int intersects[], int faces[])
+{
+    int non_intersecting_face = -1;
+    for (int i = 0; i < 3; i++)
+    {
+        if (!intersects[faces[i]])
+        {
+            non_intersecting_face = faces[i];
+            break;
+        }
+    }
+    FCLAW_ASSERT(non_intersecting_face >= 0);
+    int edge_axis = non_intersecting_face / 2;
+    int face_0;
+    int face_1;
+    switch(edge_axis)
+    {
+        case 0:
+            face_0 = faces[1];
+            face_1 = faces[2];
+            break;
+        case 1:
+            face_0 = faces[0];
+            face_1 = faces[2];
+            break;
+        case 2:
+            face_0 = faces[0];
+            face_1 = faces[1];
+            break;
+    }
+    FCLAW_ASSERT(face_0 != non_intersecting_face);
+    FCLAW_ASSERT(face_1 != non_intersecting_face);
+
+    int upper_0 = face_0 % 2;
+    int upper_1 = face_1 % 2;
+
+    int edge = 4*edge_axis + 2*upper_1 + upper_0;
+
+    FCLAW_ASSERT(edge >= 0 && edge < 12);
+
+    return edge;
+}
+
+/**
+ * @brief Get the corner type for a patch
+ * 
+ * @param glob the global context
+ * @param icorner the corner to get the cornertype on
+ * @param intersects_bdry Size 4 for 2D, 6 for 3D. True if patch intersects a boundary on a face
+ * @param intersects_block Size 4 for 2D, 6 for 3D. True if patch intersects a block boundary on a face
+ * @param interior_corner Returns true if the corner is interior to a block
+ * @param ftransform The ftransform object to fill in
+ *                      This will fill in the is_block_corner, is_block_edge, is_block_face, block_iface, block_iedge, and block_iface fields.
+ * @param ftransform_fine The ftransform object to fill in
+ *                      This will fill in the is_block_corner, is_block_edge, and is_block_face fields.
+ *                      block_iface and block_iedge will be initialized to -1.
+ */
 static
 void get_corner_type(fclaw_global_t* glob,
                      int icorner,
                      int intersects_bdry[],
                      int intersects_block[],
-                     int *interior_corner,
-                     int *is_block_corner,
-                     int *block_iface)
+                     int *is_interior_in_domain,
+                     fclaw_patch_transform_data_t* tdata,
+                     fclaw_patch_transform_data_t* tdata_finegrid)
 {
     fclaw_domain_t *domain = glob->domain;
 
+    tdata->icorner = icorner;
+    tdata->iedge = -1;
+    tdata->iface = -1;
+
     // p4est has tons of lookup table like this, can be exposed similarly
-    int corner_faces[FCLAW2D_SPACEDIM];
+    int corner_faces[domain->refine_dim];
     fclaw_domain_corner_faces(domain, icorner, corner_faces);
 
     /* Both faces are at a physical boundary */
-    int is_phys_corner =
-        intersects_bdry[corner_faces[0]] && intersects_bdry[corner_faces[1]];
-
-    /* Corner lies in interior of physical boundary edge. */
-    int corner_on_phys_face = !is_phys_corner &&
-             (intersects_bdry[corner_faces[0]] || intersects_bdry[corner_faces[1]]);
+    int num_phys_faces = get_num_intersections(domain->refine_dim, 
+                                               intersects_bdry,
+                                               corner_faces);
 
     /* Either a corner is at a block boundary (but not a physical boundary),
        or internal to a block.  L-shaped domains are excluded for now
        (i.e. no reentrant corners). */
-    *interior_corner = !corner_on_phys_face && !is_phys_corner;
+    *is_interior_in_domain = num_phys_faces == 0;
 
+    int num_block_faces = get_num_intersections(domain->refine_dim, 
+                                                intersects_block,
+                                                corner_faces);
     /* Both faces are at a block boundary, physical or not */
-    *is_block_corner =
-        intersects_block[corner_faces[0]] && intersects_block[corner_faces[1]];
+    tdata->is_block_corner = num_block_faces == domain->refine_dim;
 
-    *block_iface = -1;
-    if (!*is_block_corner)
+    if(domain->refine_dim == 2)
     {
-        /* At most one of these is true if corner is not a block corner */
-        if (intersects_block[corner_faces[0]])
+        tdata->is_block_edge = 0;
+        tdata->block_iedge = -1;
+    }
+    else
+    {
+        tdata->is_block_edge = num_block_faces == 2;
+        tdata->block_iedge = -1;
+        if(tdata->is_block_edge)
         {
-            /* Corner is on a block face. */
-            *block_iface = corner_faces[0];
-        }
-        else if (intersects_block[corner_faces[1]])
-        {
-            /* Corner is on a block face. */
-            *block_iface = corner_faces[1];
+        tdata->block_iedge = find_edge(icorner, intersects_block, corner_faces);
         }
     }
-}
 
+    tdata->is_block_face = num_block_faces == 1;
+    tdata->block_iface = -1;
+    if (num_block_faces == 1)
+    {
+        tdata->block_iface = find_face(domain->refine_dim, intersects_block, corner_faces);
+    }
+
+    tdata_finegrid->is_block_corner = tdata->is_block_corner;
+    tdata_finegrid->is_block_edge = tdata->is_block_edge;
+    tdata_finegrid->is_block_face = tdata->is_block_face;
+
+    tdata_finegrid->block_iface = -1;
+    tdata_finegrid->block_iedge = -1;
+}
 
 /* --------------------------------------------------------
    Four cases to consider.   The 'has_corner_neighbor'
@@ -104,22 +193,26 @@ void get_corner_type(fclaw_global_t* glob,
    The corner than satisfies one of the following four
    cases.
 
-   Case No. | has_corner_neighbor  |  is_block_corner
+   Case No. | has_corner_neighbor  |  block_boundary_type
    --------------------------------------------------------
-      1     |       T              |        T
+      1     |       T              |    is_block_corner
+      2     |       T              |    is_block_edge
+      3     |       T              |    is_block_face
+      4     |       T              |    interior
       2     |       F              |        F
       3     |       T              |        F
       4     |       F              |        T
 
-    Case 1 : In this case, 4 or more patches meet at a block
+    Case 1-2 : In this case, 4 or more patches meet at a
              corner. No transforms are yet available, so we 
              assume that at block corners, the patches all 
              have the same orientation.
+    Case 3 : Corner is either is on block face.
+             The transform is well-defined.
+    Case 4 : Corner is either interior to a block.
+             The transform is well-defined.
     Case 2 : Corner is at a hanging node and has no valid
              adjacent corner.
-    Case 3 : Corner is either interior to a block, or on a
-             block edge.  In each case, the transform is
-             well-defined.
     Case 4 : Either 3 patches meet at a corner, in which
              case we don't have an adjacent corner, or we are
              on a pillow grid, in which case we have a 
@@ -129,45 +222,41 @@ void get_corner_type(fclaw_global_t* glob,
 
 static
 void get_corner_neighbor(fclaw_global_t *glob,
-                         int this_block_idx,
-                         int this_patch_idx,
-                         fclaw_patch_t* this_patch,
                          int icorner,
-                         int block_iface,
-                         int is_block_corner,
-                         int *corner_block_idx,
-                         fclaw_patch_t** corner_patch,
-                         int *rcornerno,
-                         int **ref_flag_ptr,
+                         int *is_valid_neighbor,
                          int *block_corner_count,
-                         int ftransform[],
-                         fclaw_patch_transform_data_t* ftransform_finegrid)
+                         fclaw_patch_transform_data_t* tdata,
+                         fclaw_patch_transform_data_t* tdata_fine)
 {
     fclaw_domain_t *domain = glob->domain;
+    /* assume neighbor is valid for now*/
+    *is_valid_neighbor = 1;
     /* See what p4est thinks we have for corners, and consider four cases */
     int rproc_corner;
-    int corner_patch_idx;
-    fclaw_patch_relation_t neighbor_type;
-
+    
     /* Note : Pillowsphere case does not return a block corner neighbor */
-    int ispillowsphere = fclaw_map_pillowsphere(glob);
+    int ispillowsphere = 0;
+    if(domain->refine_dim == 2)
+    {
+        ispillowsphere =  FCLAW_MAP_IS_PILLOWSPHERE(&glob->cont);
+    }
 
     fclaw_timer_start (&glob->timers[FCLAW_TIMER_NEIGHBOR_SEARCH]);
     int has_corner_neighbor =
         fclaw_patch_corner_neighbors(domain,
-                                       this_block_idx,
-                                       this_patch_idx,
-                                       icorner,
-                                       &rproc_corner,
-                                       corner_block_idx,
-                                       &corner_patch_idx,
-                                       rcornerno,
-                                       &neighbor_type);
+                                     tdata->this_blockno,
+                                     tdata->this_patchno,
+                                     icorner,
+                                     &rproc_corner,
+                                     &tdata->neighbor_blockno,
+                                     &tdata->neighbor_patchno,
+                                     &tdata_fine->icorner,
+                                     &tdata->neighbor_type);
 
     fclaw_timer_stop (&glob->timers[FCLAW_TIMER_NEIGHBOR_SEARCH]);    
 
     *block_corner_count = 0;  /* Assume we are not at a block corner */
-    if (has_corner_neighbor && is_block_corner)
+    if (has_corner_neighbor && tdata->is_block_corner)
     {
         /* Case 1 : 4 or more patches meet at a block corner.
         This case does NOT include the pillowgrid.   */
@@ -175,117 +264,156 @@ void get_corner_neighbor(fclaw_global_t *glob,
 
         /* No block corner transforms yet, so we use the 
         interior 'default' transforms. */
-        fclaw_patch_transform_blockface_intra (glob, ftransform);
+        fclaw_patch_transform_blockface_intra (glob, tdata->transform);
         fclaw_patch_transform_blockface_intra
-            (glob, ftransform_finegrid->transform);
+            (glob, tdata_fine->transform);
     }
-    else if (!has_corner_neighbor && !is_block_corner)
+    else if (has_corner_neighbor && tdata->is_block_edge)
     {
-        /* Case 2 : 'icorner' is a hanging node */
-        /* We do not return valid transformation objects! */
-        *ref_flag_ptr = NULL;
-        *corner_patch = NULL;
-        return;
+        FCLAW_ASSERT(domain->refine_dim == 3);
+        /* The corner is on a block face (but is not a block corner).
+           Compute a transform between blocks. First, get the
+           remote face number.  The remote face number encodes the
+           orientation, so we have 0 <= rfaceno < 8 */
+
+        //int rfaceno;
+        //int rproc[2];
+        //int rpatchno[2];
+        //int rblockno;  /* Should equal *corner_block_idx, above. */
+        //fclaw_patch_edge_neighbors(domain,
+        //                             tdata->this_blockno,
+        //                             tdata->this_patchno,
+        //                             tdata->block_iface,
+        //                             rproc,
+        //                             &rblockno,
+        //                             rpatchno,
+        //                             &rfaceno);
+
+        //FCLAW_ASSERT(rblockno == tdata->neighbor_blockno);
+
+        ///* Get encoding of transforming a neighbor coordinate across a face */
+        //fclaw_patch_transform_blockface (glob, tdata->block_iface, rfaceno, tdata->transform);
+        fclaw_patch_transform_blockface_intra(glob, tdata->transform);
+
+        /* Get transform needed to swap parallel ghost patch with fine
+           grid on-proc patch.  This is done so that averaging and
+           interpolation routines can be re-used. */
+        //int iface1 = tdata->block_iface;
+        //int rface1 = rfaceno;
+        //fclaw_patch_face_swap(domain->refine_dim, &iface1, &rface1);
+        //TODO edge transforms
+        fclaw_patch_transform_blockface_intra(glob, tdata_fine->transform);
+
+        //TODO update this for rotation
+        tdata_fine->block_iedge = tdata->block_iedge ^ 3;
     }
-    else if (has_corner_neighbor && !is_block_corner)
+    else if (has_corner_neighbor && tdata->is_block_face)
     {
-        /* Case 3 : 'icorner' is an interior corner, at a block edge,
-         or we are on a periodic block.  Need to return a valid
+        /* The corner is on a block face (but is not a block corner).
+           Compute a transform between blocks. First, get the
+           remote face number.  The remote face number encodes the
+           orientation, so we have 0 <= rfaceno < 8 */
+
+        int rfaceno;
+        int rproc[4]; // overallocate for 3d
+        int rpatchno[4];
+        int rblockno;  /* Should equal *corner_block_idx, above. */
+        fclaw_patch_face_neighbors(domain,
+                                   tdata->this_blockno,
+                                   tdata->this_patchno,
+                                   tdata->block_iface,
+                                   rproc,
+                                   &rblockno,
+                                   rpatchno,
+                                   &rfaceno);
+
+        FCLAW_ASSERT(rblockno == tdata->neighbor_blockno);
+
+        /* Get encoding of transforming a neighbor coordinate across a face */
+        fclaw_patch_transform_blockface (glob, tdata->block_iface, rfaceno, tdata->transform);
+
+        /* Get transform needed to swap parallel ghost patch with fine
+           grid on-proc patch.  This is done so that averaging and
+           interpolation routines can be re-used. */
+        int iface1 = tdata->block_iface;
+        int rface1 = rfaceno;
+        fclaw_patch_face_swap(domain->refine_dim, &iface1, &rface1);
+        fclaw_patch_transform_blockface(glob, iface1, rface1,
+                                        tdata_fine->transform);
+        
+        tdata_fine->block_iface = iface1;
+    }
+    else if (has_corner_neighbor && !tdata->is_block_corner)
+    {
+        /* Case 4 : 'icorner' is an interior corner,
+         or we are on a periodic single block.  Need to return a valid
          transform in 'ftransform' */
-        /* block_iface is the block number at the of the neighbor? */
-        if (block_iface >= 0)
-        {
-            /* The corner is on a block edge (but is not a block corner).
-               Compute a transform between blocks. First, get the
-               remote face number.  The remote face number encodes the
-               orientation, so we have 0 <= rfaceno < 8 */
-            int rfaceno;
-            int rproc[FCLAW2D_REFINEFACTOR];
-            int rpatchno[FCLAW2D_REFINEFACTOR];
-            int rblockno;  /* Should equal *corner_block_idx, above. */
-            fclaw_patch_face_neighbors(domain,
-                                         this_block_idx,
-                                         this_patch_idx,
-                                         block_iface,
-                                         rproc,
-                                         &rblockno,
-                                         rpatchno,
-                                         &rfaceno);
-
-            FCLAW_ASSERT(rblockno == *corner_block_idx);
-
-            /* Get encoding of transforming a neighbor coordinate across a face */
-            fclaw_patch_transform_blockface (glob, block_iface, rfaceno, ftransform);
-
-            /* Get transform needed to swap parallel ghost patch with fine
-               grid on-proc patch.  This is done so that averaging and
-               interpolation routines can be re-used. */
-            int iface1 = block_iface;
-            int rface1 = rfaceno;
-            fclaw_patch_face_swap(domain->refine_dim,&iface1,&rface1);
-            fclaw_patch_transform_blockface(glob, iface1, rface1,
-                                              ftransform_finegrid->transform);
-            ftransform_finegrid->block_iface = iface1;
-        }
-        else if (this_block_idx == *corner_block_idx)
+        if (tdata->this_blockno == tdata->neighbor_blockno)
         {
             /* Both patches are in the same block, so we set the transform to
                a default transform.  This could be the case for periodic boundaries. */
             *block_corner_count = 4;  /* assume four for now */
-            fclaw_patch_transform_blockface_intra (glob, ftransform);
+            fclaw_patch_transform_blockface_intra (glob, tdata->transform);
             fclaw_patch_transform_blockface_intra
-                (glob, ftransform_finegrid->transform);
+                (glob, tdata_fine->transform);
 
         }
         else
         {
-            fclaw_global_essentialf("WARNING : this_block_idx = %d\n",this_block_idx);
-            fclaw_global_essentialf("WARNING : corner_block_idx = %d\n",*corner_block_idx);
-            fclaw_global_essentialf("get_corner_neighbors " \
+            fclaw_errorf("WARNING : this_block_idx = %d\n",tdata->this_blockno);
+            fclaw_errorf("WARNING : corner_block_idx = %d\n",tdata->neighbor_blockno);
+            fclaw_abortf("get_corner_neighbors " \
                                     "(fclaw2d_corner_neighbors.c : " \
                                     "We should not be here\n");
-            exit(0);
         }
     }
-    else if (!has_corner_neighbor && is_block_corner)
+    else if (!has_corner_neighbor && tdata->is_block_corner)
     {
-        /* Case 4 : Pillow sphere case or cubed sphere  */
+        /* Case 4 : In 2d: Pillow sphere case or cubed sphere
+           In 3D: not yet supported */
+        if(domain->refine_dim == 3)
+        {
+            *block_corner_count = 0;
+            *is_valid_neighbor = 0;
+            return;
+        }
+
         if (!ispillowsphere)
         {
             *block_corner_count = 3;
             /* Exactly 3 patches meet at a corner, e.g. the cubed sphere.
                In this case, 'this_patch' has no corner-adjacent only
                neighbors, and so there is nothing to do. */
-            *ref_flag_ptr = NULL;
-            *corner_patch = NULL;
+            *is_valid_neighbor = 0;
             return;
         }
         else
         {
+            /* return face neighbor as corner neighbor */
             *block_corner_count = 2;
             has_corner_neighbor = 1;
-            int rpatchno[FCLAW2D_REFINEFACTOR];
-            int rproc[FCLAW2D_REFINEFACTOR];
+            int rpatchno[4]; // overallocate for 3d
+            int rproc[4];
             int rfaceno;
 
             /* Use only faces 0 or 1 to get block data. */
             int iface = icorner % 2;
-            neighbor_type =
+            tdata->neighbor_type =
                 fclaw_patch_face_neighbors(domain,
-                                             this_block_idx,
-                                             this_patch_idx,
+                                             tdata->this_blockno,
+                                             tdata->this_patchno,
                                              iface,
                                              rproc,
-                                             corner_block_idx,
+                                             &tdata->neighbor_blockno,
                                              rpatchno,
                                              &rfaceno);
 
             int igrid;
-            if (neighbor_type == FCLAW_PATCH_HALFSIZE)
+            if (tdata->neighbor_type == FCLAW_PATCH_HALFSIZE)
             {
                 /* igrid = 0 at corners 0,1 and (R-1) at corners 2,3,
                    where R = refinement factor */
-                igrid = (icorner/2)*(FCLAW2D_REFINEFACTOR - 1);
+                igrid = (icorner/2)*(2 - 1);
             }
             else
             {
@@ -293,10 +421,17 @@ void get_corner_neighbor(fclaw_global_t *glob,
                 igrid = 0;
             }
 
-            *rcornerno = icorner;    /* This wasn't being set! */
-            corner_patch_idx = rpatchno[igrid];
+            tdata_fine->icorner = icorner;    /* This wasn't being set! */
+            tdata->neighbor_patchno = rpatchno[igrid];
             rproc_corner = rproc[igrid];
         }
+    }
+    else if (!has_corner_neighbor)
+    {
+        /* 'icorner' is a hanging node or not yet supported */
+        /* We do not return valid transformation objects! */
+        *is_valid_neighbor = 0;
+        return;
     }
 
     /* ---------------------------------------------------------------------
@@ -307,36 +442,46 @@ void get_corner_neighbor(fclaw_global_t *glob,
 
     if (domain->mpirank != rproc_corner)
     {
-        *corner_patch = &domain->ghost_patches[corner_patch_idx];
+        tdata->neighbor_patch = &domain->ghost_patches[tdata->neighbor_patchno];
     }
     else
     {
-        fclaw_block_t *neighbor_block = &domain->blocks[*corner_block_idx];
-        *corner_patch = &neighbor_block->patches[corner_patch_idx];
+        fclaw_block_t *neighbor_block = &domain->blocks[tdata->neighbor_blockno];
+        tdata->neighbor_patch = &neighbor_block->patches[tdata->neighbor_patchno];
     }
 
-    if (neighbor_type == FCLAW_PATCH_HALFSIZE)
+    
+
+    // set neighbor information in tdata_finegrid
+    tdata_fine->this_patch = tdata->neighbor_patch;
+    tdata_fine->this_blockno = tdata->neighbor_blockno;
+    tdata_fine->this_patchno = tdata->neighbor_patchno;
+
+    if (tdata->neighbor_type == FCLAW_PATCH_HALFSIZE)
     {
-        **ref_flag_ptr = 1;
+        tdata_fine->neighbor_type = FCLAW_PATCH_DOUBLESIZE;
     }
-    else if (neighbor_type == FCLAW_PATCH_SAMESIZE)
+    else if (tdata->neighbor_type == FCLAW_PATCH_SAMESIZE)
     {
-        **ref_flag_ptr = 0;
+        tdata_fine->neighbor_type = FCLAW_PATCH_SAMESIZE;
     }
     else /* FCLAW2D_PATCH_DOUBLESIZE */
     {
-        **ref_flag_ptr = -1;
+        tdata_fine->neighbor_type = FCLAW_PATCH_HALFSIZE;
     }
 }
 
 
 
-void cb_corner_fill(fclaw_domain_t *domain,
-                    fclaw_patch_t *this_patch,
-                    int this_block_idx,
-                    int this_patch_idx,
-                    void *user)
+void fclaw_corner_fill_cb(fclaw_domain_t *domain,
+                          fclaw_patch_t *this_patch,
+                          int this_blockno,
+                          int this_patchno,
+                          void *user)
 {
+    const int num_faces = fclaw_domain_num_faces(domain);
+    const int num_corners = fclaw_domain_num_corners(domain);
+
     fclaw_global_iterate_t* s = (fclaw_global_iterate_t*) user; 
 
     fclaw_exchange_info_t *filltype = (fclaw_exchange_info_t*) s->user;
@@ -350,98 +495,81 @@ void cb_corner_fill(fclaw_domain_t *domain,
     int average_from_neighbor = filltype->exchange_type == FCLAW_AVERAGE;
     int interpolate_to_neighbor = filltype->exchange_type == FCLAW_INTERPOLATE;
 
-    int intersects_bdry[FCLAW2D_NUMFACES];
-    int intersects_block[FCLAW2D_NUMFACES];
-    int is_block_corner;
-    int is_interior_corner;
-    int block_corner_count;
-
-    int icorner;
-
-    fclaw_physical_get_bc(s->glob,this_block_idx,this_patch_idx,
+    
+    int intersects_bdry[num_faces];
+    fclaw_physical_get_bc(s->glob,this_blockno,this_patchno,
                             intersects_bdry);
 
+    int intersects_block[num_faces];
     fclaw_block_get_block_boundary(s->glob, this_patch, intersects_block);
 
     /* Transform data needed at multi-block boundaries */
-    fclaw_patch_transform_data_t transform_data;
-    transform_data.glob = s->glob;
-    transform_data.based = 1;   // cell-centered data in this routine.
-    transform_data.this_patch = this_patch;
-    transform_data.neighbor_patch = NULL;  // gets filled in below.
+    fclaw_patch_transform_data_t tdata;
+
+    tdata.glob = s->glob;
+    tdata.based = 1;   // cell-centered data in this routine.
+    tdata.this_patch = this_patch;
+    tdata.this_blockno = this_blockno;
+    tdata.this_patchno = this_patchno;
+    tdata.neighbor_patch = NULL;  // gets filled in below.
 
     fclaw_patch_transform_init_data(s->glob,this_patch,
-                                      this_block_idx,
-                                      this_patch_idx,
-                                      &transform_data);
+                                      this_blockno,
+                                      this_patchno,
+                                      &tdata);
 
 
-    fclaw_patch_transform_data_t transform_data_finegrid;
-    transform_data_finegrid.glob = s->glob;
-    transform_data_finegrid.based = 1;   // cell-centered data in this routine.
+    fclaw_patch_transform_data_t tdata_fine;
+
+    tdata_fine.glob = s->glob;
+    tdata_fine.neighbor_patch = this_patch;
+    tdata_fine.neighbor_blockno = this_blockno;
+    tdata_fine.neighbor_patchno = this_patchno;
+    tdata_fine.based = 1;   // cell-centered data in this routine.
 
     fclaw_patch_transform_init_data(s->glob,this_patch,
-                                      this_block_idx,
-                                      this_patch_idx,
-                                      &transform_data_finegrid);
+                                      this_blockno,
+                                      this_patchno,
+                                      &tdata_fine);
 
 
-    for (icorner = 0; icorner < FCLAW2D_NUMCORNERS; icorner++)
+    for (int icorner = 0; icorner < num_corners; icorner++)
     {
-        block_corner_count = 0;
+        int block_corner_count = 0;
+        // get corner type and initialize is_block_* values in transform_data and transform_data_finegrid
+        // block_i* values will be initialized for transform_data
+        // block_i* values will be initialized to -1 for transform_data_finegrid
+        int is_interior_in_domain;
         get_corner_type(s->glob,icorner,
                         intersects_bdry,
                         intersects_block,
-                        &is_interior_corner,
-                        &is_block_corner,
-                        &transform_data.block_iface);
-
-        transform_data_finegrid.block_iface = -1;
+                        &is_interior_in_domain,
+                        &tdata,
+                        &tdata_fine);
 
         /* Sets block_corner_count to 0 */
         fclaw_patch_set_block_corner_count(s->glob, this_patch,
                                              icorner,block_corner_count);
 
-        if (is_interior_corner)
+        if (is_interior_in_domain)
         {
             /* Is an interior patch corner;  may also be a block corner */
 
-            int corner_block_idx;
-            int neighbor_level;
-            int *ref_flag_ptr = &neighbor_level;
-            fclaw_patch_t *corner_patch;
-            int rcornerno;
+            int is_valid_neighbor;
 
-            transform_data.icorner = icorner;
-            corner_block_idx = -1;
             get_corner_neighbor(s->glob,
-                                this_block_idx,
-                                this_patch_idx,
-                                this_patch,
                                 icorner,
-                                transform_data.block_iface,
-                                is_block_corner,
-                                &corner_block_idx,
-                                &corner_patch,
-                                &rcornerno,
-                                &ref_flag_ptr,
+                                &is_valid_neighbor,
                                 &block_corner_count,
-                                transform_data.transform,
-                                &transform_data_finegrid);
+                                &tdata,
+                                &tdata_fine);
 
             /* This sets value in block_corner_count_array */
             fclaw_patch_set_block_corner_count(s->glob, this_patch,
                                                  icorner,block_corner_count);
-            transform_data.is_block_corner = is_block_corner;
+            
 
-            /* Needed for switching the context */
-            transform_data_finegrid.is_block_corner = is_block_corner;
-            transform_data_finegrid.icorner = rcornerno;
-            transform_data_finegrid.this_patch = corner_patch;
-            transform_data_finegrid.neighbor_patch = this_patch;
-
-
-            if (ref_flag_ptr == NULL)
+            if (!is_valid_neighbor)
             {
                 /* No corner neighbor.  Either :
                    -- Hanging node
@@ -450,83 +578,74 @@ void cb_corner_fill(fclaw_domain_t *domain,
                 continue;
             }
 
-            int remote_neighbor = fclaw_patch_is_ghost(corner_patch);
+            int remote_neighbor = fclaw_patch_is_ghost(tdata.neighbor_patch);
             if (is_coarse && ((read_parallel_patches && remote_neighbor) || !remote_neighbor))
             {
-                transform_data.neighbor_patch = corner_patch;
-                if (neighbor_level == FINER_GRID)
+                if (tdata.neighbor_type == FCLAW_PATCH_HALFSIZE)
                 {
-                    fclaw_patch_t* coarse_patch = this_patch;
-                    fclaw_patch_t* fine_patch = corner_patch;
-                    int coarse_blockno = this_block_idx;
-                    int fine_blockno = corner_block_idx;
                     if (interpolate_to_neighbor && !remote_neighbor)
                     {
                         /* No need to interpolate to remote ghost patches. */
                         fclaw_patch_interpolate_corner(s->glob,
-                                                         coarse_patch,
-                                                         fine_patch,
-                                                         coarse_blockno,
-                                                         fine_blockno,
-                                                         is_block_corner,
-                                                         icorner,time_interp,
-                                                         &transform_data);
+                                                       tdata.this_patch,
+                                                       tdata.neighbor_patch,
+                                                       tdata.this_blockno,
+                                                       tdata.neighbor_blockno,
+                                                       tdata.is_block_corner,
+                                                       tdata.icorner,
+                                                       time_interp,
+                                                       &tdata);
                     }
                     else if (average_from_neighbor)
                     {
                         /* Average even if neighbor is a remote neighbor */
-                        fclaw_patch_t* coarse_patch = this_patch;
-                        fclaw_patch_t* fine_patch = corner_patch;
                         fclaw_patch_average_corner(s->glob,
-                                                     coarse_patch,
-                                                     fine_patch,
-                                                     coarse_blockno,
-                                                     fine_blockno,
-                                                     is_block_corner,
-                                                     icorner,time_interp,
-                                                     &transform_data);                        
+                                                   tdata.this_patch,
+                                                   tdata.neighbor_patch,
+                                                   tdata.this_blockno,
+                                                   tdata.neighbor_blockno,
+                                                   tdata.is_block_corner,
+                                                   tdata.icorner,
+                                                   time_interp,
+                                                   &tdata);                        
                     }
                 }
-                else if (neighbor_level == SAMESIZE_GRID && copy_from_neighbor)
+                else if (tdata.neighbor_type == FCLAW_PATCH_SAMESIZE && copy_from_neighbor)
                 {
                     fclaw_patch_copy_corner(s->glob,
-                                              this_patch,
-                                              corner_patch,
-                                              this_block_idx,
-                                              corner_block_idx,
-                                              is_block_corner,
-                                              icorner, time_interp,
-                                              &transform_data);
+                                            tdata.this_patch,
+                                            tdata.neighbor_patch,
+                                            tdata.this_blockno,
+                                            tdata.neighbor_blockno,
+                                            tdata.is_block_corner,
+                                            tdata.icorner, 
+                                            time_interp,
+                                            &tdata);
                 }
 
             }  /* End of non-parallel patch case */
-            else if (is_fine && neighbor_level == COARSER_GRID &&
+            else if (is_fine && tdata.neighbor_type == FCLAW_PATCH_DOUBLESIZE &&
                      remote_neighbor && read_parallel_patches)
             {
                 /* The coarse grid is now the remote patch;  swap contexts and 
                 call same routines above, but with remote patch as the "coarse" 
                 grid */
                 
-                fclaw_patch_t* coarse_patch = corner_patch;
-                fclaw_patch_t* fine_patch = this_patch;
-                int coarse_blockno = corner_block_idx;
-                int fine_blockno = this_patch_idx;
-
                 if (interpolate_to_neighbor)
                 {
                     /* Interpolate from remote coarse grid patch (coarse grid) to
                        local fine grid patch.  We do not need to average to the 
                        remote patch corners unless corners are used in the 
                        interpolation stencil. */
-                    int coarse_icorner = transform_data_finegrid.icorner;
-                    fclaw_patch_interpolate_corner(s->glob,
-                                                     coarse_patch,
-                                                     fine_patch,
-                                                     coarse_blockno,
-                                                     fine_blockno,
-                                                     is_block_corner,
-                                                     coarse_icorner,time_interp,
-                                                     &transform_data_finegrid);
+                       fclaw_patch_interpolate_corner(s->glob,
+                                                      tdata_fine.this_patch,
+                                                      tdata_fine.neighbor_patch,
+                                                      tdata_fine.this_blockno,
+                                                      tdata_fine.neighbor_blockno,
+                                                      tdata_fine.is_block_corner,
+                                                      tdata_fine.icorner,
+                                                      time_interp,
+                                                      &tdata_fine);
 
                 }
             } /* End of parallel case */

--- a/src/fclaw_corner_neighbors.h
+++ b/src/fclaw_corner_neighbors.h
@@ -41,11 +41,11 @@ struct fclaw_domain;
 struct fclaw_patch;
 
 
-void cb_corner_fill(struct fclaw_domain *domain,
-                    struct fclaw_patch *this_patch,
-                    int this_block_idx,
-                    int this_patch_idx,
-                    void *user);
+void fclaw_corner_fill_cb(struct fclaw_domain *domain,
+                          struct fclaw_patch *this_patch,
+                          int this_block_idx,
+                          int this_patch_idx,
+                          void *user);
 
 #ifdef __cplusplus
 #if 0

--- a/src/fclaw_edge_neighbors.c
+++ b/src/fclaw_edge_neighbors.c
@@ -1,0 +1,536 @@
+/*
+Copyright (c) 2012-2022 Carsten Burstedde, Donna Calhoun, Scott Aiton
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <fclaw_edge_neighbors.h>
+
+#include <fclaw_block.h>
+#include <fclaw_ghost_fill.h>
+#include <fclaw_map_query.h>
+#include <fclaw_options.h>
+#include <fclaw_global.h>
+#include <fclaw_physical_bc.h>
+#include <fclaw_patch.h>
+
+#include <forestclaw.h>
+#include <fclaw_convenience.h>
+
+
+static
+int get_num_intersections(int intersects[], int faces[])
+{
+    int num_intersections = 0;
+    int i;
+    for (i = 0; i < 2; i++)
+    {
+        if (intersects[faces[i]])
+        {
+            num_intersections++;
+        }
+    }
+    return num_intersections;
+}
+
+static
+int find_face(int intersects[], int faces[])
+{
+    int i;
+    for (i = 0; i < 2; i++)
+    {
+        if (intersects[faces[i]])
+        {
+            return faces[i];
+        }
+    }
+    return -1;
+}
+
+static
+void get_edge_type(fclaw_global_t* glob,
+                   int iedge,
+                   int intersects_bdry[],
+                   int intersects_block[],
+                   int *is_interior_in_domain,
+                   fclaw_patch_transform_data_t* tdata,
+                   fclaw_patch_transform_data_t* tdata_nbr)
+{
+    fclaw_domain_t *domain = glob->domain;
+
+    tdata->icorner = -1;
+    tdata->iedge = iedge;
+    tdata->iface = -1;
+
+    tdata_nbr->icorner = -1;
+    tdata_nbr->iedge = -1;
+    tdata_nbr->iface = -1;
+    
+    //can't be corner
+    tdata->is_block_corner = 0;
+    tdata_nbr->is_block_corner = 0;
+
+    // p4est has tons of lookup table like this, can be exposed similarly
+    int edge_faces[2];
+    fclaw_domain_edge_faces(domain, iedge, edge_faces);
+
+    /* Both faces are at a physical boundary */
+    int num_phys_faces = get_num_intersections(intersects_bdry,
+                                               edge_faces);
+
+    /* Either a edge is at a block boundary (but not a physical boundary),
+       or internal to a block.  L-shaped domains are excluded for now
+       (i.e. no reentrant corners). */
+    *is_interior_in_domain = num_phys_faces == 0;
+
+    int num_block_faces = get_num_intersections(intersects_block,
+                                                edge_faces);
+    /* Both faces are at a block boundary, physical or not */
+    tdata->is_block_edge = num_block_faces == 2;
+    if(tdata->is_block_edge)
+    {
+        tdata->block_iedge = iedge;
+    }
+    else
+    {
+        tdata->block_iedge = -1;
+    }
+
+    tdata->is_block_face = num_block_faces == 1;
+    tdata->block_iface = -1;
+    if (tdata->is_block_face)
+    {
+        tdata->block_iface = find_face(intersects_block, edge_faces);
+    }
+
+    //set nbr tdata
+    tdata_nbr->is_block_edge = tdata->is_block_edge;
+    tdata_nbr->is_block_face = tdata->is_block_face;
+    tdata_nbr->block_iedge = -1;
+    tdata_nbr->block_iface = -1;
+}
+
+
+/* --------------------------------------------------------
+   Four cases to consider.   The 'has_corner_neighbor'
+   value is returned from p4est.  The assumption going
+   into this routine is that we have found a valid
+   interior corner (not a corner on a physical boundary).
+   The corner than satisfies one of the following four
+   cases.
+
+   Case No. | has_corner_neighbor  |  is_block_corner
+   --------------------------------------------------------
+      1     |       T              |        T
+      2     |       F              |        F
+      3     |       T              |        F
+      4     |       F              |        T
+
+    Case 1 : In this case, 4 or more patches meet at a block
+             corner. No transforms are yet available, so we 
+             assume that at block corners, the patches all 
+             have the same orientation.
+    Case 2 : Corner is at a hanging node and has no valid
+             adjacent corner.
+    Case 3 : Corner is either interior to a block, or on a
+             block edge.  In each case, the transform is
+             well-defined.
+    Case 4 : Either 3 patches meet at a corner, in which
+             case we don't have an adjacent corner, or we are
+             on a pillow grid, in which case we have a 
+             corner, but one which we nonetheless treat
+             as a special case.
+   ------------------------------------------------------ */
+
+typedef struct get_edge_neighbors_return
+{
+    int is_valid_neighbor;
+    fclaw_patch_t* patches[2];
+    int patchnos[2];
+    int block_edge_count;
+} edge_neighbors_t;
+
+static
+edge_neighbors_t
+get_edge_neighbors(fclaw_global_t *glob,
+                   fclaw_patch_transform_data_t* tdata,
+                   fclaw_patch_transform_data_t* tdata_nbr)
+{
+    edge_neighbors_t retval;
+    /* assume it is a valid neighbor for now */
+    retval.is_valid_neighbor = 1;
+
+    fclaw_domain_t *domain = glob->domain;
+    const int num_face_neighbors = fclaw_domain_num_siblings(domain)/2;
+
+    for(int i=0; i<2; i++)
+    {
+        retval.patches[i] = NULL;
+    }
+
+    fclaw_timer_start (&glob->timers[FCLAW_TIMER_NEIGHBOR_SEARCH]);
+
+    /* See what p4est thinks we have for edges, and consider four cases */
+    int rproc_edge[2];
+    int has_edge_neighbor =
+        fclaw_patch_edge_neighbors(domain,
+                                   tdata->this_blockno,
+                                   tdata->this_patchno,
+                                   tdata->iedge,
+                                   rproc_edge,
+                                   &tdata->neighbor_blockno,
+                                   retval.patchnos,
+                                   &tdata_nbr->iedge,
+                                   &tdata->neighbor_type);
+
+    fclaw_timer_stop (&glob->timers[FCLAW_TIMER_NEIGHBOR_SEARCH]);    
+
+    retval.block_edge_count = 0;  /* Assume we are not at a block edge */
+    if (has_edge_neighbor && tdata->is_block_edge)
+    {
+        /* Case 1 : 4 or more patches meet at a block corner.
+        This case does NOT include the pillowgrid.   */
+        retval.block_edge_count = 4;  /* assume four for now */
+
+        /* No block corner transforms yet, so we use the 
+        interior 'default' transforms. */
+        fclaw_patch_transform_blockface_intra (glob, tdata->transform);
+        fclaw_patch_transform_blockface_intra
+            (glob, tdata_nbr->transform);
+    }
+    else if (has_edge_neighbor && tdata->is_block_face)
+    {
+        /* The corner is on a block face (but is not a block edge).
+           Compute a transform between blocks. First, get the
+           remote face number.  The remote face number encodes the
+           orientation, so we have 0 <= rfaceno < 8 */
+        int rfaceno;
+        int rproc[num_face_neighbors];
+        int rpatchno[num_face_neighbors];
+        int rblockno;  /* Should equal *corner_block_idx, above. */
+        fclaw_patch_face_neighbors(domain,
+                                   tdata->this_blockno,
+                                   tdata->this_patchno,
+                                   tdata->block_iface,
+                                   rproc,
+                                   &rblockno,
+                                   rpatchno,
+                                   &rfaceno);
+
+        FCLAW_ASSERT(rblockno == tdata->neighbor_blockno);
+
+        /* Get encoding of transforming a neighbor coordinate across a face */
+        fclaw_patch_transform_blockface (glob, tdata->block_iface, rfaceno, tdata->transform);
+
+        /* Get transform needed to swap parallel ghost patch with fine
+           grid on-proc patch.  This is done so that averaging and
+           interpolation routines can be re-used. */
+        int iface1 = tdata->block_iface;
+        int rface1 = rfaceno;
+        fclaw_patch_face_swap(domain->refine_dim, &iface1, &rface1);
+        fclaw_patch_transform_blockface(glob, iface1, rface1,
+                                          tdata_nbr->transform);
+
+        tdata_nbr->block_iface = iface1;
+    }
+    else if (has_edge_neighbor)
+    {
+        /* Case 3 : 'iedge' is an interior edge */
+        if (tdata->this_blockno == tdata->neighbor_blockno)
+        {
+            /* Both patches are in the same block, so we set the transform to
+               a default transform.  This could be the case for periodic boundaries. */
+            retval.block_edge_count = 4;
+            fclaw_patch_transform_blockface_intra(glob, tdata->transform);
+            fclaw_patch_transform_blockface_intra(glob, tdata_nbr->transform);
+
+        }
+        else
+        {
+            fclaw_errorf("WARNING : this_block_idx = %d\n",tdata->this_blockno);
+            fclaw_errorf("WARNING : neighbor_block_idx = %d\n",tdata->neighbor_blockno);
+            fclaw_abortf("get_edge_neighbors " \
+                            "(fclaw_edge_neighbors.c : " \
+                            "We should not be here\n");
+        }
+    }
+    else if (!has_edge_neighbor)
+    {
+        /* Case 2 : 'iedge' is a hanging node */
+        /* We do not return valid transformation objects! */
+        retval.is_valid_neighbor = 0;
+        return retval;
+    }
+
+    /* ---------------------------------------------------------------------
+       We have a valid neighbor and possibly a transform. We just now need
+       to get a pointer to the neighbor patch (which may be a parallel patch)
+       and the relative level (-1,0,1).
+       --------------------------------------------------------------------- */
+
+    
+    int num_neighbors;
+    if (tdata->neighbor_type == FCLAW_PATCH_HALFSIZE)
+    {
+        tdata_nbr->neighbor_type = FCLAW_PATCH_DOUBLESIZE;
+        num_neighbors = 2;
+    }
+    else if (tdata->neighbor_type == FCLAW_PATCH_SAMESIZE)
+    {
+        tdata_nbr->neighbor_type = FCLAW_PATCH_SAMESIZE;
+        num_neighbors = 1;
+    }
+    else /* FCLAW2D_PATCH_DOUBLESIZE */
+    {
+        tdata_nbr->neighbor_type = FCLAW_PATCH_HALFSIZE;
+        num_neighbors = 1;
+    }
+
+    for(int i=0; i < num_neighbors; i++)
+    {
+        if (domain->mpirank != rproc_edge[i])
+        {
+            retval.patches[i] = &domain->ghost_patches[retval.patchnos[i]];
+        }
+        else
+        {
+            fclaw_block_t *neighbor_block = &domain->blocks[tdata->neighbor_blockno];
+            retval.patches[i] = &neighbor_block->patches[retval.patchnos[i]];
+        }
+    }
+
+    //set tdata_fine
+    tdata_nbr->this_blockno = tdata->neighbor_blockno;
+
+    return retval;
+}
+
+
+
+void fclaw_edge_fill_cb(fclaw_domain_t *domain,
+                        fclaw_patch_t *this_patch,
+                        int this_blockno,
+                        int this_patchno,
+                        void *user)
+{
+    const int num_faces = fclaw_domain_num_faces(domain);
+    const int num_edges = fclaw_domain_num_edges(domain);
+
+    fclaw_global_iterate_t* s = (fclaw_global_iterate_t*) user; 
+
+    fclaw_exchange_info_t *filltype = (fclaw_exchange_info_t*) s->user;
+    int time_interp = filltype->time_interp;
+    int is_coarse = filltype->grid_type == FCLAW_IS_COARSE;
+    int is_fine = filltype->grid_type == FCLAW_IS_FINE;
+
+    int read_parallel_patches = filltype->read_parallel_patches;
+
+    int copy_from_neighbor = filltype->exchange_type == FCLAW_COPY;
+    int average_from_neighbor = filltype->exchange_type == FCLAW_AVERAGE;
+    int interpolate_to_neighbor = filltype->exchange_type == FCLAW_INTERPOLATE;
+
+    int intersects_bdry[num_faces];
+    int intersects_block[num_faces];
+
+    fclaw_physical_get_bc(s->glob,this_blockno,this_patchno,
+                            intersects_bdry);
+
+    fclaw_block_get_block_boundary(s->glob, this_patch, intersects_block);
+
+    /* Transform data needed at multi-block boundaries */
+    fclaw_patch_transform_data_t tdata;
+
+    tdata.glob = s->glob;
+    tdata.based = 1;   // cell-centered data in this routine.
+    tdata.this_patch = this_patch;
+    tdata.this_blockno = this_blockno;
+    tdata.this_patchno = this_patchno;
+    tdata.neighbor_patch = NULL;  // gets filled in below.
+
+    fclaw_patch_transform_init_data(s->glob,this_patch,
+                                      this_blockno,
+                                      this_patchno,
+                                      &tdata);
+
+
+    fclaw_patch_transform_data_t tdata_nbr;
+
+    tdata_nbr.glob = s->glob;
+    tdata_nbr.based = 1;   // cell-centered data in this routine.
+    tdata_nbr.neighbor_patch = this_patch;
+    tdata_nbr.neighbor_blockno = this_blockno;
+    tdata_nbr.neighbor_patchno = this_patchno;
+
+    fclaw_patch_transform_init_data(s->glob,this_patch,
+                                      this_blockno,
+                                      this_patchno,
+                                      &tdata_nbr);
+
+
+    for (int iedge = 0; iedge < num_edges; iedge++)
+    {
+        int is_interior_in_domain;
+        get_edge_type(s->glob,iedge,
+                        intersects_bdry,
+                        intersects_block,
+                        &is_interior_in_domain,
+                        &tdata,
+                        &tdata_nbr);
+
+        /* Sets block_corner_count to 0 */
+        // TODO is this necessary?
+        //fclaw_patch_set_block_edge_count(s->glob, this_patch,
+        //                                 iedge,block_edge_count);
+
+        if (is_interior_in_domain)
+        {
+            /* Is an interior patch edge;  may also be a block edge */
+
+            edge_neighbors_t edge_neighbors =
+                get_edge_neighbors(s->glob,
+                                   &tdata,
+                                   &tdata_nbr);
+
+            /* This sets value in block_corner_count_array */
+            //TODO is this necessary?
+            //fclaw_patch_set_block_corner_count(s->glob, this_patch,
+            //                                     icorner,block_corner_count);
+
+            if (!edge_neighbors.is_valid_neighbor)
+            {
+                /* No corner neighbor.  Either :
+                   -- Hanging node
+                   -- Cubed sphere
+                */
+                continue;
+            }
+            FCLAW_ASSERT(tdata.iedge == iedge);
+            FCLAW_ASSERT(tdata_nbr.iedge == (iedge^3));
+
+            /* Parallel distribution keeps siblings on same processor */
+            int remote_neighbor = fclaw_patch_is_ghost(edge_neighbors.patches[0]);
+            if (is_coarse)
+            {
+                if (tdata.neighbor_type == FCLAW_PATCH_HALFSIZE)
+                {
+                    for (int igrid = 0; igrid < 2; igrid++)
+                    {
+                        tdata.neighbor_patch = edge_neighbors.patches[igrid];
+                        tdata.neighbor_patchno = edge_neighbors.patchnos[igrid];
+
+                        remote_neighbor = fclaw_patch_is_ghost(tdata.neighbor_patch);
+                        int valid_remote = read_parallel_patches && remote_neighbor;
+                        int local_neighbor = !remote_neighbor;
+                        if (!(local_neighbor || valid_remote))
+                        {
+                            continue;
+                        }
+
+                        if (interpolate_to_neighbor && !remote_neighbor)
+                        {
+                            /* interpolate to igrid */
+                            fclaw_patch_interpolate_edge(s->glob,
+                                                         tdata.this_patch,
+                                                         tdata.neighbor_patch,
+                                                         tdata.iedge,
+                                                         time_interp,
+                                                         &tdata);
+                        }
+                        else if (average_from_neighbor)
+                        {
+                            /* average from igrid */
+                            fclaw_patch_average_edge(s->glob,
+                                                     tdata.this_patch,
+                                                     tdata.neighbor_patch,
+                                                     tdata.iedge,
+                                                     time_interp,
+                                                     &tdata);
+                        }
+                    }
+                }
+                else if (tdata.neighbor_type == FCLAW_PATCH_SAMESIZE && copy_from_neighbor)
+                {
+                    /* Copy to same size patch */
+                    tdata.neighbor_patch = edge_neighbors.patches[0];
+                    tdata.neighbor_patchno = edge_neighbors.patchnos[0];
+
+                    fclaw_patch_copy_edge(s->glob,
+                                          tdata.this_patch,
+                                          tdata.neighbor_patch,
+                                          tdata.this_blockno,
+                                          tdata.neighbor_blockno,
+                                          tdata.iedge,
+                                          time_interp,
+                                          &tdata);
+
+                    /* We also need to copy _to_ the remote neighbor; switch contexts, but
+                       use ClawPatches that are only in scope here, to avoid
+                       conflicts with above uses of the same variables. This is needed
+                       in case we want to interpolate to adjacent corners on fine grids.*/
+                    if (remote_neighbor)
+                    {
+                        tdata_nbr.this_patch = edge_neighbors.patches[0];
+                        tdata_nbr.this_patchno = edge_neighbors.patchnos[0];
+                        fclaw_patch_copy_edge(s->glob,
+                                              tdata_nbr.this_patch,
+                                              tdata_nbr.neighbor_patch,
+                                              tdata_nbr.this_blockno,
+                                              tdata_nbr.neighbor_blockno,
+                                              tdata_nbr.iedge, 
+                                              time_interp,
+                                              &tdata_nbr);                            
+                    }
+                }
+            }
+            else if (is_fine && tdata.neighbor_type == FCLAW_PATCH_DOUBLESIZE && remote_neighbor
+                     && read_parallel_patches)
+            {
+                /* Swap 'this_patch' (fine grid) and the neighbor patch 
+                (a coarse grid) */
+                tdata_nbr.this_patch = edge_neighbors.patches[0];
+                tdata_nbr.this_patchno = edge_neighbors.patchnos[0];
+
+                if (average_from_neighbor)
+                {
+                        /* Average from 'this' grid (fine grid) to remote grid 
+                    (coarse grid) */
+                    fclaw_patch_average_edge(s->glob,
+                                             tdata_nbr.this_patch,
+                                             tdata_nbr.neighbor_patch,
+                                             tdata_nbr.iedge,
+                                             time_interp,
+                                             &tdata_nbr);
+                }
+                else if (interpolate_to_neighbor)
+                {
+                    /* Interpolate from remote neighbor to 'this' patch (the finer grid */
+                    fclaw_patch_interpolate_edge(s->glob,
+                                                 tdata_nbr.this_patch,
+                                                 tdata_nbr.neighbor_patch,
+                                                 tdata_nbr.iedge,
+                                                 time_interp,
+                                                 &tdata_nbr);
+                }
+            }
+        }  /* End of 'interior_edge' */
+    }  /* End of iedge loop */
+}

--- a/src/fclaw_edge_neighbors.h
+++ b/src/fclaw_edge_neighbors.h
@@ -1,0 +1,57 @@
+/*
+Copyright (c) 2012 Carsten Burstedde, Donna Calhoun
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef FCLAW_EDGE_NEIGHBORS_H
+#define FCLAW_EDGE_NEIGHBORS_H
+
+#include <fclaw_base.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#if 0
+}
+#endif
+#endif
+
+struct fclaw_global;
+struct fclaw_domain;
+struct fclaw_patch;
+
+
+void fclaw_edge_fill_cb(struct fclaw_domain *domain,
+                        struct fclaw_patch *this_patch,
+                        int this_block_idx,
+                        int this_patch_idx,
+                        void *user);
+
+#ifdef __cplusplus
+#if 0
+{
+#endif
+}
+#endif
+
+#endif

--- a/src/fclaw_exchange.c
+++ b/src/fclaw_exchange.c
@@ -183,7 +183,7 @@ void fclaw_exchange_setup(fclaw_global_t* glob,
        on manifolds).*/
     int zz = 0;
     int nb;
-void ** patch_data = get_patch_data(domain);
+    void ** patch_data = get_patch_data(domain);
     for (nb = 0; nb < domain->num_blocks; ++nb)
     {
         int np;
@@ -258,6 +258,7 @@ void fclaw_exchange_delete(fclaw_global_t* glob)
 
     /* Free contiguous memory, if allocated.  If no memory was allocated
        (because we are not storing the area), nothing de-allocated. */
+    void ** patch_data = get_patch_data(*domain);
     if (e_old != NULL)
     {
         /* Delete local patches which are passed to other procs */
@@ -270,7 +271,7 @@ void fclaw_exchange_delete(fclaw_global_t* glob)
             {
                 if (fclaw_patch_on_parallel_boundary(&(*domain)->blocks[nb].patches[np]))
                 {
-                    fclaw_patch_local_ghost_free(glob,&e_old->d2->patch_data[zz++]);
+                    fclaw_patch_local_ghost_free(glob,&patch_data[zz++]);
                 }
             }
         }

--- a/src/fclaw_face_neighbors.h
+++ b/src/fclaw_face_neighbors.h
@@ -39,11 +39,11 @@ struct fclaw_domain;
 struct fclaw_patch;
 
 
-void cb_face_fill(struct fclaw_domain *domain,
-                  struct fclaw_patch *this_patch,
-                  int this_block_idx,
-                  int this_patch_idx,
-                  void *user);
+void fclaw_face_fill_cb(struct fclaw_domain *domain,
+                        struct fclaw_patch *this_patch,
+                        int this_block_idx,
+                        int this_patch_idx,
+                        void *user);
 
 void fclaw_face_neighbor_ghost(struct fclaw_global* glob,
                                  int minlevel,

--- a/src/fclaw_ghost_fill.c
+++ b/src/fclaw_ghost_fill.c
@@ -162,7 +162,7 @@ void copy2ghost(fclaw_global_t *glob,
     fclaw_global_iterate_level(glob, level, cb_parallel_wrap,
                          (void *) &parallel_mode);
     /* corner exchanges */
-    parallel_mode.cb_fill = cb_corner_fill;
+    parallel_mode.cb_fill = fclaw_corner_fill_cb;
     fclaw_global_iterate_level(glob, level, cb_parallel_wrap,
                           (void *) &parallel_mode);
 }
@@ -194,7 +194,7 @@ void average2ghost(fclaw_global_t *glob,
                    cb_interface_wrap, (void *) &parallel_mode);
 
     /* Corner average */
-    parallel_mode.cb_fill = cb_corner_fill;
+    parallel_mode.cb_fill = fclaw_corner_fill_cb;
     fclaw_global_iterate_level(glob, coarse_level, cb_interface_wrap,
                    (void *) &parallel_mode);
 
@@ -255,7 +255,7 @@ void interpolate2ghost(fclaw_global_t *glob,
                                          (void *) &parallel_mode);
 
     /* Corner interpolate */
-    parallel_mode.cb_fill = cb_corner_fill;
+    parallel_mode.cb_fill = fclaw_corner_fill_cb;
     fclaw_global_iterate_level(glob,coarse_level, cb_interface_wrap,
                   (void *) &parallel_mode);
     /* -----------------------------------------------------
@@ -276,7 +276,7 @@ void interpolate2ghost(fclaw_global_t *glob,
 
     /* Interpolate to corners at parallel boundaries from coarse grid
        ghost patches */
-    parallel_mode.cb_fill = cb_corner_fill;
+    parallel_mode.cb_fill = fclaw_corner_fill_cb;
     fclaw_global_iterate_level(glob, fine_level, cb_interface_wrap,
                                  (void *) &parallel_mode);
 }

--- a/src/fclaw_ghost_fill.c
+++ b/src/fclaw_ghost_fill.c
@@ -67,6 +67,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <fclaw_ghost_fill.h>
 #include <fclaw_corner_neighbors.h>
+#include <fclaw_edge_neighbors.h>
 #include <fclaw_face_neighbors.h>
 
 #include <fclaw_global.h>
@@ -161,6 +162,15 @@ void copy2ghost(fclaw_global_t *glob,
     parallel_mode.cb_fill = fclaw_face_fill_cb;
     fclaw_global_iterate_level(glob, level, cb_parallel_wrap,
                          (void *) &parallel_mode);
+
+    if(glob->domain->refine_dim == 3)
+    {
+        /* edge exchanges */
+        parallel_mode.cb_fill = fclaw_edge_fill_cb;
+        fclaw_global_iterate_level(glob, level, cb_parallel_wrap,
+                              (void *) &parallel_mode);
+    }
+
     /* corner exchanges */
     parallel_mode.cb_fill = fclaw_corner_fill_cb;
     fclaw_global_iterate_level(glob, level, cb_parallel_wrap,
@@ -192,6 +202,14 @@ void average2ghost(fclaw_global_t *glob,
     parallel_mode.cb_fill = fclaw_face_fill_cb;
     fclaw_global_iterate_level(glob, coarse_level,
                    cb_interface_wrap, (void *) &parallel_mode);
+
+	if(glob->domain->refine_dim ==3)
+    {
+        /* Edge average */
+        parallel_mode.cb_fill = fclaw_edge_fill_cb;
+        fclaw_global_iterate_level(glob, coarse_level, cb_interface_wrap,
+                       (void *) &parallel_mode);
+    }
 
     /* Corner average */
     parallel_mode.cb_fill = fclaw_corner_fill_cb;
@@ -254,6 +272,14 @@ void interpolate2ghost(fclaw_global_t *glob,
     fclaw_global_iterate_level(glob,coarse_level, cb_interface_wrap,
                                          (void *) &parallel_mode);
 
+    if(glob->domain->refine_dim ==3)
+    {
+        /* Edge interpolate */
+        parallel_mode.cb_fill = fclaw_edge_fill_cb;
+        fclaw_global_iterate_level(glob, coarse_level, cb_interface_wrap,
+                                  (void *) &parallel_mode);
+    }
+
     /* Corner interpolate */
     parallel_mode.cb_fill = fclaw_corner_fill_cb;
     fclaw_global_iterate_level(glob,coarse_level, cb_interface_wrap,
@@ -273,6 +299,15 @@ void interpolate2ghost(fclaw_global_t *glob,
     parallel_mode.cb_fill = fclaw_face_fill_cb;
     fclaw_global_iterate_level(glob, fine_level, cb_interface_wrap,
                                  (void *) &parallel_mode);
+
+	if(glob->domain->refine_dim == 3)
+    {
+        /* Interpolate to edges at parallel boundaries from coarse grid
+           ghost patches */
+        parallel_mode.cb_fill = fclaw_edge_fill_cb;
+        fclaw_global_iterate_level(glob, fine_level, cb_interface_wrap,
+                                     (void *) &parallel_mode);
+    }
 
     /* Interpolate to corners at parallel boundaries from coarse grid
        ghost patches */

--- a/src/fclaw_ghost_fill.c
+++ b/src/fclaw_ghost_fill.c
@@ -158,7 +158,7 @@ void copy2ghost(fclaw_global_t *glob,
     parallel_mode.ghost_mode = ghost_mode;
     parallel_mode.user = (void*) &e_info;
 
-    parallel_mode.cb_fill = cb_face_fill;
+    parallel_mode.cb_fill = fclaw_face_fill_cb;
     fclaw_global_iterate_level(glob, level, cb_parallel_wrap,
                          (void *) &parallel_mode);
     /* corner exchanges */
@@ -189,7 +189,7 @@ void average2ghost(fclaw_global_t *glob,
 	parallel_mode.user = (void*) &e_info;
 	parallel_mode.ghost_mode = ghost_mode;
 
-    parallel_mode.cb_fill = cb_face_fill;
+    parallel_mode.cb_fill = fclaw_face_fill_cb;
     fclaw_global_iterate_level(glob, coarse_level,
                    cb_interface_wrap, (void *) &parallel_mode);
 
@@ -207,7 +207,7 @@ void average2ghost(fclaw_global_t *glob,
 		int fine_level = coarse_level + 1;
 
 		/* Face average */
-		parallel_mode.cb_fill = cb_face_fill;
+		parallel_mode.cb_fill = fclaw_face_fill_cb;
 		fclaw_global_iterate_level(glob, fine_level,
 									 cb_interface_wrap, (void *) &parallel_mode);
 
@@ -250,7 +250,7 @@ void interpolate2ghost(fclaw_global_t *glob,
     parallel_mode.user = (void*) &e_info;
 
     /* Face interpolate */
-    parallel_mode.cb_fill = cb_face_fill;
+    parallel_mode.cb_fill = fclaw_face_fill_cb;
     fclaw_global_iterate_level(glob,coarse_level, cb_interface_wrap,
                                          (void *) &parallel_mode);
 
@@ -270,7 +270,7 @@ void interpolate2ghost(fclaw_global_t *glob,
        patches */
     int fine_level = coarse_level + 1;
 
-    parallel_mode.cb_fill = cb_face_fill;
+    parallel_mode.cb_fill = fclaw_face_fill_cb;
     fclaw_global_iterate_level(glob, fine_level, cb_interface_wrap,
                                  (void *) &parallel_mode);
 

--- a/src/fclaw_ghost_fill.h
+++ b/src/fclaw_ghost_fill.h
@@ -83,12 +83,6 @@ typedef struct fclaw_exchange_info
 
 } fclaw_exchange_info_t;
 
-void cb_face_fill(struct fclaw_domain *domain,
-				  struct fclaw_patch *this_patch,
-				  int this_block_idx,
-				  int this_patch_idx,
-				  void *user);
-
 void fclaw_ghost_update(struct fclaw_global* glob,
 						  int fine_level,
 						  int coarse_level,

--- a/src/fclaw_ghost_fill.h
+++ b/src/fclaw_ghost_fill.h
@@ -83,12 +83,6 @@ typedef struct fclaw_exchange_info
 
 } fclaw_exchange_info_t;
 
-void cb_corner_fill(struct fclaw_domain *domain,
-					struct fclaw_patch *this_patch,
-					int this_block_idx,
-					int this_patch_idx,
-					void *user);
-
 void cb_face_fill(struct fclaw_domain *domain,
 				  struct fclaw_patch *this_patch,
 				  int this_block_idx,

--- a/src/fclaw_map_query.h
+++ b/src/fclaw_map_query.h
@@ -71,10 +71,10 @@ int FCLAW_MAP_IS_SPHERE(fclaw_map_context_t** cont);
 #define FCLAW_MAP_IS_HEMISPHERE FCLAW_F77_FUNC_(fclaw_map_is_hemisphere,FCLAW_MAP_IS_HEMISPHERE)
 int FCLAW_MAP_IS_HEMISPHERE(fclaw_map_context_t** cont);
 
-#define FCLAW_MAP_IS_TORUS FCLAW_F77_FUNC_(fclaw_map_is_torus,FCLAW2D_MAP_TORUS)
+#define FCLAW_MAP_IS_TORUS FCLAW_F77_FUNC_(fclaw_map_is_torus,FCLAW_MAP_IS_TORUS)
 int FCLAW_MAP_IS_TORUS(fclaw_map_context_t** cont);
 
-#define FCLAW_MAP_IS_BRICK FCLAW_F77_FUNC_(fclaw_map_is_brick,FCLAW2D_MAP_BRICK)
+#define FCLAW_MAP_IS_BRICK FCLAW_F77_FUNC_(fclaw_map_is_brick,FCLAW_MAP_IS_BRICK)
 int FCLAW_MAP_IS_BRICK(fclaw_map_context_t** cont);
 
 

--- a/src/fclaw_options.c
+++ b/src/fclaw_options.c
@@ -307,11 +307,17 @@ fclaw_register (fclaw_options_t* fclaw_opt, sc_options_t * opt)
     sc_options_add_int (opt, 0, "mj", &fclaw_opt->mj, 1,
                         "Number of blocks in y direction  [1]");
 
+    sc_options_add_int (opt, 0, "mk", &fclaw_opt->mk, 1,
+                        "Number of blocks in z direction  [1]");
+
     sc_options_add_bool (opt, 0, "periodic_x", &fclaw_opt->periodic_x, 0,
                         "Periodic in x direction [F]");
 
     sc_options_add_bool (opt, 0, "periodic_y", &fclaw_opt->periodic_y, 0,
                         "Periodic in y direction  [F]");
+
+    sc_options_add_bool (opt, 0, "periodic_z", &fclaw_opt->periodic_z, 0,
+                        "Periodic in z direction  [F]");
 
     fclaw_options_add_double_array (opt,0, "scale",
                                     &fclaw_opt->scale_string, "1 1 1",

--- a/src/fclaw_options.h
+++ b/src/fclaw_options.h
@@ -164,8 +164,10 @@ struct fclaw_options
     int manifold;
     int mi;
     int mj;
+    int mk;
     int periodic_x;
     int periodic_y;
+    int periodic_z;
 
     /* Advanced options */
     int flux_correction;
@@ -201,9 +203,8 @@ struct fclaw_options
     double bx;   /**< Only for the single block, unmapped case */
     double ay;   /**< Only for the single block, unmapped case */
     double by;   /**< Only for the single block, unmapped case */
-    // TODO 
-    double az;
-    double bz;
+    double az;   /**< Only for the single block, unmapped case */
+    double bz;   /**< Only for the single block, unmapped case */
 
     /* Diagnostics */
     int run_user_diagnostics;

--- a/src/fclaw_partition.c
+++ b/src/fclaw_partition.c
@@ -70,8 +70,10 @@ void  cb_partition_transfer(fclaw_domain_t * old_domain,
     {
         FCLAW_ASSERT(old_patch->xlower == new_patch->xlower);
         FCLAW_ASSERT(old_patch->ylower == new_patch->ylower);
+        FCLAW_ASSERT(old_patch->zlower == new_patch->zlower);
         FCLAW_ASSERT(old_patch->xupper == new_patch->xupper);
         FCLAW_ASSERT(old_patch->yupper == new_patch->yupper);
+        FCLAW_ASSERT(old_patch->zupper == new_patch->zupper);
 
         new_patch->user = old_patch->user;
         old_patch->user = NULL;

--- a/src/fclaw_patch.h
+++ b/src/fclaw_patch.h
@@ -461,19 +461,6 @@ void fclaw_patch_interpolate_corner(struct fclaw_global* glob,
                                       struct fclaw_patch_transform_data* transform_data);
 
 ///@}
-/**
- * DEPRECATED
- * @deprecated NOT USED
- */
-void fclaw_patch_create_user_data(struct fclaw_global* glob,
-                                    struct fclaw_patch* patch);
-
-/**
- * DEPRECATED
- * @deprecated NOT USED
- */
-void fclaw_patch_destroy_user_data(struct fclaw_global* glob,
-                                     struct fclaw_patch* patch);
 
 /* ------------------------------------------------------------------------------------ */
 ///                         @name Transform Functions

--- a/src/fclaw_patch.h
+++ b/src/fclaw_patch.h
@@ -73,17 +73,21 @@ typedef enum
  */
 struct fclaw_patch_data
 {
+    int refine_dim;
+
     /** Pointer to the core patch structure in the domain */
     const fclaw_patch_t *real_patch;
 
     /** Neighbor relation on each face */
-    fclaw_patch_relation_t face_neighbors[4];
+    fclaw_patch_relation_t face_neighbors[6];
+    /** Neighbor relation on each edge */
+    fclaw_patch_relation_t edge_neighbors[12];
     /** Neighbor relation on each corner */
-    fclaw_patch_relation_t corner_neighbors[4];
+    fclaw_patch_relation_t corner_neighbors[8];
     /** True if coner has neighbor */
-    int corners[4];
+    int corners[8];
     /** The number of patches that meet at each corner */
-    int block_corner_count[4];
+    int block_corner_count[8];
     /** True if this patch lies on a coarse-fine interface */
     int on_coarsefine_interface;
     /** True if there are finer neighbors */
@@ -159,16 +163,6 @@ struct fclaw_patch;
 ///                         @name Creating/Deleting Patches
 /* ------------------------------------------------------------------------------------ */
 ///@{
-
-/**
- * DEPRECATED
- * @deprecated NOT USED
- */
-void fclaw_patch_reset_data(struct fclaw_global* glob,
-                              struct fclaw_patch* old_patch,
-                              struct fclaw_patch* new_patch,
-                              int blockno,int old_patchno, int new_patchno);
-
 
 /**
  * @brief Deallocate the user data pointer for a patch

--- a/src/fclaw_patch.h
+++ b/src/fclaw_patch.h
@@ -111,12 +111,26 @@ struct fclaw_patch_data
  */
 struct fclaw_patch_transform_data
 {
+    int dim;
+
     /** Pointer to this patch */
     struct fclaw_patch *this_patch;
+    /** This patch's blockno */
+    int this_blockno;
+    /** This patch's patchno */
+    int this_patchno;
     /** Pointer to the neighbor patch */
     struct fclaw_patch *neighbor_patch;
+    /** Neighbor patch's blockno */
+    int neighbor_blockno;
+    /** Neighbor patch's patchno */
+    int neighbor_patchno;
+    /** Neighbor type */
+    fclaw_patch_relation_t neighbor_type;
     /**
      * @brief Transform array
+     * 
+     * .        For 2D:
      * 
      *          This array holds 9 integers.
      *  [0,2]   The coordinate axis sequence of the origin face,
@@ -132,19 +146,45 @@ struct fclaw_patch_transform_data
      *          [8] & 4: Both patches are in the same block,
      *                   the \a ftransform contents are ignored.
      *  [1,4,7] 0 (unused for compatibility with 3D).ftransform 
+     *
+     * .        For 3D:
+     *
+     *  [0]..[2]    The coordinate axis sequence of the origin face,
+     *              the first two referring to the tangentials and the
+     *              third to the normal.  A permutation of (0, 1, 2).
+     *  [3]..[5]    The coordinate axis sequence of the target face.
+     *  [6]..[8]    Edge reversal flags for tangential axes (boolean);
+     *              face code in [0, 3] for the normal coordinate q:
+     *              0: q' = -q
+     *              1: q' = q + 1
+     *              2: q' = q - 1
+     *              3: q' = 2 - q
+     *
      */
     int transform[9];
-    /** The corner that the neighboring patch is on. */
-    int icorner;
     /**
      * @brief Base index
      * 
      * 1 for cell-centered (1 .. mx); 0 for nodes (0 .. mx)
      */
     int based;
-    /** True if patch is on a block corner */
+    
+    /** The corner that the neighboring patch is on. */
+    int icorner;
+    /** The edge that the neighboring patch is on. */
+    int iedge;
+    /** The face that the neighboring patch is on */
+    int iface;
+
+    /** True if neighbor is across a block corner */
     int is_block_corner;
-    /** -1 for interior faces or block corners */
+    /** True if neighbor is accross a block edge */
+    int is_block_edge;
+    /** True if neighbor is across a block face */
+    int is_block_face;
+    /** -1 for unless neighbor is across a block edge */
+    int block_iedge;   
+    /** -1 for unless neighbor is across a block face */
     int block_iface;   
 
     /** Pointer to the glboal context */

--- a/src/fclaw_patch.h
+++ b/src/fclaw_patch.h
@@ -392,6 +392,64 @@ void fclaw_patch_interpolate_face(struct fclaw_global* glob,
                                     struct fclaw_patch_transform_data* transform_data);
 
 /**
+ * @brief Copies values from a edge-neighboring grid
+ * 
+ * @param[in]     glob the global context
+ * @param[in,out] this_patch this patch context
+ * @param[in]     neighbor_patch the neighbor patch context
+ * @param[in]     this_blockno the block number of this patch
+ * @param[in]     neighbor_blockno the block number of the neighbor patch
+ * @param[in]     is_block_corner true if corner is on the corner of a block
+ * @param[in]     iedge the edge that the neighboring patch is on
+ * @param[in]     time_interp true if ghost filling for time interpolated level (non-global update)
+ * @param[in]     tranform_data the tranform data for the neighbor's coordinate system
+ */
+void fclaw_patch_copy_edge(struct fclaw_global* glob,
+                           struct fclaw_patch *this_patch,
+                           struct fclaw_patch *neighbor_patch,
+                           int this_blockno,
+                           int neighbor_blockno,
+                           int iedge,
+                           int time_interp,
+                           struct fclaw_patch_transform_data *transform_data);
+
+/**
+ * @brief Averages values from a edge-neighboring fine grid
+ * 
+ * @param[in]     glob the global context
+ * @param[in,out] coarse_patch the coarse patch context
+ * @param[in]     fine_patch the fine patch context
+ * @param[in]     iedge_coarse the edge of the coarse patch that the fine patch is on
+ * @param[in]     time_interp true if ghost filling for time interpolated level (non-global update)
+ * @param[in]     tranform_data the tranform data for the neighbor's coordinate system
+ */
+void fclaw_patch_average_edge(struct fclaw_global* glob,
+                              struct fclaw_patch *coarse_patch,
+                              struct fclaw_patch *fine_patch,
+                              int iedge_coarse,
+                              int time_interp,
+                              struct fclaw_patch_transform_data* transform_data);
+
+/**
+ * @brief Interpolates values from a edge-neighboring coarse grid
+ * 
+ * @param[in]     glob the global context
+ * @param[in]     coarse_patch the coarse patch context
+ * @param[in,out] fine_patch the fine patch context
+ * @param[in]     iedge the edge of the coarse patch that the fine patch is on
+ * @param[in]     time_interp true if ghost filling for time interpolated level (non-global update)
+ * @param[in]     tranform_data the tranform data for the neighbor's coordinate system
+ */
+void fclaw_patch_interpolate_edge(struct fclaw_global* glob,
+                                    struct fclaw_patch* coarse_patch,
+                                    struct fclaw_patch* fine_patch,
+                                    int iedge,
+                                    int time_interp,
+                                    struct fclaw_patch_transform_data* transform_data);
+
+
+
+/**
  * @brief Copies values from a corner-neighboring grid
  * 
  * @param[in]     glob the global context
@@ -1037,6 +1095,65 @@ typedef void (*fclaw_patch_interpolate_face_t)(struct fclaw_global* glob,
                                                  *transform_data);
 
 /**
+ * @brief Copies values from a edge-neighboring grid
+ * 
+ * @param[in]     glob the global context
+ * @param[in,out] this_patch this patch context
+ * @param[in]     neighbor_patch the neighbor patch context
+ * @param[in]     this_blockno the block number of this patch
+ * @param[in]     neighbor_blockno the block number of the neighbor patch
+ * @param[in]     iedge the edge that the neighboring patch is on
+ * @param[in]     time_interp true if ghost filling for time interpolated level (non-global update)
+ * @param[in]     tranform_data the tranform data for the neighbor's coordinate system
+ */
+typedef void (*fclaw_patch_copy_edge_t)(struct fclaw_global* glob,
+                                        struct fclaw_patch *this_patch,
+                                        struct fclaw_patch *neighbor_patch,
+                                        int this_blockno,
+                                        int neighbor_blockno,
+                                        int iedge,
+                                        int time_interp,
+                                        struct fclaw_patch_transform_data 
+                                        *transform_data);
+    
+/**
+ * @brief Averages values from a edge-neighboring fine grid
+ * 
+ * @param[in]     glob the global context
+ * @param[in,out] coarse_patch the coarse patch context
+ * @param[in]     fine_patch the fine patch context
+ * @param[in]     icorner the corner of the coarse patch that the fine patch is on
+ * @param[in]     time_interp true if ghost filling for time interpolated level (non-global update)
+ * @param[in]     tranform_data the tranform data for the neighbor's coordinate system
+ */
+typedef void (*fclaw_patch_average_edge_t)(struct fclaw_global* glob,
+                                           struct fclaw_patch *coarse_patch,
+                                           struct fclaw_patch *fine_patch,
+                                           int icorner,
+                                           int time_interp,
+                                           struct fclaw_patch_transform_data 
+                                           *transform_data);
+
+/**
+ * @brief Interpolates values from a edge-neighboring coarse grid
+ * 
+ * @param[in]     glob the global context
+ * @param[in]     coarse_patch the coarse patch context
+ * @param[in,out] fine_patch the fine patch context
+ * @param[in]     iedge the edge of the coarse patch that the fine patch is on
+ * @param[in]     time_interp true if ghost filling for time interpolated level (non-global update)
+ * @param[in]     tranform_data the tranform data for the neighbor's coordinate system
+ */   
+typedef void (*fclaw_patch_interpolate_edge_t)(struct fclaw_global* glob,
+                                               struct fclaw_patch *coarse_patch,
+                                               struct fclaw_patch *fine_patch,
+                                               int iedge,
+                                               int time_interp,
+                                               struct fclaw_patch_transform_data 
+                                               *transform_data);
+ 
+
+/**
  * @brief Copies values from a corner-neighboring grid
  * 
  * @param[in]     glob the global context
@@ -1395,15 +1512,15 @@ struct fclaw_patch_vtable
 {
     /** @{ @name Creating/Deleting/Building */
 
-    /** @copybrief ::fclaw2d_patch_new_t */
+    /** @copybrief ::fclaw_patch_new_t */
     fclaw_patch_new_t                   patch_new;
-    /** @copybrief ::fclaw2d_patch_delete_t */
+    /** @copybrief ::fclaw_patch_delete_t */
     fclaw_patch_delete_t                patch_delete;
-    /** @copybrief ::fclaw2d_patch_build_t */
+    /** @copybrief ::fclaw_patch_build_t */
     fclaw_patch_build_t                 build;
-    /** @copybrief ::fclaw2d_patch_build_from_fine_t */
+    /** @copybrief ::fclaw_patch_build_from_fine_t */
     fclaw_patch_build_from_fine_t       build_from_fine;
-    /** @copybrief ::fclaw2d_patch_setup_t */
+    /** @copybrief ::fclaw_patch_setup_t */
     fclaw_patch_setup_t                 setup;
 
     /** @} */
@@ -1413,57 +1530,57 @@ struct fclaw_patch_vtable
 
     /** @{ @name User Data */
 
-    /** @copybrief ::fclaw2d_patch_create_user_data_t */
+    /** @copybrief ::fclaw_patch_create_user_data_t */
     fclaw_patch_create_user_data_t      create_user_data;
-    /** @copybrief ::fclaw2d_patch_destroy_user_data_t */
+    /** @copybrief ::fclaw_patch_destroy_user_data_t */
     fclaw_patch_destroy_user_data_t     destroy_user_data;
 
     /** @} */
 
     /** @{ @name Solver Functions */
 
-    /** @copybrief ::fclaw2d_patch_initialize_t */
+    /** @copybrief ::fclaw_patch_initialize_t */
     fclaw_patch_initialize_t            initialize;
-    /** @copybrief ::fclaw2d_patch_physical_bc_t */
+    /** @copybrief ::fclaw_patch_physical_bc_t */
     fclaw_patch_physical_bc_t           physical_bc;
-    /** @copybrief ::fclaw2d_patch_single_step_update_t */
+    /** @copybrief ::fclaw_patch_single_step_update_t */
     fclaw_patch_single_step_update_t    single_step_update;
-    /** @copybrief ::fclaw2d_patch_rhs_t */
+    /** @copybrief ::fclaw_patch_rhs_t */
     fclaw_patch_rhs_t                   rhs;
 
     /** @} */
 
     /** @{ @name Time Stepping */
 
-    /** @copybrief ::fclaw2d_patch_restore_step_t */
+    /** @copybrief ::fclaw_patch_restore_step_t */
     fclaw_patch_restore_step_t          restore_step;
-    /** @copybrief ::fclaw2d_patch_save_step_t */
+    /** @copybrief ::fclaw_patch_save_step_t */
     fclaw_patch_save_step_t             save_step;
-    /** @copybrief ::fclaw2d_patch_setup_timeinterp_t */
+    /** @copybrief ::fclaw_patch_setup_timeinterp_t */
     fclaw_patch_setup_timeinterp_t      setup_timeinterp;
 
     /** @} */
 
     /** @{ @name Regridding Functions */
 
-    /** @copybrief ::fclaw2d_patch_tag4refinement_t */
+    /** @copybrief ::fclaw_patch_tag4refinement_t */
     fclaw_patch_tag4refinement_t        tag4refinement;
-    /** @copybrief ::fclaw2d_patch_tag4coarsening_t */
+    /** @copybrief ::fclaw_patch_tag4coarsening_t */
     fclaw_patch_tag4coarsening_t        tag4coarsening;
-    /** @copybrief ::fclaw2d_patch_average2coarse_t */
+    /** @copybrief ::fclaw_patch_average2coarse_t */
     fclaw_patch_average2coarse_t        average2coarse;
-    /** @copybrief ::fclaw2d_patch_interpolate2fine_t */
+    /** @copybrief ::fclaw_patch_interpolate2fine_t */
     fclaw_patch_interpolate2fine_t      interpolate2fine;
 
     /** @} */
 
     /** @{ @name Time Syncing Functions for Conservation */
 
-    /** @copybrief ::fclaw2d_patch_time_sync_f2c_t */
+    /** @copybrief ::fclaw_patch_time_sync_f2c_t */
     fclaw_patch_time_sync_f2c_t         time_sync_f2c;
-    /** @copybrief ::fclaw2d_patch_time_sync_samesize_t */
+    /** @copybrief ::fclaw_patch_time_sync_samesize_t */
     fclaw_patch_time_sync_samesize_t    time_sync_samesize;
-    /** @copybrief ::fclaw2d_patch_time_sync_reset_t */
+    /** @copybrief ::fclaw_patch_time_sync_reset_t */
     fclaw_patch_time_sync_reset_t       time_sync_reset;
 
     /** @} */
@@ -1471,77 +1588,87 @@ struct fclaw_patch_vtable
 
     /** @{ @name Face Ghost Filling Functions */
 
-    /** @copybrief ::fclaw2d_patch_copy_face_t */
+    /** @copybrief ::fclaw_patch_copy_face_t */
     fclaw_patch_copy_face_t             copy_face;
-    /** @copybrief ::fclaw2d_patch_average_face_t */
+    /** @copybrief ::fclaw_patch_average_face_t */
     fclaw_patch_average_face_t          average_face;
-    /** @copybrief ::fclaw2d_patch_interpolate_face_t */
+    /** @copybrief ::fclaw_patch_interpolate_face_t */
     fclaw_patch_interpolate_face_t      interpolate_face;
 
     /** @} */
 
+    /** @{ @name Edge Ghost Filling Functions */
+
+    /** @copybrief ::fclaw_patch_copy_edge_t */
+    fclaw_patch_copy_edge_t              copy_edge;
+    /** @copybrief ::fclaw_patch_average_edge_t */
+    fclaw_patch_average_edge_t           average_edge;
+    /** @copybrief ::fclaw_patch_average_edge_t */
+    fclaw_patch_interpolate_edge_t       interpolate_edge;
+
+    /** @} */
     /** @{ @name Block Face and Interior Corner Ghost Filling Functions */
 
-    /** @copybrief ::fclaw2d_patch_copy_corner_t */
+    /** @copybrief ::fclaw_patch_copy_corner_t */
     fclaw_patch_copy_corner_t           copy_corner;
-    /** @copybrief ::fclaw2d_patch_average_corner_t */
+    /** @copybrief ::fclaw_patch_average_corner_t */
     fclaw_patch_average_corner_t        average_corner;
-    /** @copybrief ::fclaw2d_patch_interpolate_corner_t */
+    /** @copybrief ::fclaw_patch_interpolate_corner_t */
     fclaw_patch_interpolate_corner_t    interpolate_corner;
 
     /** @} */
 
     /** @{ @name Block Corner Ghost Filling Functions */
 
-    /** @copybrief ::fclaw2d_patch_copy_corner_t */
+    /** @copybrief ::fclaw_patch_copy_corner_t */
     fclaw_patch_copy_corner_t           copy_block_corner;
-    /** @copybrief ::fclaw2d_patch_average_corner_t */
+    /** @copybrief ::fclaw_patch_average_corner_t */
     fclaw_patch_average_corner_t        average_block_corner;
-    /** @copybrief ::fclaw2d_patch_interpolate_corner_t */
+    /** @copybrief ::fclaw_patch_interpolate_corner_t */
     fclaw_patch_interpolate_corner_t    interpolate_block_corner;
 
     /** @} */
 
     /** @{ @name Transform Functions */
 
-    /** @copybrief ::fclaw2d_patch_transform_init_data_t */
+    /** @copybrief ::fclaw_patch_transform_init_data_t */
     fclaw_patch_transform_init_data_t        transform_init_data;
-    /** @copybrief ::fclaw2d_patch_transform_blockface_t */
+    /** @copybrief ::fclaw_patch_transform_blockface_t */
     fclaw_patch_transform_blockface_t        transform_face;
-    /** @copybrief ::fclaw2d_patch_transform_blockface_intra_t */
+    /** @copybrief ::fclaw_patch_transform_blockface_intra_t */
     fclaw_patch_transform_blockface_intra_t  transform_face_intra;
 
     /** @} */
 
     /** @{ @name Ghost Packing Functions (for parallel use) */
 
-    /** @copybrief ::fclaw2d_patch_ghost_packsize_t */
+    /** @copybrief ::fclaw_patch_ghost_packsize_t */
     fclaw_patch_ghost_packsize_t        ghost_packsize;
-    /** @copybrief ::fclaw2d_patch_local_ghost_pack_t */
+    /** @copybrief ::fclaw_patch_local_ghost_pack_t */
     fclaw_patch_local_ghost_pack_t      local_ghost_pack;
-    /** @copybrief ::fclaw2d_patch_local_ghost_alloc_t */
+    /** @copybrief ::fclaw_patch_local_ghost_alloc_t */
     fclaw_patch_local_ghost_alloc_t     local_ghost_alloc;
-    /** @copybrief ::fclaw2d_patch_local_ghost_free_t */
+    /** @copybrief ::fclaw_patch_local_ghost_free_t */
     fclaw_patch_local_ghost_free_t      local_ghost_free;
 
-    /** @copybrief ::fclaw2d_patch_remote_ghost_build_t */
+    /** @copybrief ::fclaw_patch_remote_ghost_build_t */
     fclaw_patch_remote_ghost_build_t    remote_ghost_build;
-    /** @copybrief ::fclaw2d_patch_remote_ghost_setup_t */
+    /** @copybrief ::fclaw_patch_remote_ghost_setup_t */
     fclaw_patch_remote_ghost_setup_t    remote_ghost_setup;
-    /** @copybrief ::fclaw2d_patch_remote_ghost_unpack_t */
+    /** @copybrief ::fclaw_patch_remote_ghost_unpack_t */
     fclaw_patch_remote_ghost_unpack_t   remote_ghost_unpack;
-    /** @copybrief ::fclaw2d_patch_remote_ghost_delete_t */
+    /** @copybrief ::fclaw_patch_remote_ghost_delete_t */
     fclaw_patch_remote_ghost_delete_t   remote_ghost_delete;
 
     /** @} */
 
     /** @{ @name Parallel Load Balancing (partitioning) */
 
-    /** @copybrief ::fclaw2d_patch_partition_pack_t */
+    /** @copybrief ::fclaw_patch_partition_pack_t */
     fclaw_patch_partition_pack_t         partition_pack;
-    /** @copybrief ::fclaw2d_patch_partition_unpack_t */
+    /** @copybrief ::fclaw_patch_partition_unpack_t */
     fclaw_patch_partition_unpack_t       partition_unpack;
-    /** @copybrief ::fclaw2d_patch_partition_packsize_t */
+    /** @copybrief ::fclaw_patch_partition_packsize_t */
     fclaw_patch_partition_packsize_t     partition_packsize;
 
     /** @} */
@@ -1711,6 +1838,17 @@ void fclaw_patch_set_face_type(struct fclaw_patch *patch, int iface,
                                  fclaw_patch_relation_t face_type);
 
 /**
+ * @brief Set the edge type for a patch
+ * 
+ * @param patch the patch context
+ * @param iedge the edge
+ * @param edge_type the edge type
+ */
+void fclaw_patch_set_edge_type(fclaw_patch_t *patch,int iedge,
+							   fclaw_patch_relation_t edge_type);
+
+
+/**
  * @brief Set the corner type for a patch
  * 
  * @param patch the patch context
@@ -1733,17 +1871,25 @@ void fclaw_patch_set_missing_corner(struct fclaw_patch *patch, int icorner);
  * 
  * @param patch the patch context
  * @param iface the face
- * @return fclaw2d_patch_relation_t the face type
+ * @return fclaw_patch_relation_t the face type
  */
 fclaw_patch_relation_t fclaw_patch_get_face_type(struct fclaw_patch* patch,
                                                         int iface);
-
+/**
+ * @brief Get the edge type of a patch
+ * 
+ * @param patch the patch context
+ * @param iface the edge
+ * @return fclaw3d_patch_relation_t the edge type
+ */
+fclaw_patch_relation_t fclaw_patch_get_edge_type(fclaw_patch_t* patch,
+												 int iedge);
 /**
  * @brief Get the corner type of a patch
  * 
  * @param patch the patch context
  * @param icorner the corner
- * @return fclaw2d_patch_relation_t the patch relation
+ * @return fclaw_patch_relation_t the patch relation
  */
 fclaw_patch_relation_t fclaw_patch_get_corner_type(struct fclaw_patch* patch,
                                                           int icorner);

--- a/src/fclaw_physical_bc.c
+++ b/src/fclaw_physical_bc.c
@@ -25,8 +25,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <fclaw_physical_bc.h>
 
-#include <fclaw2d_defs.h>
-
 #include <fclaw_domain.h>
 #include <fclaw_global.h>
 #include <fclaw_patch.h>
@@ -55,7 +53,7 @@ void cb_fclaw_physical_set_bc(fclaw_domain_t *domain,
 
     t_info = (fclaw_physical_time_info_t*) s->user;
 
-    int intersects_bc[FCLAW2D_NUMFACES];
+    int intersects_bc[fclaw_domain_num_faces(domain)];
 
     /* Time dt should not be passed in here. If BCs are obtained by 
        evolving an ODE, then we should really evolve the ODE at the same time 
@@ -81,11 +79,11 @@ void fclaw_physical_get_bc(fclaw_global_t *glob,
                              int this_patch_idx,
                              int *intersects_bdry)
 {
-    // const int numfaces = get_faces_per_patch(domain);
-    int bdry[FCLAW2D_NUMFACES];
+    const int num_faces = fclaw_domain_num_faces(glob->domain);
+    int bdry[num_faces]; //overallocate for 3d
     fclaw_patch_boundary_type(glob->domain,this_block_idx,this_patch_idx,bdry);
     int i;
-    for(i = 0; i < FCLAW2D_NUMFACES; i++)
+    for(i = 0; i < num_faces; i++)
     {
         // Physical boundary conditions
         intersects_bdry[i] = bdry[i] == 1;

--- a/src/fclaw_regrid.c
+++ b/src/fclaw_regrid.c
@@ -97,7 +97,7 @@ void cb_regrid_tag4coarsening(fclaw_domain_t *domain,
         if (family_coarsened == 1)
         {
             int igrid;
-            for (igrid = 0; igrid < 4; igrid++)
+            for (igrid = 0; igrid < fclaw_domain_num_siblings(domain); igrid++)
             {
                 int fine_patchno = fine0_patchno + igrid;
                 fclaw_patch_mark_coarsen(domain,blockno, fine_patchno);
@@ -141,7 +141,7 @@ void cb_fclaw_regrid_repopulate(fclaw_domain_t * old_domain,
         fclaw_patch_t *coarse_patch = old_patch;
 
         int i;
-        for (i = 0; i < 4; i++)
+        for (i = 0; i < fclaw_domain_num_siblings(old_domain); i++)
         {
             fclaw_patch_t *fine_patch = &fine_siblings[i];
             int fine_patchno = new_patchno + i;
@@ -211,7 +211,7 @@ void cb_fclaw_regrid_repopulate(fclaw_domain_t * old_domain,
 
         }
         int i;
-        for(i = 0; i < 4; i++)
+        for(i = 0; i < fclaw_domain_num_siblings(old_domain); i++)
         {
             fclaw_patch_t* fine_patch = &fine_siblings[i];
             /* used to pass in old_domain */
@@ -339,13 +339,11 @@ void cb_set_neighbor_types(fclaw_domain_t *domain,
 						   int patchno,
 						   void *user)
 {
-	int iface, icorner;
-
-	for (iface = 0; iface < 4; iface++)
+	for (int iface = 0; iface < fclaw_domain_num_faces(domain); iface++)
 	{
-		int rproc[2];
+		int rproc[4]; //allocate for 3d
 		int rblockno;
-		int rpatchno[2];
+		int rpatchno[4];
 		int rfaceno;
 
 		fclaw_patch_relation_t neighbor_type =
@@ -361,7 +359,28 @@ void cb_set_neighbor_types(fclaw_domain_t *domain,
 		fclaw_patch_set_face_type(this_patch,iface,neighbor_type);
 	}
 
-	for (icorner = 0; icorner < 4; icorner++)
+	for (int iedge = 0; iedge < fclaw_domain_num_edges(domain); iedge++)
+	{
+		int rproc[2];
+		int rblockno;
+		int rpatchno[2];
+		int redgeno;
+
+		fclaw_patch_relation_t neighbor_type;
+		fclaw_patch_edge_neighbors(domain,
+								     blockno,
+								     patchno,
+								     iedge,
+								     rproc,
+								     &rblockno,
+                                     rpatchno,
+								     &redgeno,
+								     &neighbor_type);
+
+		fclaw_patch_set_edge_type(this_patch,iedge,neighbor_type);
+	}
+
+	for (int icorner = 0; icorner < fclaw_domain_num_corners(domain); icorner++)
 	{
 		int rproc_corner;
 		int cornerpatchno;

--- a/src/fclaw_time_sync.c
+++ b/src/fclaw_time_sync.c
@@ -30,6 +30,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <fclaw_patch.h>
 #include <fclaw_options.h>
 #include <fclaw_exchange.h>
+#include <fclaw_face_neighbors.h>
 
 typedef struct fclaw2d_time_sync_info
 {
@@ -95,7 +96,7 @@ void copy_at_blockbdry(fclaw_global_t *glob,
 	e_info.time_interp = 0;
 	e_info.read_parallel_patches = read_parallel_patches;
 
-	fclaw_global_iterate_level(glob, level, cb_face_fill,
+	fclaw_global_iterate_level(glob, level, fclaw_face_fill_cb,
 						 &e_info);    
 }
 
@@ -112,7 +113,7 @@ void fine2coarse(fclaw_global_t *glob,
 	e_info.time_interp = 0;
 	e_info.read_parallel_patches = read_parallel_patches;
 
-	fclaw_global_iterate_level(glob, level, cb_face_fill, &e_info);
+	fclaw_global_iterate_level(glob, level, fclaw_face_fill_cb, &e_info);
 }
 
 static

--- a/src/forestclaw.h
+++ b/src/forestclaw.h
@@ -589,7 +589,8 @@ void fclaw_patch_3d_transform_face2 (fclaw_patch_t * ipatch,
                         then 4 parallel to y axis, then 4 parallel to z.
  * \param [out] rproc   Processor number of neighbor patch.
  * \param [out] rblockno        Neighbor block number.
- * \param [out] rpatchno        Neighbor patch number relative to the block.
+ * \param [out] rpatchno        Neighbor patch number of up to 2 neighbors.
+    `                           The patch number is relative to its block.
  *                              If the neighbor is off-processor, this is not
  *                              a patch number but in [0, num_ghosts_patches[.
  * \param [out] redge           Number of the edge from the other neighbor.

--- a/src/forestclaw2d.c
+++ b/src/forestclaw2d.c
@@ -1052,7 +1052,77 @@ fclaw2d_patch_corner_neighbors (fclaw2d_domain_t * domain,
             *rcorner = cornerno ^ (P4EST_CHILDREN - 1);
         }
     }
+#ifdef P4_TO_P8
+    else if(qid == -1)
+    {
+        /* workaround for hanging edge corners */
+        fclaw3d_block_t *block = &domain->blocks[blockno];
+        fclaw3d_patch_t *patch = &block->patches[patchno];
+        int childid = fclaw3d_patch_childid (patch);
+        int edge;
+        int face;
+        const int* corner_edges = p8est_corner_edges[cornerno];
+        const int* corner_faces = p8est_corner_faces[cornerno];
 
+        switch (childid ^ cornerno)
+        {
+        case 1:
+            edge = corner_edges[0]; /* hanging on edge parallel to x */
+            face = corner_faces[0];
+            break;
+        case 2:
+            edge = corner_edges[1]; /* hanging on edge parallel to y */
+            face = corner_faces[1];
+            break;
+        case 4:
+            edge = corner_edges[2]; /* hanging on edge parallel to z */
+            face = corner_faces[2];
+            break;
+        default:
+            /* 3, 5, 6 is hanging on face; 0 or 7 is not hanging at all */
+            edge = -1;
+        }
+
+        if(edge != -1)
+        {
+            /* traverse across same-size face neighbor */
+            p4est_locidx_t f_qid = mesh->quad_to_quad[P4EST_FACES*local_num+face];
+            int v = mesh->quad_to_face[P4EST_FACES*local_num+face];
+
+            /* In the hanging edge case, the face neighboring quadrant we are trying
+               to traverse will need to be local. If there is ever a partitioning
+               where this isn't the case, then the workaround can't be performed. */
+            if(f_qid >= 0 && f_qid < mesh->local_num_quadrants && v >= 0 && v <= 23)
+            {
+                p4est_locidx_t qte = mesh->quad_to_edge[P8EST_EDGES * f_qid + edge];
+                if (qte >= 0 && qte < mesh->local_num_quadrants + mesh->ghost_num_quadrants)
+                {
+                    /* same size, same tree */
+                    qid = qte;
+                    *rcorner = cornerno ^ (P8EST_CHILDREN - 1);
+                }
+                else if(qte >= 0)
+                {
+                    /* possibly same-size different block */
+                    qte -= mesh->local_num_quadrants + mesh->ghost_num_quadrants;
+                    p4est_locidx_t cstart = fclaw2d_array_index_locidx (mesh->edge_offset, qte);
+                    p4est_locidx_t cend = fclaw2d_array_index_locidx (mesh->edge_offset, qte + 1);
+                    int8_t e = *(int8_t *) sc_array_index_int (mesh->edge_edge, (int) cstart);
+                    if(cstart + 1 == cend && e >= 0 && e <= 24)
+                    {
+                        /* TODO this can be rotated 
+                           check that it is not for now */
+                        FCLAW_ASSERT(((e%12)^3) == edge);
+                        /* same-size different block */
+                        qid = fclaw2d_array_index_locidx (mesh->edge_quad, (int) cstart);
+                        *rcorner = cornerno ^ (P8EST_CHILDREN - 1);
+                    }
+                }
+            }
+        }
+    }
+#endif
+ 
     if (qid < 0)
     {
         /* The value -1 is expected for a corner on the physical boundary */

--- a/src/forestclaw3d.c
+++ b/src/forestclaw3d.c
@@ -53,7 +53,7 @@ fclaw3d_patch_edge_neighbors (fclaw2d_domain_t * domain,
     p4est_ghost_t *ghost = wrap->match_aux ? wrap->ghost_aux : wrap->ghost;
     p4est_mesh_t *mesh = wrap->match_aux ? wrap->mesh_aux : wrap->mesh;
     p4est_locidx_t local_num, qid, qte;
-    p4est_locidx_t edgeid, cstart, cend;
+    p4est_locidx_t cstart, cend;
     const p4est_quadrant_t *q;
     p4est_tree_t *rtree;
     fclaw2d_block_t *block;
@@ -149,7 +149,7 @@ fclaw3d_patch_edge_neighbors (fclaw2d_domain_t * domain,
     /* get rproc and rpatchno for each neighbor */
     for(int i=0; i < num_neighbors; i++)
     {
-        p4est_locidx_t qid = rpatchno[i];
+        qid = rpatchno[i];
         if (qid < mesh->local_num_quadrants)
         {
             /* local quadrant may be in a different tree */

--- a/src/forestclaw3d.c
+++ b/src/forestclaw3d.c
@@ -53,7 +53,7 @@ fclaw3d_patch_edge_neighbors (fclaw2d_domain_t * domain,
     p4est_ghost_t *ghost = wrap->match_aux ? wrap->ghost_aux : wrap->ghost;
     p4est_mesh_t *mesh = wrap->match_aux ? wrap->mesh_aux : wrap->mesh;
     p4est_locidx_t local_num, qid, qte;
-    p4est_locidx_t edgeid, cstart, cend;
+    p4est_locidx_t edge_offset_i, edgeid, cstart, cend;
     const p4est_quadrant_t *q;
     p4est_tree_t *rtree;
     fclaw2d_block_t *block;
@@ -84,7 +84,7 @@ fclaw3d_patch_edge_neighbors (fclaw2d_domain_t * domain,
         {
             /* This is an inter-tree (face or edge) edge neighbor 
                or half/double sized neighbor */
-            p4est_locidx_t edge_offset_i =
+            edge_offset_i =
                 qte - (mesh->local_num_quadrants + mesh->ghost_num_quadrants);
             FCLAW_ASSERT (edge_offset_i < mesh->local_num_edges);
 
@@ -97,6 +97,8 @@ fclaw3d_patch_edge_neighbors (fclaw2d_domain_t * domain,
             if ((edgeid >= 0 && cstart + 1 < cend) || cstart + 2 < cend)
             {
                 /* At least a five-edge, which is currently not supported */
+                *neighbor_size = FCLAW2D_PATCH_BOUNDARY;
+                *redge = -1;
             }
             else
             {

--- a/src/forestclaw3d.c
+++ b/src/forestclaw3d.c
@@ -53,7 +53,7 @@ fclaw3d_patch_edge_neighbors (fclaw2d_domain_t * domain,
     p4est_ghost_t *ghost = wrap->match_aux ? wrap->ghost_aux : wrap->ghost;
     p4est_mesh_t *mesh = wrap->match_aux ? wrap->mesh_aux : wrap->mesh;
     p4est_locidx_t local_num, qid, qte;
-    p4est_locidx_t cstart, cend;
+    p4est_locidx_t edgeid, cstart, cend;
     const p4est_quadrant_t *q;
     p4est_tree_t *rtree;
     fclaw2d_block_t *block;
@@ -92,9 +92,9 @@ fclaw3d_patch_edge_neighbors (fclaw2d_domain_t * domain,
             cend = fclaw2d_array_index_locidx (mesh->edge_offset, edge_offset_i + 1);
 
             /* get value in edge_edge array */
-            int e = *(int8_t *) sc_array_index_int (mesh->edge_edge,
+            edgeid = *(int8_t *) sc_array_index_int (mesh->edge_edge,
                                                     (int) cstart);
-            if ((e >= 0 && cstart + 1 < cend) || cstart + 2 < cend)
+            if ((edgeid >= 0 && cstart + 1 < cend) || cstart + 2 < cend)
             {
                 /* At least a five-edge, which is currently not supported */
             }
@@ -103,28 +103,28 @@ fclaw3d_patch_edge_neighbors (fclaw2d_domain_t * domain,
                 /* at least have one neighbor, get the first neighbor */
                 rpatchno[0] = fclaw2d_array_index_locidx (mesh->edge_quad, cstart);
                 /* decode */
-                if(e < 0)
+                if(edgeid < 0)
                 {
                     /* half sized neighbor */
                     num_neighbors = 2;
                     *neighbor_size = FCLAW2D_PATCH_HALFSIZE;
-                    *redge = (e + 24)%12;
+                    *redge = (edgeid + 24)%12;
                     /* get the second neighbor */
                     rpatchno[1] = fclaw2d_array_index_locidx (mesh->edge_quad, cstart+1);
                 }
-                else if (e > 23)
+                else if (edgeid > 23)
                 {
                     /* double sized neighbor */
                     num_neighbors = 1;
                     *neighbor_size = FCLAW2D_PATCH_DOUBLESIZE;
-                    *redge = (e - 24)%12;
+                    *redge = (edgeid - 24)%12;
                 }
                 else 
                 {
                     /* same sized neighbor inter-tree */
                     num_neighbors = 1;
                     *neighbor_size = FCLAW2D_PATCH_SAMESIZE;
-                    *redge = e%12;
+                    *redge = edgeid%12;
                 }
                 FCLAW_ASSERT (0 <= *redge && *redge < P8EST_EDGES);
             }

--- a/src/forestclaw3d.c
+++ b/src/forestclaw3d.c
@@ -44,7 +44,7 @@ fclaw3d_domain_num_edges (const fclaw3d_domain_t * domain)
 int
 fclaw3d_patch_edge_neighbors (fclaw2d_domain_t * domain,
                               int blockno, int patchno, int edgeno,
-                              int *rproc, int *rblockno, int *rpatchno,
+                              int rproc[2], int *rblockno, int rpatchno[2],
                               int *redge,
                               fclaw2d_patch_relation_t * neighbor_size)
 {

--- a/src/forestclaw3d.c
+++ b/src/forestclaw3d.c
@@ -57,7 +57,7 @@ fclaw3d_patch_edge_neighbors (fclaw2d_domain_t * domain,
     const p4est_quadrant_t *q;
     p4est_tree_t *rtree;
     fclaw2d_block_t *block;
-    int num_neighbors = 0;
+    int i, num_neighbors;
 
     FCLAW_ASSERT (domain->num_ghost_patches ==
                   (int) mesh->ghost_num_quadrants);
@@ -97,6 +97,7 @@ fclaw3d_patch_edge_neighbors (fclaw2d_domain_t * domain,
             if ((edgeid >= 0 && cstart + 1 < cend) || cstart + 2 < cend)
             {
                 /* At least a five-edge, which is currently not supported */
+                num_neighbors = 0;
                 *neighbor_size = FCLAW2D_PATCH_BOUNDARY;
                 *redge = -1;
             }
@@ -144,12 +145,13 @@ fclaw3d_patch_edge_neighbors (fclaw2d_domain_t * domain,
     {
         /* The value -1 is expected for an edge on the physical boundary */
         /* Currently we also return this for five- and more-edges */
+        num_neighbors = 0;
         *neighbor_size = FCLAW2D_PATCH_BOUNDARY;
         *redge = -1;
     }
 
     /* get rproc and rpatchno for each neighbor */
-    for(int i=0; i < num_neighbors; i++)
+    for(i = 0; i < num_neighbors; i++)
     {
         qid = rpatchno[i];
         if (qid < mesh->local_num_quadrants)

--- a/src/forestclaw3d.h
+++ b/src/forestclaw3d.h
@@ -577,7 +577,8 @@ void fclaw3d_patch_transform_face2 (fclaw3d_patch_t * ipatch,
                         then 4 parallel to y axis, then 4 parallel to z.
  * \param [out] rproc   Processor number of neighbor patch.
  * \param [out] rblockno        Neighbor block number.
- * \param [out] rpatchno        Neighbor patch number relative to the block.
+ * \param [out] rpatchno        Neighbor patch number of up to 2 neighbors.
+    `                           The patch number is relative to its block.
  *                              If the neighbor is off-processor, this is not
  *                              a patch number but in [0, num_ghosts_patches[.
  * \param [out] redge           Number of the edge from the other neighbor.
@@ -587,7 +588,7 @@ void fclaw3d_patch_transform_face2 (fclaw3d_patch_t * ipatch,
  */
 int fclaw3d_patch_edge_neighbors (fclaw3d_domain_t * domain,
                                   int blockno, int patchno, int edgeno,
-                                  int *rproc, int *rblockno, int *rpatchno,
+                                  int rproc[2], int *rblockno, int rpatchno[2],
                                   int *redge,
                                   fclaw3d_patch_relation_t * neighbor_size);
 


### PR DESCRIPTION
These are the changes needed in the main ForestClaw library. Most of the changes are relatively minor (like changing loops to loop over all siblings depending on the refinement dimension). This adds edge function to `fclaw_patch.c` and adds `fclaw_edge_neighbors.c`. The changes needed in fclaw_face_neighbors.c  are minor, but `fclaw_corner_neighbors.c` needed some rework. This depends on #308.