### PR TITLE
Fix Edge Neighbors

### DIFF
--- a/src/forestclaw3d.c
+++ b/src/forestclaw3d.c
@@ -53,7 +53,7 @@ fclaw3d_patch_edge_neighbors (fclaw2d_domain_t * domain,
     p4est_ghost_t *ghost = wrap->match_aux ? wrap->ghost_aux : wrap->ghost;
     p4est_mesh_t *mesh = wrap->match_aux ? wrap->mesh_aux : wrap->mesh;
     p4est_locidx_t local_num, qid, qte;
-    p4est_locidx_t edgeid, cstart, cend;
+    p4est_locidx_t cstart, cend;
     const p4est_quadrant_t *q;
     p4est_tree_t *rtree;
     fclaw2d_block_t *block;
@@ -149,7 +149,7 @@ fclaw3d_patch_edge_neighbors (fclaw2d_domain_t * domain,
     /* get rproc and rpatchno for each neighbor */
     for(int i=0; i < num_neighbors; i++)
     {
-        p4est_locidx_t qid = rpatchno[i];
+        qid = rpatchno[i];
         if (qid < mesh->local_num_quadrants)
         {
             /* local quadrant may be in a different tree */

--- a/src/forestclaw3d.c
+++ b/src/forestclaw3d.c
@@ -53,7 +53,7 @@ fclaw3d_patch_edge_neighbors (fclaw2d_domain_t * domain,
     p4est_ghost_t *ghost = wrap->match_aux ? wrap->ghost_aux : wrap->ghost;
     p4est_mesh_t *mesh = wrap->match_aux ? wrap->mesh_aux : wrap->mesh;
     p4est_locidx_t local_num, qid, qte;
-    p4est_locidx_t edgeid, cstart, cend;
+    p4est_locidx_t edge_offset_i, edgeid, cstart, cend;
     const p4est_quadrant_t *q;
     p4est_tree_t *rtree;
     fclaw2d_block_t *block;
@@ -84,7 +84,7 @@ fclaw3d_patch_edge_neighbors (fclaw2d_domain_t * domain,
         {
             /* This is an inter-tree (face or edge) edge neighbor 
                or half/double sized neighbor */
-            p4est_locidx_t edge_offset_i =
+            edge_offset_i =
                 qte - (mesh->local_num_quadrants + mesh->ghost_num_quadrants);
             FCLAW_ASSERT (edge_offset_i < mesh->local_num_edges);
 
@@ -97,6 +97,8 @@ fclaw3d_patch_edge_neighbors (fclaw2d_domain_t * domain,
             if ((edgeid >= 0 && cstart + 1 < cend) || cstart + 2 < cend)
             {
                 /* At least a five-edge, which is currently not supported */
+                *neighbor_size = FCLAW2D_PATCH_BOUNDARY;
+                *redge = -1;
             }
             else
             {

--- a/src/forestclaw3d.c
+++ b/src/forestclaw3d.c
@@ -53,7 +53,7 @@ fclaw3d_patch_edge_neighbors (fclaw2d_domain_t * domain,
     p4est_ghost_t *ghost = wrap->match_aux ? wrap->ghost_aux : wrap->ghost;
     p4est_mesh_t *mesh = wrap->match_aux ? wrap->mesh_aux : wrap->mesh;
     p4est_locidx_t local_num, qid, qte;
-    p4est_locidx_t cstart, cend;
+    p4est_locidx_t edgeid, cstart, cend;
     const p4est_quadrant_t *q;
     p4est_tree_t *rtree;
     fclaw2d_block_t *block;
@@ -92,9 +92,9 @@ fclaw3d_patch_edge_neighbors (fclaw2d_domain_t * domain,
             cend = fclaw2d_array_index_locidx (mesh->edge_offset, edge_offset_i + 1);
 
             /* get value in edge_edge array */
-            int e = *(int8_t *) sc_array_index_int (mesh->edge_edge,
+            edgeid = *(int8_t *) sc_array_index_int (mesh->edge_edge,
                                                     (int) cstart);
-            if ((e >= 0 && cstart + 1 < cend) || cstart + 2 < cend)
+            if ((edgeid >= 0 && cstart + 1 < cend) || cstart + 2 < cend)
             {
                 /* At least a five-edge, which is currently not supported */
             }
@@ -103,28 +103,28 @@ fclaw3d_patch_edge_neighbors (fclaw2d_domain_t * domain,
                 /* at least have one neighbor, get the first neighbor */
                 rpatchno[0] = fclaw2d_array_index_locidx (mesh->edge_quad, cstart);
                 /* decode */
-                if(e < 0)
+                if(edgeid < 0)
                 {
                     /* half sized neighbor */
                     num_neighbors = 2;
                     *neighbor_size = FCLAW2D_PATCH_HALFSIZE;
-                    *redge = (e + 24)%12;
+                    *redge = (edgeid + 24)%12;
                     /* get the second neighbor */
                     rpatchno[1] = fclaw2d_array_index_locidx (mesh->edge_quad, cstart+1);
                 }
-                else if (e > 23)
+                else if (edgeid > 23)
                 {
                     /* double sized neighbor */
                     num_neighbors = 1;
                     *neighbor_size = FCLAW2D_PATCH_DOUBLESIZE;
-                    *redge = (e - 24)%12;
+                    *redge = (edgeid - 24)%12;
                 }
                 else 
                 {
                     /* same sized neighbor inter-tree */
                     num_neighbors = 1;
                     *neighbor_size = FCLAW2D_PATCH_SAMESIZE;
-                    *redge = e%12;
+                    *redge = edgeid%12;
                 }
                 FCLAW_ASSERT (0 <= *redge && *redge < P8EST_EDGES);
             }

--- a/src/forestclaw3d.c
+++ b/src/forestclaw3d.c
@@ -44,7 +44,7 @@ fclaw3d_domain_num_edges (const fclaw3d_domain_t * domain)
 int
 fclaw3d_patch_edge_neighbors (fclaw2d_domain_t * domain,
                               int blockno, int patchno, int edgeno,
-                              int *rproc, int *rblockno, int *rpatchno,
+                              int rproc[2], int *rblockno, int rpatchno[2],
                               int *redge,
                               fclaw2d_patch_relation_t * neighbor_size)
 {

--- a/src/forestclaw3d.c
+++ b/src/forestclaw3d.c
@@ -57,7 +57,7 @@ fclaw3d_patch_edge_neighbors (fclaw2d_domain_t * domain,
     const p4est_quadrant_t *q;
     p4est_tree_t *rtree;
     fclaw2d_block_t *block;
-    int num_neighbors = 0;
+    int i, num_neighbors;
 
     FCLAW_ASSERT (domain->num_ghost_patches ==
                   (int) mesh->ghost_num_quadrants);
@@ -97,6 +97,7 @@ fclaw3d_patch_edge_neighbors (fclaw2d_domain_t * domain,
             if ((edgeid >= 0 && cstart + 1 < cend) || cstart + 2 < cend)
             {
                 /* At least a five-edge, which is currently not supported */
+                num_neighbors = 0;
                 *neighbor_size = FCLAW2D_PATCH_BOUNDARY;
                 *redge = -1;
             }
@@ -144,12 +145,13 @@ fclaw3d_patch_edge_neighbors (fclaw2d_domain_t * domain,
     {
         /* The value -1 is expected for an edge on the physical boundary */
         /* Currently we also return this for five- and more-edges */
+        num_neighbors = 0;
         *neighbor_size = FCLAW2D_PATCH_BOUNDARY;
         *redge = -1;
     }
 
     /* get rproc and rpatchno for each neighbor */
-    for(int i=0; i < num_neighbors; i++)
+    for(i = 0; i < num_neighbors; i++)
     {
         qid = rpatchno[i];
         if (qid < mesh->local_num_quadrants)

--- a/src/forestclaw3d.h
+++ b/src/forestclaw3d.h
@@ -577,7 +577,8 @@ void fclaw3d_patch_transform_face2 (fclaw3d_patch_t * ipatch,
                         then 4 parallel to y axis, then 4 parallel to z.
  * \param [out] rproc   Processor number of neighbor patch.
  * \param [out] rblockno        Neighbor block number.
- * \param [out] rpatchno        Neighbor patch number relative to the block.
+ * \param [out] rpatchno        Neighbor patch number of up to 2 neighbors.
+    `                           The patch number is relative to its block.
  *                              If the neighbor is off-processor, this is not
  *                              a patch number but in [0, num_ghosts_patches[.
  * \param [out] redge           Number of the edge from the other neighbor.
@@ -587,7 +588,7 @@ void fclaw3d_patch_transform_face2 (fclaw3d_patch_t * ipatch,
  */
 int fclaw3d_patch_edge_neighbors (fclaw3d_domain_t * domain,
                                   int blockno, int patchno, int edgeno,
-                                  int *rproc, int *rblockno, int *rpatchno,
+                                  int rproc[2], int *rblockno, int rpatchno[2],
                                   int *redge,
                                   fclaw3d_patch_relation_t * neighbor_size);
 


### PR DESCRIPTION
This is a fix needed for 3D to work. `fclaw3d_patch_edge_neighbors` needs to be updated to handle the cases of finer/coarser neighbors.