### PR TITLE
update glob constructor in tests

### DIFF
--- a/src/fclaw_diagnostics.h.TEST.cpp
+++ b/src/fclaw_diagnostics.h.TEST.cpp
@@ -29,8 +29,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 TEST_CASE("fclaw_diagnostics_vtable_initialize stores two seperate vtables in two seperate globs")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_diagnostics_vtable_initialize(glob1);
 	fclaw_diagnostics_vtable_initialize(glob2);
@@ -43,7 +43,7 @@ TEST_CASE("fclaw_diagnostics_vtable_initialize stores two seperate vtables in tw
 
 TEST_CASE("fclaw_diagnostics_vtable_initialize sets is_set flag")
 {
-	fclaw_global_t* glob = fclaw_global_new();
+	fclaw_global_t* glob = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_diagnostics_vtable_initialize(glob);
 
@@ -56,8 +56,8 @@ TEST_CASE("fclaw_diagnostics_vtable_initialize sets is_set flag")
 
 TEST_CASE("fclaw_diagnostics_vtable_initialize fails if called twice on a glob")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_diagnostics_vtable_initialize(glob1);
 	CHECK_SC_ABORTED(fclaw_diagnostics_vtable_initialize(glob1));

--- a/src/fclaw_elliptic_solver.h.TEST.cpp
+++ b/src/fclaw_elliptic_solver.h.TEST.cpp
@@ -29,8 +29,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 TEST_CASE("fclaw_elliptic_vtable_initialize stores two seperate vtables in two seperate globs")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_elliptic_vtable_initialize(glob1);
 	fclaw_elliptic_vtable_initialize(glob2);
@@ -43,7 +43,7 @@ TEST_CASE("fclaw_elliptic_vtable_initialize stores two seperate vtables in two s
 
 TEST_CASE("fclaw_elliptic_vtable_initialize sets is_set flag")
 {
-	fclaw_global_t* glob = fclaw_global_new();
+	fclaw_global_t* glob = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_elliptic_vtable_initialize(glob);
 
@@ -56,8 +56,8 @@ TEST_CASE("fclaw_elliptic_vtable_initialize sets is_set flag")
 
 TEST_CASE("fclaw_elliptic_vtable_initialize fails if called twice on a glob")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_elliptic_vtable_initialize(glob1);
 	CHECK_SC_ABORTED(fclaw_elliptic_vtable_initialize(glob1));

--- a/src/fclaw_gauges.h.TEST.cpp
+++ b/src/fclaw_gauges.h.TEST.cpp
@@ -30,8 +30,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 TEST_CASE("fclaw_gauges_vtable_initialize stores two seperate vtables in two seperate globs")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_diagnostics_vtable_initialize(glob1);
 	fclaw_gauges_vtable_initialize(glob1);
@@ -47,7 +47,7 @@ TEST_CASE("fclaw_gauges_vtable_initialize stores two seperate vtables in two sep
 
 TEST_CASE("fclaw_gauges_vtable_initialize sets is_set flag")
 {
-	fclaw_global_t* glob = fclaw_global_new();
+	fclaw_global_t* glob = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_diagnostics_vtable_initialize(glob);
 	fclaw_gauges_vtable_initialize(glob);
@@ -61,8 +61,8 @@ TEST_CASE("fclaw_gauges_vtable_initialize sets is_set flag")
 
 TEST_CASE("fclaw_guages_vtable_initialize fails if called twice on a glob")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_diagnostics_vtable_initialize(glob1);
 	fclaw_gauges_vtable_initialize(glob1);

--- a/src/fclaw_global.h.TEST.cpp
+++ b/src/fclaw_global.h.TEST.cpp
@@ -40,7 +40,7 @@ TEST_CASE("fclaw2d_global_pack with no options")
 	for(double curr_dt : {1.0, 1.2})
 	{
 		fclaw_global_t* glob1;
-    	glob1 = fclaw_global_new();
+    	glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);
 		glob1->curr_time                    = curr_time;
 		glob1->curr_dt                      = curr_dt;
 
@@ -141,7 +141,7 @@ TEST_CASE("fclaw_global_pack with no options structure")
 	for(double curr_dt : {1.0, 1.2})
 	{
 		fclaw_global_t* glob1;
-    	glob1 = fclaw_global_new();
+    	glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 		glob1->curr_time                    = curr_time;
 		glob1->curr_dt                      = curr_dt;
 
@@ -180,7 +180,7 @@ TEST_CASE("fclaw_global_pack with a single options structure")
 		int argc = 1;
 		//fclaw_app_t* app = fclaw_app_new_on_comm(sc_MPI_COMM_WORLD,&argc,&argv,NULL);
 		fclaw_global_t* glob1;
-    	glob1 = fclaw_global_new();
+    	glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);
 		glob1->curr_time                    = curr_time;
 		glob1->curr_dt                      = curr_dt;
 
@@ -226,7 +226,7 @@ TEST_CASE("fclaw_global_pack with two options structure")
 	for(double curr_dt : {1.0, 1.2})
 	{
 		fclaw_global_t* glob1;
-    	glob1 = fclaw_global_new();
+    	glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);
 		glob1->curr_time                    = curr_time;
 		glob1->curr_dt                      = curr_dt;
 
@@ -274,7 +274,7 @@ TEST_CASE("fclaw_global_pack with two options structure")
 TEST_CASE("fclaw_global_pack aborts with unregistered vtable")
 {
 	fclaw_global_t* glob1;
-   	glob1 = fclaw_global_new();
+   	glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	glob1->curr_time                    = 100;
 	glob1->curr_dt                      = 200;
 
@@ -287,7 +287,7 @@ TEST_CASE("fclaw_global_pack aborts with unregistered vtable")
 TEST_CASE("fclaw2d_global_packsize aborts with unregistered vtable")
 {
 	fclaw_global_t* glob1;
-   	glob1 = fclaw_global_new();
+   	glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	glob1->curr_time                    = 100;
 	glob1->curr_dt                      = 200;
 
@@ -299,7 +299,7 @@ TEST_CASE("fclaw2d_global_packsize aborts with unregistered vtable")
 TEST_CASE("fclaw_global_unppack aborts with unregistered vtable")
 {
 	fclaw_global_t* glob1;
-   	glob1 = fclaw_global_new();
+   	glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	glob1->curr_time                    = 1;
 	glob1->curr_dt                      = 1;
 
@@ -321,7 +321,7 @@ TEST_CASE("fclaw_global_unppack aborts with unregistered vtable")
 	CHECK_SC_ABORTED(fclaw2d_global_unpack(buffer, &glob2));
 }
 TEST_CASE("fclaw_global_options_store and fclaw_global_get_options test") {
-    fclaw_global_t* glob = fclaw_global_new();
+    fclaw_global_t* glob = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
     // Test with an integer
     int option1 = 10;

--- a/src/fclaw_options.h.TEST.cpp
+++ b/src/fclaw_options.h.TEST.cpp
@@ -33,8 +33,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 TEST_CASE("fclaw_options can store options in two seperate globs")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_options_t* opts1 = FCLAW_ALLOC_ZERO(fclaw_options_t,1);
 	fclaw_options_t* opts2 = FCLAW_ALLOC_ZERO(fclaw_options_t,1);
@@ -54,8 +54,8 @@ TEST_CASE("fclaw_options can store options in two seperate globs")
 
 TEST_CASE("fclaw_get_options fails if not intialized")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	CHECK_SC_ABORTED(fclaw_get_options(glob1));
 
@@ -67,8 +67,8 @@ TEST_CASE("fclaw_get_options fails if not intialized")
 
 TEST_CASE("fclaw_options_store fails if called twice on a glob")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_options_store(glob1, FCLAW_ALLOC_ZERO(fclaw_options_t,1));
 	CHECK_SC_ABORTED(fclaw_options_store(glob1, FCLAW_ALLOC_ZERO(fclaw_options_t,1)));

--- a/src/fclaw_patch.h.TEST.cpp
+++ b/src/fclaw_patch.h.TEST.cpp
@@ -29,8 +29,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 TEST_CASE("fclaw_patch_vtable_initialize stores two seperate vtables in two seperate globs")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_patch_vtable_initialize(glob1);
 	fclaw_patch_vtable_initialize(glob2);
@@ -43,7 +43,7 @@ TEST_CASE("fclaw_patch_vtable_initialize stores two seperate vtables in two sepe
 
 TEST_CASE("fclaw_patch_vtable_initialize sets is_set flag")
 {
-	fclaw_global_t* glob = fclaw_global_new();
+	fclaw_global_t* glob = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_patch_vtable_initialize(glob);
 
@@ -56,8 +56,8 @@ TEST_CASE("fclaw_patch_vtable_initialize sets is_set flag")
 
 TEST_CASE("fclaw_patch_vtable_initialize fails if called twice on a glob")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_patch_vtable_initialize(glob1);
 	CHECK_SC_ABORTED(fclaw_patch_vtable_initialize(glob1));

--- a/src/fclaw_vtable.h.TEST.cpp
+++ b/src/fclaw_vtable.h.TEST.cpp
@@ -29,8 +29,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 TEST_CASE("fclaw_vtable_initialize stores two seperate vtables in two seperate globs")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_vtable_initialize(glob1);
 	fclaw_vtable_initialize(glob2);
@@ -43,7 +43,7 @@ TEST_CASE("fclaw_vtable_initialize stores two seperate vtables in two seperate g
 
 TEST_CASE("fclaw_vtable_initialize sets is_set flag")
 {
-	fclaw_global_t* glob = fclaw_global_new();
+	fclaw_global_t* glob = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_vtable_initialize(glob);
 
@@ -56,8 +56,8 @@ TEST_CASE("fclaw_vtable_initialize sets is_set flag")
 
 TEST_CASE("fclaw_vtable_initialize fails if called twice on a glob")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_vtable_initialize(glob1);
 	CHECK_SC_ABORTED(fclaw_vtable_initialize(glob1));

--- a/src/patches/clawpatch/fclaw2d_clawpatch_fort.h.TEST.cpp
+++ b/src/patches/clawpatch/fclaw2d_clawpatch_fort.h.TEST.cpp
@@ -64,7 +64,7 @@ TEST_CASE("FCLAW2D_CLAWPATCH_EXCEEDS_THRESHOLD calls user function")
     exceeds_test_parameters& params = global_exceeds_test_parameters;
 
     fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 1);
-	fclaw_global_t* glob = fclaw_global_new();
+	fclaw_global_t* glob = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
     fclaw_global_store_domain(glob, domain);
 
     fclaw_clawpatch_options_t* clawpatch_opts = fclaw_clawpatch_options_new(2);
@@ -136,7 +136,7 @@ TEST_CASE("FCLAW3DX_CLAWPATCH_EXCEEDS_THRESHOLD calls user function")
     exceeds_test_parameters& params = global_exceeds_test_parameters;
 
     fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 1);
-	fclaw_global_t* glob = fclaw_global_new();
+	fclaw_global_t* glob = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
     fclaw_global_store_domain(glob, domain);
 
 	fclaw_clawpatch_options_t* opts = fclaw_clawpatch_options_new(3);

--- a/src/patches/clawpatch/fclaw_clawpatch.h.2d.TEST.cpp
+++ b/src/patches/clawpatch/fclaw_clawpatch.h.2d.TEST.cpp
@@ -33,9 +33,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 TEST_CASE("2d fclaw_clawpatch_vtable_initialize stores two separate vtables in two separate globs")
 {
 	fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 1);
-	fclaw_global_t* glob1 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_store_domain(glob1, domain);
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_store_domain(glob2, domain);
 
 	fclaw_clawpatch_options_t* opts = fclaw_clawpatch_options_new(2);
@@ -59,9 +59,9 @@ TEST_CASE("2d fclaw_clawpatch_vtable_initialize stores two separate vtables in t
 TEST_CASE("3dx fclaw_clawpatch_vtable_initialize stores two separate vtables in two separate globs")
 {
 	fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 1);
-	fclaw_global_t* glob1 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_store_domain(glob1, domain);
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_store_domain(glob2, domain);
 
 	fclaw_clawpatch_options_t* opts = fclaw_clawpatch_options_new(3);
@@ -85,7 +85,7 @@ TEST_CASE("3dx fclaw_clawpatch_vtable_initialize stores two separate vtables in 
 TEST_CASE("2d fclaw_clawpatch_vtable_initialize sets is_set flag")
 {
 	fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 1);
-	fclaw_global_t* glob = fclaw_global_new();
+	fclaw_global_t* glob = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_store_domain(glob, domain);
 
 	fclaw_clawpatch_options_t* opts = fclaw_clawpatch_options_new(2);
@@ -105,7 +105,7 @@ TEST_CASE("2d fclaw_clawpatch_vtable_initialize sets is_set flag")
 TEST_CASE("3dx fclaw_clawpatch_vtable_initialize sets is_set flag")
 {
 	fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 1);
-	fclaw_global_t* glob = fclaw_global_new();
+	fclaw_global_t* glob = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_store_domain(glob, domain);
 
 	fclaw_clawpatch_options_t* opts = fclaw_clawpatch_options_new(3);
@@ -127,9 +127,9 @@ TEST_CASE("3dx fclaw_clawpatch_vtable_initialize sets is_set flag")
 TEST_CASE("2d fclaw_clawpatch_vtable_initialize fails if called twice on a glob")
 {
 	fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 1);
-	fclaw_global_t* glob1 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_store_domain(glob1, domain);
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_store_domain(glob2, domain);
 
 	fclaw_clawpatch_options_t* opts = fclaw_clawpatch_options_new(2);
@@ -153,9 +153,9 @@ TEST_CASE("2d fclaw_clawpatch_vtable_initialize fails if called twice on a glob"
 TEST_CASE("3dx fclaw_clawpatch_vtable_initialize fails if called twice on a glob")
 {
 	fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 1);
-	fclaw_global_t* glob1 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_store_domain(glob1, domain);
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_store_domain(glob2, domain);
 
 	fclaw_clawpatch_options_t* opts = fclaw_clawpatch_options_new(3);

--- a/src/patches/clawpatch/fclaw_clawpatch.h.3d.TEST.cpp
+++ b/src/patches/clawpatch/fclaw_clawpatch.h.3d.TEST.cpp
@@ -68,7 +68,7 @@ struct SinglePatchDomain {
     fclaw_clawpatch_options_t* opts;
 
     SinglePatchDomain(){
-        glob = fclaw_global_new();
+        glob = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
         opts = fclaw_clawpatch_options_new(3);
         memset(&fopts, 0, sizeof(fopts));
         fopts.mi=1;
@@ -119,7 +119,7 @@ struct OctDomain {
     fclaw_clawpatch_options_t* opts;
 
     OctDomain(){
-        glob = fclaw_global_new();
+        glob = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
         opts = fclaw_clawpatch_options_new(3);
         memset(&fopts, 0, sizeof(fopts));
         fopts.mi=1;
@@ -176,7 +176,7 @@ struct OctDomain {
 TEST_CASE("3d fclaw_clawpatch_vtable_initialize")
 {
 	fclaw_domain_t* domain = fclaw_domain_new_unitcube(sc_MPI_COMM_WORLD, 1);
-    fclaw_global_t* glob = fclaw_global_new();
+    fclaw_global_t* glob = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_store_domain(glob, domain);
 
     fclaw_clawpatch_options_t* opts = fclaw_clawpatch_options_new(3);
@@ -259,7 +259,7 @@ TEST_CASE("3d fclaw_clawpatch patch_build")
     for(const int& rhs_fields : {0,2})
     for(fclaw_build_mode_t build_mode : {FCLAW_BUILD_FOR_GHOST_AREA_COMPUTED, FCLAW_BUILD_FOR_UPDATE})
     {
-        fclaw_global_t* glob = fclaw_global_new();
+        fclaw_global_t* glob = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
         fclaw_options_t fopts;
         memset(&fopts, 0, sizeof(fopts));
@@ -683,7 +683,7 @@ TEST_CASE("3d fclaw_clawpatch_metric_scalar")
 /* DAC : Fix this test for fclaw3d_metric? */
 TEST_CASE("3d fclaw_clawpatch_metric_vector")
 {
-    fclaw_global_t* glob = fclaw_global_new(); 
+    fclaw_global_t* glob = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);; 
     fclaw_vtables_initialize(glob);
 
     SinglePatchDomain test_data;

--- a/src/patches/clawpatch/fclaw_clawpatch.h.3d.ghostfill.TEST.cpp
+++ b/src/patches/clawpatch/fclaw_clawpatch.h.3d.ghostfill.TEST.cpp
@@ -58,7 +58,7 @@ struct TestData {
     fclaw_clawpatch_vtable_t * clawpatch_vt;
 
     TestData(fclaw_domain_t* domain, fclaw_map_context_t* map, int minlevel, int maxlevel){
-        glob = fclaw_global_new();
+        glob = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
         opts = fclaw_clawpatch_options_new(3);
         memset(&fopts, 0, sizeof(fopts));
         fopts.mi=1;

--- a/src/patches/clawpatch/fclaw_clawpatch.h.3dx.TEST.cpp
+++ b/src/patches/clawpatch/fclaw_clawpatch.h.3dx.TEST.cpp
@@ -69,7 +69,7 @@ struct SinglePatchDomain {
     fclaw_clawpatch_options_t* opts;
 
     SinglePatchDomain(){
-        glob = fclaw_global_new();
+        glob = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
         opts = fclaw_clawpatch_options_new(3);
         memset(&fopts, 0, sizeof(fopts));
         fopts.mi=1;
@@ -122,7 +122,7 @@ struct QuadDomain {
     fclaw_clawpatch_options_t* opts;
 
     QuadDomain(){
-        glob = fclaw_global_new();
+        glob = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
         opts = fclaw_clawpatch_options_new(3);
         memset(&fopts, 0, sizeof(fopts));
         fopts.mi=1;
@@ -178,7 +178,7 @@ struct QuadDomain {
 TEST_CASE("3dx fclaw_clawpatch_vtable_initialize")
 {
 	fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 1);
-    fclaw_global_t* glob = fclaw_global_new();
+    fclaw_global_t* glob = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_store_domain(glob, domain);
 
     fclaw_clawpatch_options_t* opts = fclaw_clawpatch_options_new(3);
@@ -256,7 +256,7 @@ TEST_CASE("3dx fclaw_clawpatch patch_build")
     for(const int& rhs_fields : {0,2})
     for(fclaw_build_mode_t build_mode : {FCLAW_BUILD_FOR_GHOST_AREA_COMPUTED, FCLAW_BUILD_FOR_UPDATE})
     {
-        fclaw_global_t* glob = fclaw_global_new();
+        fclaw_global_t* glob = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
         fclaw_options_t fopts;
         memset(&fopts, 0, sizeof(fopts));
@@ -680,7 +680,7 @@ TEST_CASE("3dx fclaw_clawpatch_metric_scalar")
 /* DAC : Fix this test for fclaw3d_metric? */
 TEST_CASE("3dx fclaw_clawpatch_metric_vector")
 {
-    fclaw_global_t* glob = fclaw_global_new(); 
+    fclaw_global_t* glob = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);; 
     fclaw_vtables_initialize(glob);
 
     SinglePatchDomain test_data;

--- a/src/patches/clawpatch/fclaw_clawpatch_diagnostics.h.TEST.cpp
+++ b/src/patches/clawpatch/fclaw_clawpatch_diagnostics.h.TEST.cpp
@@ -33,7 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 TEST_CASE("2d fclaw_clawpatch_diagnostics_vtable_initialize fails if fclaw2d_diagnostics_vtable_initialize is not called first")
 {
-	fclaw_global_t* glob = fclaw_global_new();
+	fclaw_global_t* glob = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	CHECK_SC_ABORTED(fclaw_clawpatch_diagnostics_vtable_initialize(glob));
 	fclaw_global_destroy(glob);
 }

--- a/src/patches/clawpatch/fclaw_clawpatch_options.h.TEST.cpp
+++ b/src/patches/clawpatch/fclaw_clawpatch_options.h.TEST.cpp
@@ -52,8 +52,8 @@ TEST_CASE("fclaw_clawpatch_options_new 3d")
 
 TEST_CASE("fclaw_clawpatch_options can store options in two seperate globs")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_clawpatch_options_t* opts1 = fclaw_clawpatch_options_new(2);
 	fclaw_clawpatch_options_t* opts2 = fclaw_clawpatch_options_new(3);
@@ -75,8 +75,8 @@ TEST_CASE("fclaw_clawpatch_options can store options in two seperate globs")
 
 TEST_CASE("fclaw_clawpatch_get_options fails if not intialized")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	CHECK_SC_ABORTED(fclaw_clawpatch_get_options(glob1));
 
@@ -88,8 +88,8 @@ TEST_CASE("fclaw_clawpatch_get_options fails if not intialized")
 
 TEST_CASE("fclaw_clawpatch_options_store fails if called twice on a glob")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_clawpatch_options_t* opts1 = fclaw_clawpatch_options_new(2);
 	fclaw_clawpatch_options_t* opts2 = fclaw_clawpatch_options_new(3);

--- a/src/patches/metric/fclaw2d_metric.h.TEST.cpp
+++ b/src/patches/metric/fclaw2d_metric.h.TEST.cpp
@@ -29,8 +29,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 TEST_CASE("fclaw2d_metric_vtable_initialize stores two seperate vtables in two seperate globs")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw2d_metric_vtable_initialize(glob1);
 	fclaw2d_metric_vtable_initialize(glob2);
@@ -43,7 +43,7 @@ TEST_CASE("fclaw2d_metric_vtable_initialize stores two seperate vtables in two s
 
 TEST_CASE("fclaw2d_metric_vtable_initialize sets is_set flag")
 {
-	fclaw_global_t* glob = fclaw_global_new();
+	fclaw_global_t* glob = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw2d_metric_vtable_initialize(glob);
 
@@ -56,8 +56,8 @@ TEST_CASE("fclaw2d_metric_vtable_initialize sets is_set flag")
 
 TEST_CASE("fclaw2d_metric_vtable_initialize fails if called twice on a glob")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw2d_metric_vtable_initialize(glob1);
 	CHECK_SC_ABORTED(fclaw2d_metric_vtable_initialize(glob1));

--- a/src/solvers/fc2d_clawpack4.6/fc2d_clawpack46.h.TEST.cpp
+++ b/src/solvers/fc2d_clawpack4.6/fc2d_clawpack46.h.TEST.cpp
@@ -33,8 +33,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 TEST_CASE("fc2d_clawpack46_solver_initialize stores two seperate vtables in two seperate globs")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 0);
 	fclaw_global_store_domain(glob1, domain);
@@ -64,7 +64,7 @@ TEST_CASE("fc2d_clawpack46_solver_initialize stores two seperate vtables in two 
 TEST_CASE("fc2d_clawpack46_solver_initialize sets is_set flag")
 {
 	fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 0);
-	fclaw_global_t* glob = fclaw_global_new();
+	fclaw_global_t* glob = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_store_domain(glob, domain);
 
 	/* create some empty options structures */
@@ -86,8 +86,8 @@ TEST_CASE("fc2d_clawpack46_solver_initialize sets is_set flag")
 
 TEST_CASE("fc2d_clawpack46_vt fails if not intialized")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 0);
 	fclaw_global_store_domain(glob1, domain);
@@ -104,8 +104,8 @@ TEST_CASE("fc2d_clawpack46_vt fails if not intialized")
 
 TEST_CASE("fc2d_clawpack46_vtable_initialize fails if called twice on a glob")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 0);
 	fclaw_global_store_domain(glob1, domain);

--- a/src/solvers/fc2d_clawpack4.6/fc2d_clawpack46_options.h.TEST.cpp
+++ b/src/solvers/fc2d_clawpack4.6/fc2d_clawpack46_options.h.TEST.cpp
@@ -31,8 +31,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 TEST_CASE("fc2d_clawpack46_options can store options in two seperate globs")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fc2d_clawpack46_options_t* opts1 = FCLAW_ALLOC_ZERO(fc2d_clawpack46_options_t,1);
 	fc2d_clawpack46_options_t* opts2 = FCLAW_ALLOC_ZERO(fc2d_clawpack46_options_t,1);
@@ -53,8 +53,8 @@ TEST_CASE("fc2d_clawpack46_options can store options in two seperate globs")
 
 TEST_CASE("fc2d_clawpack46_get_options fails if not intialized")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	CHECK_SC_ABORTED(fc2d_clawpack46_get_options(glob1));
 
@@ -66,8 +66,8 @@ TEST_CASE("fc2d_clawpack46_get_options fails if not intialized")
 
 TEST_CASE("fc2d_clawpack46_options_store fails if called twice on a glob")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fc2d_clawpack46_options_store(glob1, FCLAW_ALLOC_ZERO(fc2d_clawpack46_options_t,1));
 	CHECK_SC_ABORTED(fc2d_clawpack46_options_store(glob1, FCLAW_ALLOC_ZERO(fc2d_clawpack46_options_t,1)));

--- a/src/solvers/fc2d_clawpack5/fc2d_clawpack5.h.TEST.cpp
+++ b/src/solvers/fc2d_clawpack5/fc2d_clawpack5.h.TEST.cpp
@@ -33,8 +33,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 TEST_CASE("fc2d_clawpack5_solver_initialize stores two seperate vtables in two seperate globs")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 0);
 	fclaw_global_store_domain(glob1, domain);
@@ -63,7 +63,7 @@ TEST_CASE("fc2d_clawpack5_solver_initialize stores two seperate vtables in two s
 
 TEST_CASE("fc2d_clawpack5_solver_initialize sets is_set flag")
 {
-	fclaw_global_t* glob = fclaw_global_new();
+	fclaw_global_t* glob = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 0);
 	fclaw_global_store_domain(glob, domain);
@@ -88,8 +88,8 @@ TEST_CASE("fc2d_clawpack5_solver_initialize sets is_set flag")
 
 TEST_CASE("fc2d_clawpack5_vt fails if not intialized")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 0);
 	fclaw_global_store_domain(glob1, domain);
@@ -106,8 +106,8 @@ TEST_CASE("fc2d_clawpack5_vt fails if not intialized")
 
 TEST_CASE("fc2d_clawpack5_vtable_initialize fails if called twice on a glob")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 0);
 	fclaw_global_store_domain(glob1, domain);

--- a/src/solvers/fc2d_clawpack5/fc2d_clawpack5_options.h.TEST.cpp
+++ b/src/solvers/fc2d_clawpack5/fc2d_clawpack5_options.h.TEST.cpp
@@ -31,8 +31,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 TEST_CASE("fc2d_clawpack5_options can store options in two seperate globs")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fc2d_clawpack5_options_t* opts1 = FCLAW_ALLOC_ZERO(fc2d_clawpack5_options_t,1);
 	fc2d_clawpack5_options_t* opts2 = FCLAW_ALLOC_ZERO(fc2d_clawpack5_options_t,1);
@@ -53,8 +53,8 @@ TEST_CASE("fc2d_clawpack5_options can store options in two seperate globs")
 
 TEST_CASE("fc2d_clawpack5_get_options fails if not intialized")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	CHECK_SC_ABORTED(fc2d_clawpack5_get_options(glob1));
 
@@ -66,8 +66,8 @@ TEST_CASE("fc2d_clawpack5_get_options fails if not intialized")
 
 TEST_CASE("fc2d_clawpack5_options_store fails if called twice on a glob")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fc2d_clawpack5_options_store(glob1, FCLAW_ALLOC_ZERO(fc2d_clawpack5_options_t,1));
 	CHECK_SC_ABORTED(fc2d_clawpack5_options_store(glob1, FCLAW_ALLOC_ZERO(fc2d_clawpack5_options_t,1)));

--- a/src/solvers/fc2d_cudaclaw/fc2d_cudaclaw.h.TEST.cpp
+++ b/src/solvers/fc2d_cudaclaw/fc2d_cudaclaw.h.TEST.cpp
@@ -32,8 +32,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 TEST_CASE("fc2d_cudaclaw_solver_initialize stores two seperate vtables in two seperate globs")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	/* create some empty options structures */
 	fclaw_clawpatch_options_store(glob1, FCLAW_ALLOC_ZERO(fclaw_clawpatch_options_t,1));
@@ -56,7 +56,7 @@ TEST_CASE("fc2d_cudaclaw_solver_initialize stores two seperate vtables in two se
 
 TEST_CASE("fc2d_cudaclaw_solver_initialize sets is_set flag")
 {
-	fclaw_global_t* glob = fclaw_global_new();
+	fclaw_global_t* glob = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	/* create some empty options structures */
 	fclaw_clawpatch_options_store(glob, FCLAW_ALLOC_ZERO(fclaw_clawpatch_options_t,1));
@@ -75,8 +75,8 @@ TEST_CASE("fc2d_cudaclaw_solver_initialize sets is_set flag")
 
 TEST_CASE("fc2d_cudaclaw_vt fails if not intialized")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	CHECK_SC_ABORTED(fc2d_cudaclaw_vt(glob1));
 
@@ -88,8 +88,8 @@ TEST_CASE("fc2d_cudaclaw_vt fails if not intialized")
 
 TEST_CASE("fc2d_cudaclaw_vtable_initialize fails if called twice on a glob")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	/* create some empty options structures */
 	fclaw_clawpatch_options_store(glob1, FCLAW_ALLOC_ZERO(fclaw_clawpatch_options_t,1));

--- a/src/solvers/fc2d_cudaclaw/fc2d_cudaclaw_options.h.TEST.cpp
+++ b/src/solvers/fc2d_cudaclaw/fc2d_cudaclaw_options.h.TEST.cpp
@@ -30,8 +30,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 TEST_CASE("fc2d_cudaclaw_options can store options in two seperate globs")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fc2d_cudaclaw_options_t* opts1 = FCLAW_ALLOC_ZERO(fc2d_cudaclaw_options_t,1);
 	fc2d_cudaclaw_options_t* opts2 = FCLAW_ALLOC_ZERO(fc2d_cudaclaw_options_t,1);
@@ -52,8 +52,8 @@ TEST_CASE("fc2d_cudaclaw_options can store options in two seperate globs")
 
 TEST_CASE("fc2d_cudaclaw_get_options fails if not intialized")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	CHECK_SC_ABORTED(fc2d_cudaclaw_get_options(glob1));
 
@@ -65,8 +65,8 @@ TEST_CASE("fc2d_cudaclaw_get_options fails if not intialized")
 
 TEST_CASE("fc2d_cudaclaw_options_store fails if called twice on a glob")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fc2d_cudaclaw_options_store(glob1, FCLAW_ALLOC_ZERO(fc2d_cudaclaw_options_t,1));
 	CHECK_SC_ABORTED(fc2d_cudaclaw_options_store(glob1, FCLAW_ALLOC_ZERO(fc2d_cudaclaw_options_t,1)));

--- a/src/solvers/fc2d_geoclaw/fc2d_geoclaw.h.TEST.cpp
+++ b/src/solvers/fc2d_geoclaw/fc2d_geoclaw.h.TEST.cpp
@@ -34,8 +34,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 TEST_CASE("fc2d_geoclaw_solver_initialize stores two seperate vtables in two seperate globs")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 1);
 	fclaw_global_store_domain(glob1, domain);
@@ -68,7 +68,7 @@ TEST_CASE("fc2d_geoclaw_solver_initialize stores two seperate vtables in two sep
 TEST_CASE("fc2d_geoclaw_solver_initialize sets is_set flag")
 {
 	fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 1);
-	fclaw_global_t* glob = fclaw_global_new();
+	fclaw_global_t* glob = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_store_domain(glob, domain);
 
 	fclaw_clawpatch_options_t* clawpatch_opt = fclaw_clawpatch_options_new(2);
@@ -92,8 +92,8 @@ TEST_CASE("fc2d_geoclaw_solver_initialize sets is_set flag")
 
 TEST_CASE("fc2d_geoclaw_vt fails if not intialized")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 1);
 	fclaw_global_store_domain(glob1, domain);
@@ -110,8 +110,8 @@ TEST_CASE("fc2d_geoclaw_vt fails if not intialized")
 
 TEST_CASE("fc2d_geoclaw_vtable_initialize fails if called twice on a glob")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 1);
 	fclaw_global_store_domain(glob1, domain);

--- a/src/solvers/fc2d_geoclaw/fc2d_geoclaw_options.h.TEST.cpp
+++ b/src/solvers/fc2d_geoclaw/fc2d_geoclaw_options.h.TEST.cpp
@@ -30,8 +30,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 TEST_CASE("fc2d_geoclaw_options can store options in two seperate globs")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fc2d_geoclaw_options_t* opts1 = FCLAW_ALLOC_ZERO(fc2d_geoclaw_options_t,1);
 	fc2d_geoclaw_options_t* opts2 = FCLAW_ALLOC_ZERO(fc2d_geoclaw_options_t,1);
@@ -52,8 +52,8 @@ TEST_CASE("fc2d_geoclaw_options can store options in two seperate globs")
 
 TEST_CASE("fc2d_geoclaw_get_options fails if not intialized")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	CHECK_SC_ABORTED(fc2d_geoclaw_get_options(glob1));
 
@@ -65,8 +65,8 @@ TEST_CASE("fc2d_geoclaw_get_options fails if not intialized")
 
 TEST_CASE("fc2d_geoclaw_options_store fails if called twice on a glob")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fc2d_geoclaw_options_store(glob1, FCLAW_ALLOC_ZERO(fc2d_geoclaw_options_t,1));
 	CHECK_SC_ABORTED(fc2d_geoclaw_options_store(glob1, FCLAW_ALLOC_ZERO(fc2d_geoclaw_options_t,1)));

--- a/src/solvers/fc2d_thunderegg/fc2d_thunderegg.h.TEST.cpp
+++ b/src/solvers/fc2d_thunderegg/fc2d_thunderegg.h.TEST.cpp
@@ -32,8 +32,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 TEST_CASE("fc2d_thunderegg_solver_initialize stores two seperate vtables in two seperate globs")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 1);
 	fclaw_global_store_domain(glob1, domain);
@@ -58,7 +58,7 @@ TEST_CASE("fc2d_thunderegg_solver_initialize stores two seperate vtables in two 
 
 TEST_CASE("fc2d_thunderegg_solver_initialize sets is_set flag")
 {
-	fclaw_global_t* glob = fclaw_global_new();
+	fclaw_global_t* glob = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 1);
 	fclaw_global_store_domain(glob, domain);
@@ -80,8 +80,8 @@ TEST_CASE("fc2d_thunderegg_solver_initialize sets is_set flag")
 
 TEST_CASE("fc2d_thunderegg_vtable_initialize fails if called twice on a glob")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	
 	fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 1);
 	fclaw_global_store_domain(glob1, domain);

--- a/src/solvers/fc2d_thunderegg/fc2d_thunderegg_options.h.TEST.cpp
+++ b/src/solvers/fc2d_thunderegg/fc2d_thunderegg_options.h.TEST.cpp
@@ -30,8 +30,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 TEST_CASE("fc2d_thunderegg_options can store options in two seperate globs")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fc2d_thunderegg_options_t* opts1 = FCLAW_ALLOC_ZERO(fc2d_thunderegg_options_t,1);
 	fc2d_thunderegg_options_t* opts2 = FCLAW_ALLOC_ZERO(fc2d_thunderegg_options_t,1);
@@ -52,8 +52,8 @@ TEST_CASE("fc2d_thunderegg_options can store options in two seperate globs")
 
 TEST_CASE("fc2d_thunderegg_get_options fails if not intialized")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	CHECK_SC_ABORTED(fc2d_thunderegg_get_options(glob1));
 
@@ -65,8 +65,8 @@ TEST_CASE("fc2d_thunderegg_get_options fails if not intialized")
 
 TEST_CASE("fc2d_thunderegg_options_store fails if called twice on a glob")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fc2d_thunderegg_options_store(glob1, FCLAW_ALLOC_ZERO(fc2d_thunderegg_options_t,1));
 	CHECK_SC_ABORTED(fc2d_thunderegg_options_store(glob1, FCLAW_ALLOC_ZERO(fc2d_thunderegg_options_t,1)));

--- a/src/solvers/fc3d_clawpack46/fc3d_clawpack46.h.TEST.cpp
+++ b/src/solvers/fc3d_clawpack46/fc3d_clawpack46.h.TEST.cpp
@@ -33,8 +33,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 TEST_CASE("fc3d_clawpack46_solver_initialize stores two seperate vtables in two seperate globs")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 0);
 	fclaw_global_store_domain(glob1, domain);
@@ -68,7 +68,7 @@ TEST_CASE("fc3d_clawpack46_solver_initialize stores two seperate vtables in two 
 TEST_CASE("fc3d_clawpack46_solver_initialize sets is_set flag")
 {
 	fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 0);
-	fclaw_global_t* glob = fclaw_global_new();
+	fclaw_global_t* glob = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_store_domain(glob, domain);
 
 	fclaw_clawpatch_options_t* opts = fclaw_clawpatch_options_new(3);
@@ -92,8 +92,8 @@ TEST_CASE("fc3d_clawpack46_solver_initialize sets is_set flag")
 
 TEST_CASE("fc3d_clawpack46_vt fails if not intialized")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 0);
 	fclaw_global_store_domain(glob1, domain);
@@ -110,8 +110,8 @@ TEST_CASE("fc3d_clawpack46_vt fails if not intialized")
 
 TEST_CASE("fc3d_clawpack46_vtable_initialize fails if called twice on a glob")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 0);
 	fclaw_global_store_domain(glob1, domain);

--- a/src/solvers/fc3d_clawpack46/fc3d_clawpack46_options.h.TEST.cpp
+++ b/src/solvers/fc3d_clawpack46/fc3d_clawpack46_options.h.TEST.cpp
@@ -30,8 +30,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 TEST_CASE("fc3d_clawpack46_options can store options in two seperate globs")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fc3d_clawpack46_options_t* opts1 = FCLAW_ALLOC_ZERO(fc3d_clawpack46_options_t,1);
 	fc3d_clawpack46_options_t* opts2 = FCLAW_ALLOC_ZERO(fc3d_clawpack46_options_t,1);
@@ -52,8 +52,8 @@ TEST_CASE("fc3d_clawpack46_options can store options in two seperate globs")
 
 TEST_CASE("fc3d_clawpack46_get_options fails if not intialized")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	CHECK_SC_ABORTED(fc3d_clawpack46_get_options(glob1));
 
@@ -65,8 +65,8 @@ TEST_CASE("fc3d_clawpack46_get_options fails if not intialized")
 
 TEST_CASE("fc3d_clawpack46_options_store fails if called twice on a glob")
 {
-	fclaw_global_t* glob1 = fclaw_global_new();
-	fclaw_global_t* glob2 = fclaw_global_new();
+	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
+	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fc3d_clawpack46_options_store(glob1, FCLAW_ALLOC_ZERO(fc3d_clawpack46_options_t,1));
 	CHECK_SC_ABORTED(fc3d_clawpack46_options_store(glob1, FCLAW_ALLOC_ZERO(fc3d_clawpack46_options_t,1)));


### PR DESCRIPTION
This updates the unit tests to use the `fclaw_global_new_comm` constructor instead of the `fclaw_global_new` constructor.