### PR TITLE
Partitioning strategies for patch data

### DIFF
--- a/src/fclaw2d_to_3d.h
+++ b/src/fclaw2d_to_3d.h
@@ -57,6 +57,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define fclaw2d_match_callback_t        fclaw3d_match_callback_t
 #define fclaw2d_transfer_callback_t     fclaw3d_transfer_callback_t
 #define fclaw2d_pack_callback_t         fclaw3d_pack_callback_t
+#define fclaw2d_domain_partition_t      fclaw3d_domain_partition_t
 #define fclaw2d_domain_exchange_t       fclaw3d_domain_exchange_t
 #define fclaw2d_domain_indirect         fclaw3d_domain_indirect
 #define fclaw2d_domain_indirect_t       fclaw3d_domain_indirect_t

--- a/src/fclaw2d_to_3d.h
+++ b/src/fclaw2d_to_3d.h
@@ -174,6 +174,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define fclaw2d_domain_allocate_before_partition    fclaw3d_domain_allocate_before_partition
 #define fclaw2d_domain_retrieve_after_partition     fclaw3d_domain_retrieve_after_partition
 #define fclaw2d_domain_iterate_partitioned  fclaw3d_domain_iterate_partitioned
+#define fclaw2d_domain_iterate_pack     fclaw3d_domain_iterate_pack
+#define fclaw2d_domain_iterate_transfer fclaw3d_domain_iterate_transfer
+#define fclaw2d_domain_partition_free   fclaw3d_domain_partition_free
 #define fclaw2d_domain_free_after_partition fclaw3d_domain_free_after_partition
 #define fclaw2d_domain_allocate_before_exchange fclaw3d_domain_allocate_before_exchange
 #define fclaw2d_domain_free_after_exchange  fclaw3d_domain_free_after_exchange

--- a/src/fclaw2d_to_3d.h
+++ b/src/fclaw2d_to_3d.h
@@ -56,6 +56,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define fclaw2d_patch_relation_t        fclaw3d_patch_relation_t
 #define fclaw2d_match_callback_t        fclaw3d_match_callback_t
 #define fclaw2d_transfer_callback_t     fclaw3d_transfer_callback_t
+#define fclaw2d_pack_callback_t         fclaw3d_pack_callback_t
 #define fclaw2d_domain_exchange_t       fclaw3d_domain_exchange_t
 #define fclaw2d_domain_indirect         fclaw3d_domain_indirect
 #define fclaw2d_domain_indirect_t       fclaw3d_domain_indirect_t

--- a/src/fclaw2d_to_3d.h
+++ b/src/fclaw2d_to_3d.h
@@ -176,6 +176,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define fclaw2d_domain_retrieve_after_partition     fclaw3d_domain_retrieve_after_partition
 #define fclaw2d_domain_iterate_partitioned  fclaw3d_domain_iterate_partitioned
 #define fclaw2d_domain_iterate_pack     fclaw3d_domain_iterate_pack
+#define fclaw2d_domain_iterate_transfer fclaw3d_domain_iterate_transfer
 #define fclaw2d_domain_iterate_unpack   fclaw3d_domain_iterate_unpack
 #define fclaw2d_domain_partition_free   fclaw3d_domain_partition_free
 #define fclaw2d_domain_free_after_partition fclaw3d_domain_free_after_partition

--- a/src/fclaw2d_to_3d.h
+++ b/src/fclaw2d_to_3d.h
@@ -57,6 +57,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define fclaw2d_match_callback_t        fclaw3d_match_callback_t
 #define fclaw2d_transfer_callback_t     fclaw3d_transfer_callback_t
 #define fclaw2d_pack_callback_t         fclaw3d_pack_callback_t
+#define fclaw2d_unpack_callback_t       fclaw3d_unpack_callback_t
 #define fclaw2d_domain_partition_t      fclaw3d_domain_partition_t
 #define fclaw2d_domain_exchange_t       fclaw3d_domain_exchange_t
 #define fclaw2d_domain_indirect         fclaw3d_domain_indirect
@@ -175,7 +176,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define fclaw2d_domain_retrieve_after_partition     fclaw3d_domain_retrieve_after_partition
 #define fclaw2d_domain_iterate_partitioned  fclaw3d_domain_iterate_partitioned
 #define fclaw2d_domain_iterate_pack     fclaw3d_domain_iterate_pack
-#define fclaw2d_domain_iterate_transfer fclaw3d_domain_iterate_transfer
+#define fclaw2d_domain_iterate_unpack   fclaw3d_domain_iterate_unpack
 #define fclaw2d_domain_partition_free   fclaw3d_domain_partition_free
 #define fclaw2d_domain_free_after_partition fclaw3d_domain_free_after_partition
 #define fclaw2d_domain_allocate_before_exchange fclaw3d_domain_allocate_before_exchange

