### PR TITLE
Fix varpoisson ThunderEgg example

### DIFF
--- a/src/solvers/fc2d_thunderegg/operators/fc2d_thunderegg_varpoisson.cpp
+++ b/src/solvers/fc2d_thunderegg/operators/fc2d_thunderegg_varpoisson.cpp
@@ -397,10 +397,10 @@ void fc2d_thunderegg_varpoisson_solve(fclaw_global_t *glob)
     // set the patch solver
     Iterative::CG<2> patch_cg;
     patch_cg.setTolerance(mg_opt->patch_iter_tol);
-    patch_cg.setTolerance(mg_opt->patch_iter_max_it);
+    patch_cg.setMaxIterations(mg_opt->patch_iter_max_it);
     Iterative::BiCGStab<2> patch_bicg;
     patch_bicg.setTolerance(mg_opt->patch_iter_tol);
-    patch_bicg.setTolerance(mg_opt->patch_iter_max_it);
+    patch_bicg.setMaxIterations(mg_opt->patch_iter_max_it);
 
     Iterative::Solver<2>* patch_iterative_solver = nullptr;
     switch(mg_opt->patch_solver){


### PR DESCRIPTION
The max iterations option was setting the tolerance instead of setting the max iterations.