### PR TITLE
Add partition-for-coarsening option to fclaw_options

### DIFF
--- a/src/fclaw_initialize.c
+++ b/src/fclaw_initialize.c
@@ -80,6 +80,9 @@ void fclaw_initialize(fclaw_global_t *glob)
     int time_interp = 0;
     const fclaw_options_t *fclaw_opt = fclaw_get_options(glob);
 
+    /* set partitioning */
+    fclaw_domain_set_partitioning(*domain,  fclaw_opt->partition_for_coarsening);
+
 	/* This mapping context is needed by fortran mapping functions */
 	fclaw_map_context_t *cont = glob->cont;
 	FCLAW_MAP_SET_CONTEXT(&cont);

--- a/src/fclaw_options.c
+++ b/src/fclaw_options.c
@@ -218,6 +218,10 @@ fclaw_register (fclaw_options_t* fclaw_opt, sc_options_t * opt)
                            &fclaw_opt->refine_threshold,
                            0.5, "Refinement threshold [0.5]");
 
+    sc_options_add_bool(opt, 0, "partition-for-coarsening",
+                        &fclaw_opt->partition_for_coarsening, 1,
+                        "Partition for coarsening [T]");
+
     sc_options_add_double (opt, 0, "coarsen_threshold", 
                            &fclaw_opt->coarsen_threshold,
                            0.1, "Coarsening threshold [0.1]");

--- a/src/fclaw_options.h
+++ b/src/fclaw_options.h
@@ -150,6 +150,7 @@ struct fclaw_options
     int smooth_refine;
     int smooth_level;
     double refine_threshold;
+    int partition_for_coarsening; /**< True if domain will be partitioned for coarsening */
 
     /* Conservation */
     int time_sync;

--- a/src/forestclaw.c
+++ b/src/forestclaw.c
@@ -698,6 +698,23 @@ fclaw_domain_set_refinement (fclaw_domain_t * domain,
 }
 
 void
+fclaw_domain_set_partitioning(fclaw_domain_t *domain, int partition_for_coarsening)
+{
+    if(domain->refine_dim == 2)
+    {
+        fclaw2d_domain_set_partitioning(domain->d2,partition_for_coarsening);
+    }
+    else if (domain->refine_dim == 3)
+    {
+        fclaw3d_domain_set_partitioning(domain->d3,partition_for_coarsening);
+    }
+    else
+    {
+        SC_ABORT_NOT_REACHED();
+    }
+}
+
+void
 fclaw_patch_mark_refine(fclaw_domain_t *domain, int blockno, int patchno)
 {
     if(domain->refine_dim == 2)

--- a/src/forestclaw.h
+++ b/src/forestclaw.h
@@ -855,6 +855,18 @@ void fclaw_domain_set_refinement (fclaw_domain_t * domain,
                                   int smooth_refine, int smooth_level,
                                   int coarsen_delay);
 
+/** Set parameters of partitioning strategy in a domain.
+ * This function only needs to be called once, and only for the first domain
+ * created in the program.  The values of the parameters are automatically
+ * transferred on adaptation and partitioning.
+ * \param [in,out] domain       This domain's partitioning strategy is set.
+ * \param [in] partition_for_coarsening Boolean:  If true, all future partitions
+ *                              of the domain allow one level of coarsening.
+ *                              Suggested default: 1.
+ */
+void fclaw_domain_set_partitioning (fclaw_domain_t * domain,
+                                    int partition_for_coarsening);
+
 /** Mark a patch for refinement.
  * This must ONLY be called for local patches.
  * It is safe to call this function from an iterator callback except


### PR DESCRIPTION
Adds a partition-for-coarsening option to fclaw_options. This option get used in fclaw_initialize on the initial domain.