--- a/src/forestclaw2d.c
+++ b/src/forestclaw2d.c
@@ -1768,14 +1768,12 @@ fclaw2d_domain_iterate_transfer (fclaw2d_domain_t * old_domain,
                                  fclaw2d_transfer_callback_t patch_transfer,
                                  void *user)
 {
-    p4est_wrap_t *wrap = (p4est_wrap_t *) new_domain->pp;
     int blockno, old_patchno, new_patchno;
     fclaw2d_block_t *old_block, *new_block;
     fclaw2d_patch_t *old_patch, *new_patch;
     int dpuf, dpul, bnpb;
 
     /* this routine should only be called for a changed partition */
-    P4EST_ASSERT (wrap->old_global_first_quadrant != NULL);
     P4EST_ASSERT (!old_domain->pp_owned);
     P4EST_ASSERT (new_domain->pp_owned);
 
@@ -1812,7 +1810,6 @@ fclaw2d_domain_iterate_unpack (fclaw2d_domain_t * domain,
                                fclaw2d_unpack_callback_t patch_unpack,
                                void *user)
 {
-    p4est_wrap_t *wrap = (p4est_wrap_t *) domain->pp;
     int blockno, patchno;
     size_t zz;
     fclaw2d_block_t *block;
@@ -1821,7 +1818,6 @@ fclaw2d_domain_iterate_unpack (fclaw2d_domain_t * domain,
 
     /* this routine should only be called for the new domain of a changed
      * partition */
-    P4EST_ASSERT (wrap->old_global_first_quadrant != NULL);
     P4EST_ASSERT (domain->pp_owned);
     P4EST_ASSERT (p->inside_async);
 

--- a/src/forestclaw2d.c
+++ b/src/forestclaw2d.c
@@ -27,10 +27,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <forestclaw2d.h>
 #include <p4est_bits.h>
 #include <p4est_wrap.h>
+#include <p4est_communication.h>
 #else
 #include <forestclaw3d.h>
 #include <p8est_bits.h>
 #include <p8est_wrap.h>
+#include <p8est_communication.h>
 #endif
 
 #ifndef P4_TO_P8
@@ -1700,13 +1702,61 @@ fclaw2d_domain_iterate_partitioned (fclaw2d_domain_t * old_domain,
     }
 }
 
+typedef enum comm_tag
+{
+    COMM_TAG_FIXED,
+    COMM_TAG_CUSTOM,
+    COMM_TAG_LAST
+}
+comm_tag_t;
+
 fclaw2d_domain_partition_t *
-fclaw2d_domain_iterate_pack (fclaw2d_domain_t * domain,
+fclaw2d_domain_iterate_pack (fclaw2d_domain_t * domain, size_t data_size,
                              fclaw2d_pack_callback_t patch_pack, void *user)
 {
     fclaw2d_domain_partition_t *p;
+    p4est_wrap_t *wrap = (p4est_wrap_t *) domain->pp;
+    int blockno, patchno;
+    size_t zz;
+    fclaw2d_block_t *block;
+    fclaw2d_patch_t *patch;
+
+    /* this routine should only be called for changed partitions */
+    P4EST_ASSERT (!domain->pp_owned);
+    P4EST_ASSERT (wrap->old_global_first_quadrant != NULL);
+    P4EST_ASSERT (domain->local_num_patches == (int)
+                  wrap->old_global_first_quadrant[wrap->p4est->mpirank + 1] -
+                  wrap->old_global_first_quadrant[wrap->p4est->mpirank]);
 
     p = FCLAW_ALLOC (fclaw2d_domain_partition_t, 1);
+    p->dest_data =
+        sc_array_new_count (data_size,
+                            (size_t) wrap->p4est->local_num_quadrants);
+
+    /* pack patches into src_data array */
+    p->src_data =
+        sc_array_new_count (data_size, (size_t) domain->local_num_patches);
+    for (zz = 0, blockno = 0; blockno < domain->num_blocks; ++blockno)
+    {
+        block = domain->blocks + blockno;
+        for (patchno = 0; patchno < block->num_patches; ++zz, ++patchno)
+        {
+            FCLAW_ASSERT (zz ==
+                          (size_t) (block->num_patches_before + patchno));
+            patch = block->patches + patchno;
+            patch_pack (domain, patch, blockno, patchno,
+                        sc_array_index (p->src_data, zz), user);
+        }
+    }
+    FCLAW_ASSERT (zz == (size_t) domain->local_num_patches);
+
+    /* start transfering patch data according to the new partition */
+    p->async_state = (void *)
+        p4est_transfer_fixed_begin (wrap->p4est->global_first_quadrant,
+                                    wrap->old_global_first_quadrant,
+                                    domain->mpicomm, COMM_TAG_FIXED,
+                                    p->dest_data->array, p->src_data->array,
+                                    data_size);
 
     return p;
 }
@@ -1717,13 +1767,17 @@ fclaw2d_domain_iterate_transfer (fclaw2d_domain_t * domain,
                                  fclaw2d_transfer_callback_t patch_transfer,
                                  void *user)
 {
-
+    p4est_transfer_fixed_end ((p4est_transfer_context_t *) p->async_state);
+    p->async_state = NULL;
 }
 
 void
 fclaw2d_domain_partition_free (fclaw2d_domain_t * domain,
                                fclaw2d_domain_partition_t * p)
 {
+    sc_array_destroy (p->src_data);
+    sc_array_destroy (p->dest_data);
+
     FCLAW_FREE (p);
 }
 

--- a/src/forestclaw2d.c
+++ b/src/forestclaw2d.c
@@ -1864,8 +1864,7 @@ fclaw2d_domain_iterate_unpack (fclaw2d_domain_t * domain,
 }
 
 void
-fclaw2d_domain_partition_free (fclaw2d_domain_t * domain,
-                               fclaw2d_domain_partition_t * p)
+fclaw2d_domain_partition_free (fclaw2d_domain_partition_t * p)
 {
     sc_array_destroy (p->src_data);
     sc_array_destroy (p->dest_data);

--- a/src/forestclaw2d.c
+++ b/src/forestclaw2d.c
@@ -1757,6 +1757,7 @@ fclaw2d_domain_iterate_pack (fclaw2d_domain_t * domain, size_t data_size,
                                     domain->mpicomm, COMM_TAG_FIXED,
                                     p->dest_data->array, p->src_data->array,
                                     data_size);
+    p->inside_async = 1;
 
     return p;
 }
@@ -1822,10 +1823,12 @@ fclaw2d_domain_iterate_unpack (fclaw2d_domain_t * domain,
      * partition */
     P4EST_ASSERT (wrap->old_global_first_quadrant != NULL);
     P4EST_ASSERT (domain->pp_owned);
+    P4EST_ASSERT (p->inside_async);
 
     /* wait for transfer of patch data to complete */
     p4est_transfer_fixed_end ((p4est_transfer_context_t *) p->async_state);
     p->async_state = NULL;
+    p->inside_async = 0;
 
     /* unpack patches from dest_data array */
     dpuf = domain->partition_unchanged_first;
@@ -1866,6 +1869,7 @@ fclaw2d_domain_iterate_unpack (fclaw2d_domain_t * domain,
 void
 fclaw2d_domain_partition_free (fclaw2d_domain_partition_t * p)
 {
+    P4EST_ASSERT (!p->inside_async);
     sc_array_destroy (p->src_data);
     sc_array_destroy (p->dest_data);
 

--- a/src/forestclaw2d.c
+++ b/src/forestclaw2d.c
@@ -1803,7 +1803,8 @@ fclaw2d_domain_iterate_unpack (fclaw2d_domain_t * domain,
         bnpb = block->num_patches_before;
 
         /* iterate over new patches before unchanged section */
-        for (patchno = 0; patchno + bnpb < dpuf; ++zz, ++patchno)
+        for (patchno = 0; patchno < SC_MIN (dpuf - bnpb, block->num_patches);
+             ++zz, ++patchno)
         {
             patch = block->patches + patchno;
             patch_unpack (domain, patch, blockno, patchno,
@@ -1811,7 +1812,10 @@ fclaw2d_domain_iterate_unpack (fclaw2d_domain_t * domain,
         }
 
         /* we skip the local patches for unpacking */
-        zz += dpul;
+        if (zz == (size_t) dpuf)
+        {
+            zz += dpul;
+        }
 
         /* iterate over new patches after unchanged section */
         for (patchno = SC_MAX (0, dpuf + dpul - bnpb);

--- a/src/forestclaw2d.c
+++ b/src/forestclaw2d.c
@@ -1700,6 +1700,33 @@ fclaw2d_domain_iterate_partitioned (fclaw2d_domain_t * old_domain,
     }
 }
 
+fclaw2d_domain_partition_t *
+fclaw2d_domain_iterate_pack (fclaw2d_domain_t * domain,
+                             fclaw2d_pack_callback_t patch_pack, void *user)
+{
+    fclaw2d_domain_partition_t *p;
+
+    p = FCLAW_ALLOC (fclaw2d_domain_partition_t, 1);
+
+    return p;
+}
+
+void
+fclaw2d_domain_iterate_transfer (fclaw2d_domain_t * domain,
+                                 fclaw2d_domain_partition_t * p,
+                                 fclaw2d_transfer_callback_t patch_transfer,
+                                 void *user)
+{
+
+}
+
+void
+fclaw2d_domain_partition_free (fclaw2d_domain_t * domain,
+                               fclaw2d_domain_partition_t * p)
+{
+    FCLAW_FREE (p);
+}
+
 void
 fclaw2d_domain_free_after_partition (fclaw2d_domain_t * domain,
                                      void ***patch_data)

--- a/src/forestclaw2d.c
+++ b/src/forestclaw2d.c
@@ -1762,10 +1762,10 @@ fclaw2d_domain_iterate_pack (fclaw2d_domain_t * domain, size_t data_size,
 }
 
 void
-fclaw2d_domain_iterate_transfer (fclaw2d_domain_t * domain,
-                                 fclaw2d_domain_partition_t * p,
-                                 fclaw2d_transfer_callback_t patch_transfer,
-                                 void *user)
+fclaw2d_domain_iterate_unpack (fclaw2d_domain_t * domain,
+                               fclaw2d_domain_partition_t * p,
+                               fclaw2d_unpack_callback_t patch_unpack,
+                               void *user)
 {
     p4est_transfer_fixed_end ((p4est_transfer_context_t *) p->async_state);
     p->async_state = NULL;

--- a/src/forestclaw2d.c
+++ b/src/forestclaw2d.c
@@ -1764,7 +1764,6 @@ fclaw2d_domain_iterate_pack (fclaw2d_domain_t * domain, size_t data_size,
 void
 fclaw2d_domain_iterate_transfer (fclaw2d_domain_t * old_domain,
                                  fclaw2d_domain_t * new_domain,
-                                 fclaw2d_domain_partition_t * p,
                                  fclaw2d_transfer_callback_t patch_transfer,
                                  void *user)
 {

--- a/src/forestclaw2d.h
+++ b/src/forestclaw2d.h
@@ -824,6 +824,12 @@ fclaw2d_domain_partition_t
                                    fclaw2d_pack_callback_t patch_pack,
                                    void *user);
 
+void fclaw2d_domain_iterate_transfer (fclaw2d_domain_t * old_domain,
+                                      fclaw2d_domain_t * new_domain,
+                                      fclaw2d_domain_partition_t * p,
+                                      fclaw2d_transfer_callback_t
+                                      patch_transfer, void *user);
+
 void fclaw2d_domain_iterate_unpack (fclaw2d_domain_t * domain,
                                     fclaw2d_domain_partition_t * p,
                                     fclaw2d_unpack_callback_t patch_transfer,

--- a/src/forestclaw2d.h
+++ b/src/forestclaw2d.h
@@ -801,6 +801,12 @@ typedef void (*fclaw2d_pack_callback_t) (fclaw2d_domain_t * domain,
                                          int patchno, void *pack_data_here,
                                          void *user);
 
+typedef void (*fclaw2d_unpack_callback_t) (fclaw2d_domain_t * domain,
+                                           fclaw2d_patch_t * patch,
+                                           int blockno, int patchno,
+                                           void *unpack_data_from_here,
+                                           void *user);
+
 typedef struct fclaw2d_domain_partition
 {
     sc_array_t *src_data; /**< The patch data to send */
@@ -818,10 +824,10 @@ fclaw2d_domain_partition_t
                                    fclaw2d_pack_callback_t patch_pack,
                                    void *user);
 
-void fclaw2d_domain_iterate_transfer (fclaw2d_domain_t * domain,
-                                      fclaw2d_domain_partition_t * p,
-                                      fclaw2d_transfer_callback_t
-                                      patch_transfer, void *user);
+void fclaw2d_domain_iterate_unpack (fclaw2d_domain_t * domain,
+                                    fclaw2d_domain_partition_t * p,
+                                    fclaw2d_unpack_callback_t patch_transfer,
+                                    void *user);
 
 void fclaw2d_domain_partition_free (fclaw2d_domain_t * domain,
                                     fclaw2d_domain_partition_t * p);

--- a/src/forestclaw2d.h
+++ b/src/forestclaw2d.h
@@ -801,6 +801,12 @@ typedef void (*fclaw2d_pack_callback_t) (fclaw2d_domain_t * domain,
                                          int patchno, void *pack_data_here,
                                          void *user);
 
+typedef struct fclaw2d_domain_partition
+{
+    size_t data_size; /**< The number of bytes per patch to send */
+}
+fclaw2d_domain_partition_t;
+
 /** Free buffers that were used in transfering data during partition.
  * \param [in,out] domain       The memory lives inside this domain.
  * \param [in,out] patch_data   Address of an array of void pointers to free.

--- a/src/forestclaw2d.h
+++ b/src/forestclaw2d.h
@@ -796,6 +796,11 @@ void fclaw2d_domain_iterate_partitioned (fclaw2d_domain_t * old_domain,
                                          fclaw2d_transfer_callback_t tcb,
                                          void *user);
 
+typedef void (*fclaw2d_pack_callback_t) (fclaw2d_domain_t * domain,
+                                         fclaw2d_patch_t * patch, int blockno,
+                                         int patchno, void *pack_data_here,
+                                         void *user);
+
 /** Free buffers that were used in transfering data during partition.
  * \param [in,out] domain       The memory lives inside this domain.
  * \param [in,out] patch_data   Address of an array of void pointers to free.

--- a/src/forestclaw2d.h
+++ b/src/forestclaw2d.h
@@ -806,6 +806,7 @@ typedef struct fclaw2d_domain_partition
      * It is allocated and freed by the begin/end calls below.
      */
     void *async_state;
+    int inside_async;           /**< Between asynchronous begin and end? */
 }
 fclaw2d_domain_partition_t;
 

--- a/src/forestclaw2d.h
+++ b/src/forestclaw2d.h
@@ -834,8 +834,7 @@ void fclaw2d_domain_iterate_unpack (fclaw2d_domain_t * domain,
                                     fclaw2d_unpack_callback_t patch_transfer,
                                     void *user);
 
-void fclaw2d_domain_partition_free (fclaw2d_domain_t * domain,
-                                    fclaw2d_domain_partition_t * p);
+void fclaw2d_domain_partition_free (fclaw2d_domain_partition_t * p);
 
 /** Free buffers that were used in transfering data during partition.
  * \param [in,out] domain       The memory lives inside this domain.

--- a/src/forestclaw2d.h
+++ b/src/forestclaw2d.h
@@ -826,7 +826,6 @@ fclaw2d_domain_partition_t
 
 void fclaw2d_domain_iterate_transfer (fclaw2d_domain_t * old_domain,
                                       fclaw2d_domain_t * new_domain,
-                                      fclaw2d_domain_partition_t * p,
                                       fclaw2d_transfer_callback_t
                                       patch_transfer, void *user);
 

--- a/src/forestclaw2d.h
+++ b/src/forestclaw2d.h
@@ -803,12 +803,18 @@ typedef void (*fclaw2d_pack_callback_t) (fclaw2d_domain_t * domain,
 
 typedef struct fclaw2d_domain_partition
 {
-    size_t data_size; /**< The number of bytes per patch to send */
+    sc_array_t *src_data; /**< The patch data to send */
+    sc_array_t *dest_data; /**< The patch data to receive */
+    /** Temporary storage required for asynchronous patch data transfer.
+     * It is allocated and freed by the begin/end calls below.
+     */
+    void *async_state;
 }
 fclaw2d_domain_partition_t;
 
 fclaw2d_domain_partition_t
     * fclaw2d_domain_iterate_pack (fclaw2d_domain_t * domain,
+                                   size_t data_size,
                                    fclaw2d_pack_callback_t patch_pack,
                                    void *user);
 

--- a/src/forestclaw2d.h
+++ b/src/forestclaw2d.h
@@ -774,7 +774,8 @@ void fclaw2d_domain_retrieve_after_partition (fclaw2d_domain_t * domain,
  * \param [in] new_patchno      Number of the iterated patch wrt. the new
  *                              domain and partition.
  * \param [in,out] user         Pointer passed to \ref
- *                              fclaw2d_domain_iterate_partitioned.
+ *                              fclaw2d_domain_iterate_partitioned or
+ *                              \ref fclaw2d_domain_iterate_transfer.
  */
 typedef void (*fclaw2d_transfer_callback_t) (fclaw2d_domain_t * old_domain,
                                              fclaw2d_patch_t * old_patch,
@@ -796,17 +797,7 @@ void fclaw2d_domain_iterate_partitioned (fclaw2d_domain_t * old_domain,
                                          fclaw2d_transfer_callback_t tcb,
                                          void *user);
 
-typedef void (*fclaw2d_pack_callback_t) (fclaw2d_domain_t * domain,
-                                         fclaw2d_patch_t * patch, int blockno,
-                                         int patchno, void *pack_data_here,
-                                         void *user);
-
-typedef void (*fclaw2d_unpack_callback_t) (fclaw2d_domain_t * domain,
-                                           fclaw2d_patch_t * patch,
-                                           int blockno, int patchno,
-                                           void *unpack_data_from_here,
-                                           void *user);
-
+/** Data structure for storing allocated data for partition transfer. */
 typedef struct fclaw2d_domain_partition
 {
     sc_array_t *src_data; /**< The patch data to send */
@@ -818,22 +809,102 @@ typedef struct fclaw2d_domain_partition
 }
 fclaw2d_domain_partition_t;
 
+/** Callback to pack patch data after partitioning.
+ * We traverse every local patch in the old partition. If that patch has to be
+ * packed for the new partition, we invoke this callback.
+ * \param [in,out] domain   Domain before partition.
+ * \param [in,out] patch    Patch from the domain. Its user data should be
+                            packed into \b pack_data_here.
+ * \param [in] blockno      Number of the current block.
+ * \param [in] patchno      Number of the patch.
+ * \param [in] pack_data_here Address of storage space for the patch's user data.
+ * \param [in,out] user     Pointer passed to \ref fclaw2d_domain_iterate_pack.
+ */
+typedef void (*fclaw2d_pack_callback_t) (fclaw2d_domain_t * domain,
+                                         fclaw2d_patch_t * patch, int blockno,
+                                         int patchno, void *pack_data_here,
+                                         void *user);
+
+/** Start asynchronous transfer of patch data after partition.
+ * The function iterates over all local patches of old partition and determines
+ * patches that have to be packed by use of \b patch_pack and send to the new
+ * partition.
+ * It must be followed by a call to \ref fclaw2d_domain_iterate_unpack.
+ * \param [in,out] domain       The domain before partitioning.
+ * \param [in] data_size        The number of bytes of user data that has to be
+ *                              packed and send per patch.
+ * \param [in] patch_pack       Callback function to pack patch user data into
+ *                              a provided storage address.
+ * \param [in] user             This pointer is passed to the callback.
+ * \return                      Allocated and initialized structure containing
+ *                              internal information for patch data transfer.
+ */
 fclaw2d_domain_partition_t
     * fclaw2d_domain_iterate_pack (fclaw2d_domain_t * domain,
                                    size_t data_size,
                                    fclaw2d_pack_callback_t patch_pack,
                                    void *user);
 
+/** Transfer data of patches still local after partition.
+ * The function iterates over all pairs of local patches in the domain before
+ * and after partitioning and invokes the transfer of their user-data via
+ * \ref patch_transfer.
+ * It may be called before, between or after \ref fclaw2d_domain_iterate_pack
+ * and \ref fclaw2d_domain_iterate_unpack. It is recommended to call it between
+ * packing and unpacking, to overlap communication with computation.
+ * \param [in,out] old_domain   The domain before partitioning.
+ * \param [in,out] new_domain   The domain after partitioning.
+ * \param [in] patch_transfer   Callback function to transfer user data between
+ *                              local old and new patch, e.g. by a copy
+ *                              or reassignment.
+ * \param [in] user             This pointer is passed to the callback.
+ */
 void fclaw2d_domain_iterate_transfer (fclaw2d_domain_t * old_domain,
                                       fclaw2d_domain_t * new_domain,
                                       fclaw2d_transfer_callback_t
                                       patch_transfer, void *user);
 
+/** Callback to unpack patch data after partitioning.
+ * We traverse every local patch, that was not local before partitioning.
+ * \param [in,out] domain   Domain after partition.
+ * \param [in,out] patch    Patch from the domain. Its user data should be
+                            unpacked from \b unpack_data_from_here.
+ * \param [in] blockno      Number of the current block.
+ * \param [in] patchno      Number of the patch.
+ * \param [in] unpack_data_from_here Address of storage space that contains the
+                            packed user data of the patch.
+ * \param [in,out] user     Pointer passed to \ref fclaw2d_domain_iterate_unpack.
+ */
+typedef void (*fclaw2d_unpack_callback_t) (fclaw2d_domain_t * domain,
+                                           fclaw2d_patch_t * patch,
+                                           int blockno, int patchno,
+                                           void *unpack_data_from_here,
+                                           void *user);
+
+/** Complete asynchronous transfer of patch data after partition.
+ * The function iterates over all local patches of new partition and determines
+ * patches that have to be unpacked by use of \b patch_unpack.
+ * It must be preceded by a call to \ref fclaw2d_domain_iterate_unpack and
+ * provided with the corresponding \ref fclaw2d_domain_partition_t \b p.
+ * \param [in,out] domain       The domain after partitioning.
+ * \param [in,out] p            Structure containing internal information for
+ *                              the patch data transfer.
+ * \param [in] patch_pack       Callback function to unpack patch user data from
+ *                              a provided storage address.
+ * \param [in] user             This pointer is passed to the callback.
+ * \return                      Allocated and initialized structure containing
+ *                              internal information for patch data transfer.
+ */
 void fclaw2d_domain_iterate_unpack (fclaw2d_domain_t * domain,
                                     fclaw2d_domain_partition_t * p,
-                                    fclaw2d_unpack_callback_t patch_transfer,
+                                    fclaw2d_unpack_callback_t patch_unpack,
                                     void *user);
 
+/** Free buffers used in transfering patch data during partition.
+ * \param [in] p                Structure containing internal information for
+ *                              patch data transfer. Will be deallocated during
+ *                              this function call.
+ */
 void fclaw2d_domain_partition_free (fclaw2d_domain_partition_t * p);
 
 /** Free buffers that were used in transfering data during partition.

--- a/src/forestclaw2d.h
+++ b/src/forestclaw2d.h
@@ -807,6 +807,19 @@ typedef struct fclaw2d_domain_partition
 }
 fclaw2d_domain_partition_t;
 
+fclaw2d_domain_partition_t
+    * fclaw2d_domain_iterate_pack (fclaw2d_domain_t * domain,
+                                   fclaw2d_pack_callback_t patch_pack,
+                                   void *user);
+
+void fclaw2d_domain_iterate_transfer (fclaw2d_domain_t * domain,
+                                      fclaw2d_domain_partition_t * p,
+                                      fclaw2d_transfer_callback_t
+                                      patch_transfer, void *user);
+
+void fclaw2d_domain_partition_free (fclaw2d_domain_t * domain,
+                                    fclaw2d_domain_partition_t * p);
+
 /** Free buffers that were used in transfering data during partition.
  * \param [in,out] domain       The memory lives inside this domain.
  * \param [in,out] patch_data   Address of an array of void pointers to free.

--- a/src/forestclaw3d.h
+++ b/src/forestclaw3d.h
@@ -947,6 +947,12 @@ fclaw3d_domain_partition_t
                                    fclaw3d_pack_callback_t patch_pack,
                                    void *user);
 
+void fclaw3d_domain_iterate_transfer (fclaw3d_domain_t * old_domain,
+                                      fclaw3d_domain_t * new_domain,
+                                      fclaw3d_domain_partition_t * p,
+                                      fclaw3d_transfer_callback_t
+                                      patch_transfer, void *user);
+
 void fclaw3d_domain_iterate_unpack (fclaw3d_domain_t * domain,
                                     fclaw3d_domain_partition_t * p,
                                     fclaw3d_unpack_callback_t patch_unpack,

--- a/src/forestclaw3d.h
+++ b/src/forestclaw3d.h
@@ -924,6 +924,12 @@ typedef void (*fclaw3d_pack_callback_t) (fclaw3d_domain_t * domain,
                                          int patchno, void *pack_data_here,
                                          void *user);
 
+typedef void (*fclaw3d_unpack_callback_t) (fclaw3d_domain_t * domain,
+                                           fclaw3d_patch_t * patch,
+                                           int blockno, int patchno,
+                                           void *unpack_data_from_here,
+                                           void *user);
+
 typedef struct fclaw3d_domain_partition
 {
     sc_array_t *src_data; /**< The patch data to send */
@@ -941,10 +947,10 @@ fclaw3d_domain_partition_t
                                    fclaw3d_pack_callback_t patch_pack,
                                    void *user);
 
-void fclaw3d_domain_iterate_transfer (fclaw3d_domain_t * domain,
-                                      fclaw3d_domain_partition_t * p,
-                                      fclaw3d_transfer_callback_t
-                                      patch_transfer, void *user);
+void fclaw3d_domain_iterate_unpack (fclaw3d_domain_t * domain,
+                                    fclaw3d_domain_partition_t * p,
+                                    fclaw3d_unpack_callback_t patch_unpack,
+                                    void *user);
 
 void fclaw3d_domain_partition_free (fclaw3d_domain_t * domain,
                                     fclaw3d_domain_partition_t * p);

--- a/src/forestclaw3d.h
+++ b/src/forestclaw3d.h
@@ -924,6 +924,12 @@ typedef void (*fclaw3d_pack_callback_t) (fclaw3d_domain_t * domain,
                                          int patchno, void *pack_data_here,
                                          void *user);
 
+typedef struct fclaw3d_domain_partition
+{
+    size_t data_size; /**< The number of bytes per patch to send */
+}
+fclaw3d_domain_partition_t;
+
 /** Free buffers that were used in transfering data during partition.
  * \param [in,out] domain       The memory lives inside this domain.
  * \param [in,out] patch_data   Address of an array of void pointers to free.

--- a/src/forestclaw3d.h
+++ b/src/forestclaw3d.h
@@ -949,7 +949,6 @@ fclaw3d_domain_partition_t
 
 void fclaw3d_domain_iterate_transfer (fclaw3d_domain_t * old_domain,
                                       fclaw3d_domain_t * new_domain,
-                                      fclaw3d_domain_partition_t * p,
                                       fclaw3d_transfer_callback_t
                                       patch_transfer, void *user);
 

--- a/src/forestclaw3d.h
+++ b/src/forestclaw3d.h
@@ -929,6 +929,7 @@ typedef struct fclaw3d_domain_partition
      * It is allocated and freed by the begin/end calls below.
      */
     void *async_state;
+    int inside_async;           /**< Between asynchronous begin and end? */
 }
 fclaw3d_domain_partition_t;
 

--- a/src/forestclaw3d.h
+++ b/src/forestclaw3d.h
@@ -957,8 +957,7 @@ void fclaw3d_domain_iterate_unpack (fclaw3d_domain_t * domain,
                                     fclaw3d_unpack_callback_t patch_unpack,
                                     void *user);
 
-void fclaw3d_domain_partition_free (fclaw3d_domain_t * domain,
-                                    fclaw3d_domain_partition_t * p);
+void fclaw3d_domain_partition_free (fclaw3d_domain_partition_t * p);
 
 /** Free buffers that were used in transfering data during partition.
  * \param [in,out] domain       The memory lives inside this domain.

--- a/src/forestclaw3d.h
+++ b/src/forestclaw3d.h
@@ -919,6 +919,11 @@ void fclaw3d_domain_iterate_partitioned (fclaw3d_domain_t * old_domain,
                                          fclaw3d_transfer_callback_t tcb,
                                          void *user);
 
+typedef void (*fclaw3d_pack_callback_t) (fclaw3d_domain_t * domain,
+                                         fclaw3d_patch_t * patch, int blockno,
+                                         int patchno, void *pack_data_here,
+                                         void *user);
+
 /** Free buffers that were used in transfering data during partition.
  * \param [in,out] domain       The memory lives inside this domain.
  * \param [in,out] patch_data   Address of an array of void pointers to free.

--- a/src/forestclaw3d.h
+++ b/src/forestclaw3d.h
@@ -926,12 +926,18 @@ typedef void (*fclaw3d_pack_callback_t) (fclaw3d_domain_t * domain,
 
 typedef struct fclaw3d_domain_partition
 {
-    size_t data_size; /**< The number of bytes per patch to send */
+    sc_array_t *src_data; /**< The patch data to send */
+    sc_array_t *dest_data; /**< The patch data to receive */
+    /** Temporary storage required for asynchronous patch data transfer.
+     * It is allocated and freed by the begin/end calls below.
+     */
+    void *async_state;
 }
 fclaw3d_domain_partition_t;
 
 fclaw3d_domain_partition_t
     * fclaw3d_domain_iterate_pack (fclaw3d_domain_t * domain,
+                                   size_t data_size,
                                    fclaw3d_pack_callback_t patch_pack,
                                    void *user);
 

--- a/src/forestclaw3d.h
+++ b/src/forestclaw3d.h
@@ -930,6 +930,19 @@ typedef struct fclaw3d_domain_partition
 }
 fclaw3d_domain_partition_t;
 
+fclaw3d_domain_partition_t
+    * fclaw3d_domain_iterate_pack (fclaw3d_domain_t * domain,
+                                   fclaw3d_pack_callback_t patch_pack,
+                                   void *user);
+
+void fclaw3d_domain_iterate_transfer (fclaw3d_domain_t * domain,
+                                      fclaw3d_domain_partition_t * p,
+                                      fclaw3d_transfer_callback_t
+                                      patch_transfer, void *user);
+
+void fclaw3d_domain_partition_free (fclaw3d_domain_t * domain,
+                                    fclaw3d_domain_partition_t * p);
+
 /** Free buffers that were used in transfering data during partition.
  * \param [in,out] domain       The memory lives inside this domain.
  * \param [in,out] patch_data   Address of an array of void pointers to free.

--- a/src/forestclaw3d.h
+++ b/src/forestclaw3d.h
@@ -897,7 +897,8 @@ void fclaw3d_domain_retrieve_after_partition (fclaw3d_domain_t * domain,
  * \param [in] new_patchno      Number of the iterated patch wrt. the new
  *                              domain and partition.
  * \param [in,out] user         Pointer passed to \ref
- *                              fclaw3d_domain_iterate_partitioned.
+ *                              fclaw3d_domain_iterate_partitioned or
+ *                              \ref fclaw3d_domain_iterate_transfer.
  */
 typedef void (*fclaw3d_transfer_callback_t) (fclaw3d_domain_t * old_domain,
                                              fclaw3d_patch_t * old_patch,
@@ -919,17 +920,7 @@ void fclaw3d_domain_iterate_partitioned (fclaw3d_domain_t * old_domain,
                                          fclaw3d_transfer_callback_t tcb,
                                          void *user);
 
-typedef void (*fclaw3d_pack_callback_t) (fclaw3d_domain_t * domain,
-                                         fclaw3d_patch_t * patch, int blockno,
-                                         int patchno, void *pack_data_here,
-                                         void *user);
-
-typedef void (*fclaw3d_unpack_callback_t) (fclaw3d_domain_t * domain,
-                                           fclaw3d_patch_t * patch,
-                                           int blockno, int patchno,
-                                           void *unpack_data_from_here,
-                                           void *user);
-
+/** Data structure for storing allocated data for partition transfer. */
 typedef struct fclaw3d_domain_partition
 {
     sc_array_t *src_data; /**< The patch data to send */
@@ -941,22 +932,102 @@ typedef struct fclaw3d_domain_partition
 }
 fclaw3d_domain_partition_t;
 
+/** Callback to pack patch data after partitioning.
+ * We traverse every local patch in the old partition. If that patch has to be
+ * packed for the new partition, we invoke this callback.
+ * \param [in,out] domain   Domain before partition.
+ * \param [in,out] patch    Patch from the domain. Its user data should be
+                            packed into \b pack_data_here.
+ * \param [in] blockno      Number of the current block.
+ * \param [in] patchno      Number of the patch.
+ * \param [in] pack_data_here Address of storage space for the patch's user data.
+ * \param [in,out] user     Pointer passed to \ref fclaw3d_domain_iterate_pack.
+ */
+typedef void (*fclaw3d_pack_callback_t) (fclaw3d_domain_t * domain,
+                                         fclaw3d_patch_t * patch, int blockno,
+                                         int patchno, void *pack_data_here,
+                                         void *user);
+
+/** Start asynchronous transfer of patch data after partition.
+ * The function iterates over all local patches of old partition and determines
+ * patches that have to be packed by use of \b patch_pack and send to the new
+ * partition.
+ * It must be followed by a call to \ref fclaw3d_domain_iterate_unpack.
+ * \param [in,out] domain       The domain before partitioning.
+ * \param [in] data_size        The number of bytes of user data that has to be
+ *                              packed and send per patch.
+ * \param [in] patch_pack       Callback function to pack patch user data into
+ *                              a provided storage address.
+ * \param [in] user             This pointer is passed to the callback.
+ * \return                      Allocated and initialized structure containing
+ *                              internal information for patch data transfer.
+ */
 fclaw3d_domain_partition_t
     * fclaw3d_domain_iterate_pack (fclaw3d_domain_t * domain,
                                    size_t data_size,
                                    fclaw3d_pack_callback_t patch_pack,
                                    void *user);
 
+/** Transfer data of patches still local after partition.
+ * The function iterates over all pairs of local patches in the domain before
+ * and after partitioning and invokes the transfer of their user-data via
+ * \ref patch_transfer.
+ * It may be called before, between or after \ref fclaw3d_domain_iterate_pack
+ * and \ref fclaw3d_domain_iterate_unpack. It is recommended to call it between
+ * packing and unpacking, to overlap communication with computation.
+ * \param [in,out] old_domain   The domain before partitioning.
+ * \param [in,out] new_domain   The domain after partitioning.
+ * \param [in] patch_transfer   Callback function to transfer user data between
+ *                              local old and new patch, e.g. by a copy
+ *                              or reassignment.
+ * \param [in] user             This pointer is passed to the callback.
+ */
 void fclaw3d_domain_iterate_transfer (fclaw3d_domain_t * old_domain,
                                       fclaw3d_domain_t * new_domain,
                                       fclaw3d_transfer_callback_t
                                       patch_transfer, void *user);
 
+/** Callback to unpack patch data after partitioning.
+ * We traverse every local patch, that was not local before partitioning.
+ * \param [in,out] domain   Domain after partition.
+ * \param [in,out] patch    Patch from the domain. Its user data should be
+                            unpacked from \b unpack_data_from_here.
+ * \param [in] blockno      Number of the current block.
+ * \param [in] patchno      Number of the patch.
+ * \param [in] unpack_data_from_here Address of storage space that contains the
+                            packed user data of the patch.
+ * \param [in,out] user     Pointer passed to \ref fclaw3d_domain_iterate_unpack.
+ */
+typedef void (*fclaw3d_unpack_callback_t) (fclaw3d_domain_t * domain,
+                                           fclaw3d_patch_t * patch,
+                                           int blockno, int patchno,
+                                           void *unpack_data_from_here,
+                                           void *user);
+
+/** Complete asynchronous transfer of patch data after partition.
+ * The function iterates over all local patches of new partition and determines
+ * patches that have to be unpacked by use of \b patch_unpack.
+ * It must be preceded by a call to \ref fclaw3d_domain_iterate_unpack and
+ * provided with the corresponding \ref fclaw3d_domain_partition_t \b p.
+ * \param [in,out] domain       The domain after partitioning.
+ * \param [in,out] p            Structure containing internal information for
+ *                              the patch data transfer.
+ * \param [in] patch_pack       Callback function to unpack patch user data from
+ *                              a provided storage address.
+ * \param [in] user             This pointer is passed to the callback.
+ * \return                      Allocated and initialized structure containing
+ *                              internal information for patch data transfer.
+ */
 void fclaw3d_domain_iterate_unpack (fclaw3d_domain_t * domain,
                                     fclaw3d_domain_partition_t * p,
                                     fclaw3d_unpack_callback_t patch_unpack,
                                     void *user);
 
+/** Free buffers used in transfering patch data during partition.
+ * \param [in] p                Structure containing internal information for
+ *                              patch data transfer. Will be deallocated during
+ *                              this function call.
+ */
 void fclaw3d_domain_partition_free (fclaw3d_domain_partition_t * p);
 
 /** Free buffers that were used in transfering data during partition.


### PR DESCRIPTION
This PR adds a new interface for partitioning patch data in different modes, with one of them being already implemented.

We introduce a new workflow for partitioning patch data:
1. The patch data is packed into send buffers by calling `fclaw2d_domain_iterate_pack`. The function receives a user-defined `fclaw2d_pack_callback_t`, which packs the data of a patch into a provided storage location. Then the function starts sending the packed data according to the new partition boundaries.
2. While waiting for the communication to complete, the data of patches which stay local can be transferred between the old and the new domain with `fclaw2d_domain_iterate_transfer`.  The function uses a `fclaw2d_transfer_callback_t`, which may be a simple copy or reassignment of the patch data. `fclaw2d_domain_iterate_transfer` may be called before `iterate_pack` or after `iterate_unpack` instead.
3. Every call to `fclaw2d_domain_iterate_pack` has to be succeeded by a call to `fclaw2d_domain_iterate_unpack`. This function unpacks the repartitioned patch data it received by a user-defined `fclaw2d_unpack_callback_t`.
4. Finally, a call to `fclaw2d_domain_partition_free` frees all partition-specific context data.

The workflow has to be called after `fclaw2d_domain_partition`, which repartitions the patches without the patch data and updates the partition boundaries as required.
For now we keep the old workflow of using `assign_before_partition`, `retrieve_after_partition` and `iterate_partitioned`. It may be useful for writing a comparison paper on different partitioning modes.

The implementation currently comes with a single mode that packs all patches into the send buffer, even if they are not sent after all. For future additional modes, we propose to add two partitioning options, `skip_local` and `skip_refine`, which can be combined arbitrarily:
* With `skip_local` enabled, we pack data only for the patches that change process during repartitioning.
* With `skip_refine` enabled, we change the packing behavior for the last level of newly refined patches. To achieve this, we save the local patch indices of newly refined patches during the last call to `{domain,wrap}_adapt`. Based on these indices, only the first child of a family of newly refined patches calls the `fclaw2d_pack_callback_t`. Subsequently, the `fclaw2d_unpack_callback_t` is called for all children with the packed data from the first child.

Does this interface with the corresponding options seem convenient to you? We would appreciate your feedback/ideas on this topic!
