### PR TITLE
Feature partition for coarsening

### DIFF
--- a/src/fclaw2d_to_3d.h
+++ b/src/fclaw2d_to_3d.h
@@ -162,6 +162,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define fclaw2d_patch_transform_corner  fclaw3d_patch_transform_corner
 #define fclaw2d_patch_transform_corner2 fclaw3d_patch_transform_corner2
 #define fclaw2d_domain_set_refinement   fclaw3d_domain_set_refinement
+#define fclaw2d_domain_set_partitioning fclaw3d_domain_set_partitioning
 #define fclaw2d_patch_mark_refine       fclaw3d_patch_mark_refine
 #define fclaw2d_patch_mark_coarsen      fclaw3d_patch_mark_coarsen
 #define fclaw2d_domain_iterate_adapted  fclaw3d_domain_iterate_adapted

--- a/src/forestclaw2d.c
+++ b/src/forestclaw2d.c
@@ -1397,6 +1397,15 @@ fclaw2d_domain_set_refinement (fclaw2d_domain_t * domain,
 }
 
 void
+fclaw2d_domain_set_partitioning (fclaw2d_domain_t * domain,
+                                 int partition_for_coarsening)
+{
+    p4est_wrap_t *wrap = (p4est_wrap_t *) domain->pp;
+
+    p4est_wrap_set_partitioning (wrap, partition_for_coarsening);
+}
+
+void
 fclaw2d_patch_mark_refine (fclaw2d_domain_t * domain, int blockno,
                            int patchno)
 {

--- a/src/forestclaw2d.h
+++ b/src/forestclaw2d.h
@@ -667,6 +667,18 @@ void fclaw2d_domain_set_refinement (fclaw2d_domain_t * domain,
                                     int smooth_refine, int smooth_level,
                                     int coarsen_delay);
 
+/** Set parameters of partitioning strategy in a domain.
+ * This function only needs to be called once, and only for the first domain
+ * created in the program.  The values of the parameters are automatically
+ * transferred on adaptation and partitioning.
+ * \param [in,out] domain       This domain's partitioning strategy is set.
+ * \param [in] partition_for_coarsening Boolean:  If true, all future partitions
+ *                              of the domain allow one level of coarsening.
+ *                              Suggested default: 1.
+ */
+void fclaw2d_domain_set_partitioning (fclaw2d_domain_t * domain,
+                                      int partition_for_coarsening);
+
 /** Mark a patch for refinement.
  * This must ONLY be called for local patches.
  * It is safe to call this function from an iterator callback except

--- a/src/forestclaw3d.h
+++ b/src/forestclaw3d.h
@@ -790,6 +790,18 @@ void fclaw3d_domain_set_refinement (fclaw3d_domain_t * domain,
                                     int smooth_refine, int smooth_level,
                                     int coarsen_delay);
 
+/** Set parameters of partitioning strategy in a domain.
+ * This function only needs to be called once, and only for the first domain
+ * created in the program.  The values of the parameters are automatically
+ * transferred on adaptation and partitioning.
+ * \param [in,out] domain       This domain's partitioning strategy is set.
+ * \param [in] partition_for_coarsening Boolean:  If true, all future partitions
+ *                              of the domain allow one level of coarsening.
+ *                              Suggested default: 1.
+ */
+void fclaw3d_domain_set_partitioning (fclaw3d_domain_t * domain,
+                                      int partition_for_coarsening);
+
 /** Mark a patch for refinement.
  * This must ONLY be called for local patches.
  * It is safe to call this function from an iterator callback except


### PR DESCRIPTION
This adds the function `domain_set_partitioning` which sets the `partition_for_coarsening` parameter. If set to 0, future partitions of the domain do not allow for one level of coarsening anymore, but have a more even load distribution.