### PR TITLE
Change storage of options and vtables

### DIFF
--- a/src/fclaw_diagnostics.c
+++ b/src/fclaw_diagnostics.c
@@ -30,7 +30,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <fclaw_options.h>
 
 #include <fclaw_gauges.h>
-#include <fclaw_pointer_map.h>
 
 static
 fclaw_diagnostics_vtable_t* diagnostics_vt_new()
@@ -56,7 +55,7 @@ void diagnostics_accumulator_destroy(void* acc)
 fclaw_diagnostics_vtable_t* fclaw_diagnostics_vt(fclaw_global_t* glob)
 {
 	fclaw_diagnostics_vtable_t* diagnostics_vt = (fclaw_diagnostics_vtable_t*) 
-	   							fclaw_pointer_map_get(glob->vtables, "fclaw2d_diagnostics");
+	   							fclaw_global_get_vtable(glob, "fclaw2d_diagnostics");
 	FCLAW_ASSERT(diagnostics_vt != NULL);
 	FCLAW_ASSERT(diagnostics_vt->is_set != 0);
     return diagnostics_vt;
@@ -97,8 +96,7 @@ void fclaw_diagnostics_vtable_initialize(fclaw_global_t* glob)
 
     diag_vt->is_set = 1;
 
-	FCLAW_ASSERT(fclaw_pointer_map_get(glob->vtables,"fclaw2d_diagnostics") == NULL);
-	fclaw_pointer_map_insert(glob->vtables, "fclaw2d_diagnostics", diag_vt, diagnostics_vt_destroy);
+	fclaw_global_vtable_store(glob, "fclaw2d_diagnostics", diag_vt, diagnostics_vt_destroy);
 }
 
 

--- a/src/fclaw_diagnostics.h.TEST.cpp
+++ b/src/fclaw_diagnostics.h.TEST.cpp
@@ -54,15 +54,15 @@ TEST_CASE("fclaw_diagnostics_vtable_initialize sets is_set flag")
 
 #ifdef FCLAW_ENABLE_DEBUG
 
-TEST_CASE("fclaw_diagnostics_vtable_initialize fails if called twice on a glob")
+TEST_CASE("fclaw_diagnostics_vtable_initialize called twice on a glob")
 {
 	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_diagnostics_vtable_initialize(glob1);
-	CHECK_SC_ABORTED(fclaw_diagnostics_vtable_initialize(glob1));
+	fclaw_diagnostics_vtable_initialize(glob1);
 	fclaw_diagnostics_vtable_initialize(glob2);
-	CHECK_SC_ABORTED(fclaw_diagnostics_vtable_initialize(glob2));
+	fclaw_diagnostics_vtable_initialize(glob2);
 
 	fclaw_global_destroy(glob1);
 	fclaw_global_destroy(glob2);

--- a/src/fclaw_elliptic_solver.c
+++ b/src/fclaw_elliptic_solver.c
@@ -23,8 +23,6 @@
   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <fclaw_pointer_map.h>
-
 #include <fclaw_elliptic_solver.h>
 #include <fclaw_global.h>
 
@@ -142,8 +140,7 @@ void fclaw_elliptic_vtable_initialize(fclaw_global_t* glob)
     /* User should set the setup, rhs and solve routines */
     elliptic_vt->is_set = 1;
 
-	FCLAW_ASSERT(fclaw_pointer_map_get(glob->vtables,"fclaw2d_elliptic") == NULL);
-	fclaw_pointer_map_insert(glob->vtables, "fclaw2d_elliptic", elliptic_vt, elliptic_vt_destroy);
+	fclaw_global_vtable_store(glob, "fclaw2d_elliptic", elliptic_vt, elliptic_vt_destroy);
 }
 
 /*----------------------------------- Access functions -------------------------------- */
@@ -151,7 +148,7 @@ void fclaw_elliptic_vtable_initialize(fclaw_global_t* glob)
 fclaw_elliptic_vtable_t* fclaw_elliptic_vt(fclaw_global_t* glob)
 {
 	fclaw_elliptic_vtable_t* elliptic_vt = (fclaw_elliptic_vtable_t*) 
-	   							fclaw_pointer_map_get(glob->vtables, "fclaw2d_elliptic");
+	   							fclaw_global_get_vtable(glob, "fclaw2d_elliptic");
 	FCLAW_ASSERT(elliptic_vt != NULL);
 	FCLAW_ASSERT(elliptic_vt->is_set != 0);
 	return elliptic_vt;

--- a/src/fclaw_elliptic_solver.h.TEST.cpp
+++ b/src/fclaw_elliptic_solver.h.TEST.cpp
@@ -54,15 +54,15 @@ TEST_CASE("fclaw_elliptic_vtable_initialize sets is_set flag")
 
 #ifdef FCLAW_ENABLE_DEBUG
 
-TEST_CASE("fclaw_elliptic_vtable_initialize fails if called twice on a glob")
+TEST_CASE("fclaw_elliptic_vtable_initialize called twice on a glob")
 {
 	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_elliptic_vtable_initialize(glob1);
-	CHECK_SC_ABORTED(fclaw_elliptic_vtable_initialize(glob1));
+	fclaw_elliptic_vtable_initialize(glob1);
 	fclaw_elliptic_vtable_initialize(glob2);
-	CHECK_SC_ABORTED(fclaw_elliptic_vtable_initialize(glob2));
+	fclaw_elliptic_vtable_initialize(glob2);
 
 	fclaw_global_destroy(glob1);
 	fclaw_global_destroy(glob2);

--- a/src/fclaw_gauges.c
+++ b/src/fclaw_gauges.c
@@ -25,8 +25,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <fclaw_gauges.h>
 
-#include <fclaw_pointer_map.h>
-
 #include <fclaw_options.h>
 #include <fclaw_global.h>
 #include <fclaw_convenience.h>  /* Needed to get search function for gauges */
@@ -459,7 +457,7 @@ void fclaw_gauges_vt_destroy(void* vt)
 fclaw_gauges_vtable_t* fclaw_gauges_vt(fclaw_global_t* glob)
 {
 	fclaw_gauges_vtable_t* gauges_vt = (fclaw_gauges_vtable_t*) 
-	   							fclaw_pointer_map_get(glob->vtables, "fclaw_gauges");
+	   							fclaw_global_get_vtable(glob, "fclaw_gauges");
 	FCLAW_ASSERT(gauges_vt != NULL);
 	FCLAW_ASSERT(gauges_vt->is_set != 0);
 
@@ -478,8 +476,7 @@ void fclaw_gauges_vtable_initialize(fclaw_global_t* glob)
 
     gauges_vt->is_set = 1;
 
-	FCLAW_ASSERT(fclaw_pointer_map_get(glob->vtables,"fclaw_gauges") == NULL);
-	fclaw_pointer_map_insert(glob->vtables, "fclaw_gauges", gauges_vt, fclaw_gauges_vt_destroy);
+	fclaw_global_vtable_store(glob, "fclaw_gauges", gauges_vt, fclaw_gauges_vt_destroy);
 }
 /* ---------------------------- Virtualized Functions --------------------------------- */
 

--- a/src/fclaw_gauges.h.TEST.cpp
+++ b/src/fclaw_gauges.h.TEST.cpp
@@ -59,18 +59,18 @@ TEST_CASE("fclaw_gauges_vtable_initialize sets is_set flag")
 
 #ifdef FCLAW_ENABLE_DEBUG
 
-TEST_CASE("fclaw_guages_vtable_initialize fails if called twice on a glob")
+TEST_CASE("fclaw_guages_vtable_initialize called twice on a glob")
 {
 	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_diagnostics_vtable_initialize(glob1);
 	fclaw_gauges_vtable_initialize(glob1);
-	CHECK_SC_ABORTED(fclaw_gauges_vtable_initialize(glob1));
+	fclaw_gauges_vtable_initialize(glob1);
 
 	fclaw_diagnostics_vtable_initialize(glob2);
 	fclaw_gauges_vtable_initialize(glob2);
-	CHECK_SC_ABORTED(fclaw_gauges_vtable_initialize(glob2));
+	fclaw_gauges_vtable_initialize(glob2);
 
 	fclaw_global_destroy(glob1);
 	fclaw_global_destroy(glob2);

--- a/src/fclaw_global.c
+++ b/src/fclaw_global.c
@@ -208,7 +208,6 @@ void fclaw_global_iterate_partitioned (fclaw_global_t * glob,
 void fclaw_global_options_store (fclaw_global_t* glob, const char* key, void* options)
 {
     
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->options,key) == NULL);
     fclaw_pointer_map_insert(glob->options, key, options, NULL);
 }
 

--- a/src/fclaw_global.h.TEST.cpp
+++ b/src/fclaw_global.h.TEST.cpp
@@ -395,10 +395,11 @@ TEST_CASE("fclaw_global_options_store and fclaw_global_get_options test") {
     const char** retrieved_option2 = static_cast<const char**>(fclaw_global_get_options(glob, key2));
     CHECK_EQ(retrieved_option2, &option2);
 
-#ifdef FCLAW_ENABLE_DEBUG
     // TEST inserting twice
-    CHECK_SC_ABORTED(fclaw_global_options_store(glob, key2, &option2));
-#endif
+	const char* option3 = "Test string 2";
+	fclaw_global_options_store(glob, key2, &option3);
+	CHECK_EQ(fclaw_global_get_options(glob, key2), &option3);
+
     // Test with a non-existing key
     const char* key3 = "non-existing key";
 #ifdef FCLAW_ENABLE_DEBUG

--- a/src/fclaw_options.h.TEST.cpp
+++ b/src/fclaw_options.h.TEST.cpp
@@ -68,19 +68,29 @@ TEST_CASE("fclaw_get_options fails if not intialized")
 	fclaw_global_destroy(glob2);
 }
 
-TEST_CASE("fclaw_options_store fails if called twice on a glob")
+TEST_CASE("fclaw_options_store called twice on a glob")
 {
 	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
-	fclaw_options_store(glob1, FCLAW_ALLOC_ZERO(fclaw_options_t,1));
-	CHECK_SC_ABORTED(fclaw_options_store(glob1, FCLAW_ALLOC_ZERO(fclaw_options_t,1)));
+	fclaw_options_t *opts1_1 = FCLAW_ALLOC_ZERO(fclaw_options_t,1);
+	fclaw_options_t *opts1_2 = FCLAW_ALLOC_ZERO(fclaw_options_t,1);
+	fclaw_options_store(glob1, opts1_1);
+	fclaw_options_store(glob1, opts1_2);
+	CHECK_EQ(fclaw_get_options(glob1), opts1_2);
 
-	fclaw_options_store(glob2, FCLAW_ALLOC_ZERO(fclaw_options_t,1));
-	CHECK_SC_ABORTED(fclaw_options_store(glob2, FCLAW_ALLOC_ZERO(fclaw_options_t,1)));
+	fclaw_options_t *opts2_1 = FCLAW_ALLOC_ZERO(fclaw_options_t,1);
+	fclaw_options_t *opts2_2 = FCLAW_ALLOC_ZERO(fclaw_options_t,1);
+	fclaw_options_store(glob2, opts2_1);
+	fclaw_options_store(glob2, opts2_2);
+	CHECK_EQ(fclaw_get_options(glob2), opts2_2);
 
 	fclaw_global_destroy(glob1);
 	fclaw_global_destroy(glob2);
+	FCLAW_FREE(opts1_1);
+	FCLAW_FREE(opts1_2);
+	FCLAW_FREE(opts2_1);
+	FCLAW_FREE(opts2_2);
 }
 
 #endif

--- a/src/fclaw_patch.c
+++ b/src/fclaw_patch.c
@@ -23,8 +23,6 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <fclaw_pointer_map.h>
-
 #include <fclaw_patch.h>
 #include <fclaw_global.h>
 #include <fclaw_domain.h>
@@ -915,8 +913,7 @@ void fclaw_patch_vtable_initialize(fclaw_global_t* glob)
 
 	patch_vt->is_set = 1;
 
-	FCLAW_ASSERT(fclaw_pointer_map_get(glob->vtables,"fclaw2d_patch") == NULL);
-	fclaw_pointer_map_insert(glob->vtables, "fclaw2d_patch", patch_vt, patch_vt_destroy);
+	fclaw_global_vtable_store(glob, "fclaw2d_patch", patch_vt, patch_vt_destroy);
 }
 
 /* ------------------------------ User access functions ------------------------------- */
@@ -924,7 +921,7 @@ void fclaw_patch_vtable_initialize(fclaw_global_t* glob)
 fclaw_patch_vtable_t* fclaw_patch_vt(fclaw_global_t* glob)
 {
 	fclaw_patch_vtable_t* patch_vt = (fclaw_patch_vtable_t*) 
-	   							fclaw_pointer_map_get(glob->vtables, "fclaw2d_patch");
+	   							fclaw_global_get_vtable(glob, "fclaw2d_patch");
 	FCLAW_ASSERT(patch_vt != NULL);
 	FCLAW_ASSERT(patch_vt->is_set != 0);
 	return patch_vt;

--- a/src/fclaw_patch.h.TEST.cpp
+++ b/src/fclaw_patch.h.TEST.cpp
@@ -54,15 +54,15 @@ TEST_CASE("fclaw_patch_vtable_initialize sets is_set flag")
 
 #ifdef FCLAW_ENABLE_DEBUG
 
-TEST_CASE("fclaw_patch_vtable_initialize fails if called twice on a glob")
+TEST_CASE("fclaw_patch_vtable_initialize called twice on a glob")
 {
 	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_patch_vtable_initialize(glob1);
-	CHECK_SC_ABORTED(fclaw_patch_vtable_initialize(glob1));
+	fclaw_patch_vtable_initialize(glob1);
 	fclaw_patch_vtable_initialize(glob2);
-	CHECK_SC_ABORTED(fclaw_patch_vtable_initialize(glob2));
+	fclaw_patch_vtable_initialize(glob2);
 
 	fclaw_global_destroy(glob1);
 	fclaw_global_destroy(glob2);

--- a/src/fclaw_rays.c
+++ b/src/fclaw_rays.c
@@ -30,8 +30,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <fclaw_convenience.h>
 
-#include <fclaw_pointer_map.h>
-
 
 //static fclaw2d_ray_vtable_t s_ray_vt;
 
@@ -311,8 +309,7 @@ void fclaw_ray_vtable_initialize(fclaw_global_t *glob)
 
     fclaw_ray_vtable_t* rays_vt = fclaw2d_ray_vt_new(); 
 
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->vtables,"fclaw2d_rays") == NULL);
-    fclaw_pointer_map_insert(glob->vtables, "fclaw2d_rays", rays_vt, fclaw2d_ray_vt_destroy);
+    fclaw_global_vtable_store(glob, "fclaw2d_rays", rays_vt, fclaw2d_ray_vt_destroy);
 
     rays_vt->is_set = 1;
 }
@@ -324,7 +321,7 @@ void fclaw_ray_vtable_initialize(fclaw_global_t *glob)
 fclaw_ray_vtable_t* fclaw_ray_vt(fclaw_global_t* glob)
 {
     fclaw_ray_vtable_t* ray_vt = (fclaw_ray_vtable_t*) 
-                                fclaw_pointer_map_get(glob->vtables, "fclaw2d_rays");
+                                fclaw_global_get_vtable(glob, "fclaw2d_rays");
     FCLAW_ASSERT(ray_vt != NULL);
     FCLAW_ASSERT(ray_vt->is_set != 0);
     return ray_vt;

--- a/src/fclaw_vtable.c
+++ b/src/fclaw_vtable.c
@@ -23,7 +23,6 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <fclaw_pointer_map.h>
 #include <fclaw_vtable.h>
 #include <fclaw_output.h>
 #include <fclaw_global.h>
@@ -45,7 +44,7 @@ void vt_destroy(void* vt)
 fclaw_vtable_t* fclaw_vt(fclaw_global_t *glob)
 {
 	fclaw_vtable_t* vt = (fclaw_vtable_t*) 
-	   							fclaw_pointer_map_get(glob->vtables, "fclaw2d");
+	   							fclaw_global_get_vtable(glob, "fclaw2d");
 	FCLAW_ASSERT(vt != NULL);
 	FCLAW_ASSERT(vt->is_set != 0);
 	return vt;
@@ -69,6 +68,5 @@ void fclaw_vtable_initialize(fclaw_global_t *glob)
 
     vt->is_set = 1;
 
-	FCLAW_ASSERT(fclaw_pointer_map_get(glob->vtables,"fclaw2d") == NULL);
-	fclaw_pointer_map_insert(glob->vtables, "fclaw2d", vt, vt_destroy);
+    fclaw_global_vtable_store(glob, "fclaw2d", vt, vt_destroy);
 }

--- a/src/fclaw_vtable.h.TEST.cpp
+++ b/src/fclaw_vtable.h.TEST.cpp
@@ -54,15 +54,15 @@ TEST_CASE("fclaw_vtable_initialize sets is_set flag")
 
 #ifdef FCLAW_ENABLE_DEBUG
 
-TEST_CASE("fclaw_vtable_initialize fails if called twice on a glob")
+TEST_CASE("fclaw_vtable_initialize called twice on a glob")
 {
 	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw_vtable_initialize(glob1);
-	CHECK_SC_ABORTED(fclaw_vtable_initialize(glob1));
+	fclaw_vtable_initialize(glob1);
 	fclaw_vtable_initialize(glob2);
-	CHECK_SC_ABORTED(fclaw_vtable_initialize(glob2));
+	fclaw_vtable_initialize(glob2);
 
 	fclaw_global_destroy(glob1);
 	fclaw_global_destroy(glob2);

--- a/src/patches/clawpatch/fclaw_clawpatch.cpp
+++ b/src/patches/clawpatch/fclaw_clawpatch.cpp
@@ -66,8 +66,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <fclaw_map_query.h>
 
-#include <fclaw_pointer_map.h>
-
 
 
 /* ------------------------------- Static function defs ------------------------------- */
@@ -1952,12 +1950,7 @@ void fclaw_clawpatch_vtable_initialize(fclaw_global_t* glob,
 
     clawpatch_vt->is_set = 1;
 
-    if(fclaw_pointer_map_get(glob->vtables, "fclaw_clawpatch") != NULL)
-    {
-        fclaw_abortf("fclaw_clawpatch_vtable_initialize : " \
-                    "fclaw_clawpatch already initialized\n");
-    }
-    fclaw_pointer_map_insert(glob->vtables, "fclaw_clawpatch", clawpatch_vt, clawpatch_vt_destroy);
+    fclaw_global_vtable_store(glob, "fclaw_clawpatch", clawpatch_vt, clawpatch_vt_destroy);
 }
 
 /* ------------------------------- Public access functions ---------------------------- */
@@ -1975,7 +1968,7 @@ fclaw_clawpatch_vtable_t* fclaw_clawpatch_vt(fclaw_global_t* glob)
 {
 
     fclaw_clawpatch_vtable_t* clawpatch_vt = (fclaw_clawpatch_vtable_t*) 
-                          fclaw_pointer_map_get(glob->vtables, "fclaw_clawpatch");
+                          fclaw_global_get_vtable(glob, "fclaw_clawpatch");
     FCLAW_ASSERT(clawpatch_vt != nullptr);
     FCLAW_ASSERT(clawpatch_vt->is_set != 0);
     return clawpatch_vt;

--- a/src/patches/clawpatch/fclaw_clawpatch.h.2d.TEST.cpp
+++ b/src/patches/clawpatch/fclaw_clawpatch.h.2d.TEST.cpp
@@ -124,7 +124,7 @@ TEST_CASE("3dx fclaw_clawpatch_vtable_initialize sets is_set flag")
 
 
 
-TEST_CASE("2d fclaw_clawpatch_vtable_initialize fails if called twice on a glob")
+TEST_CASE("2d fclaw_clawpatch_vtable_initialize called twice on a glob")
 {
 	fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 1);
 	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
@@ -140,9 +140,9 @@ TEST_CASE("2d fclaw_clawpatch_vtable_initialize fails if called twice on a glob"
 	fclaw_vtables_initialize(glob2);
 
 	fclaw_clawpatch_vtable_initialize(glob1,4);
-	CHECK_SC_ABORTED(fclaw_clawpatch_vtable_initialize(glob1,4));
+	fclaw_clawpatch_vtable_initialize(glob1,4);
 	fclaw_clawpatch_vtable_initialize(glob2,4);
-	CHECK_SC_ABORTED(fclaw_clawpatch_vtable_initialize(glob2,4));
+	fclaw_clawpatch_vtable_initialize(glob2,4);
 
 	fclaw_clawpatch_options_destroy(opts);
 	fclaw_domain_destroy(domain);
@@ -150,7 +150,7 @@ TEST_CASE("2d fclaw_clawpatch_vtable_initialize fails if called twice on a glob"
 	fclaw_global_destroy(glob2);
 }
 
-TEST_CASE("3dx fclaw_clawpatch_vtable_initialize fails if called twice on a glob")
+TEST_CASE("3dx fclaw_clawpatch_vtable_initialize called twice on a glob")
 {
 	fclaw_domain_t* domain = fclaw_domain_new_unitsquare(sc_MPI_COMM_WORLD, 1);
 	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
@@ -166,9 +166,9 @@ TEST_CASE("3dx fclaw_clawpatch_vtable_initialize fails if called twice on a glob
 	fclaw_vtables_initialize(glob2);
 
 	fclaw_clawpatch_vtable_initialize(glob1,4);
-	CHECK_SC_ABORTED(fclaw_clawpatch_vtable_initialize(glob1,4));
+	fclaw_clawpatch_vtable_initialize(glob1,4);
 	fclaw_clawpatch_vtable_initialize(glob2,4);
-	CHECK_SC_ABORTED(fclaw_clawpatch_vtable_initialize(glob2,4));
+	fclaw_clawpatch_vtable_initialize(glob2,4);
 
 	fclaw_clawpatch_options_destroy(opts);
 	fclaw_domain_destroy(domain);

--- a/src/patches/clawpatch/fclaw_clawpatch_options.h.TEST.cpp
+++ b/src/patches/clawpatch/fclaw_clawpatch_options.h.TEST.cpp
@@ -86,22 +86,28 @@ TEST_CASE("fclaw_clawpatch_get_options fails if not intialized")
 	fclaw_global_destroy(glob2);
 }
 
-TEST_CASE("fclaw_clawpatch_options_store fails if called twice on a glob")
+TEST_CASE("fclaw_clawpatch_options_store called twice on a glob")
 {
 	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
-	fclaw_clawpatch_options_t* opts1 = fclaw_clawpatch_options_new(2);
-	fclaw_clawpatch_options_t* opts2 = fclaw_clawpatch_options_new(3);
+	fclaw_clawpatch_options_t* opts1_1 = fclaw_clawpatch_options_new(2);
+	fclaw_clawpatch_options_t* opts1_2 = fclaw_clawpatch_options_new(2);
+	fclaw_clawpatch_options_t* opts2_1 = fclaw_clawpatch_options_new(3);
+	fclaw_clawpatch_options_t* opts2_2 = fclaw_clawpatch_options_new(3);
 
-	fclaw_clawpatch_options_store(glob1, opts1);
-	CHECK_SC_ABORTED(fclaw_clawpatch_options_store(glob1, FCLAW_ALLOC_ZERO(fclaw_clawpatch_options_t,1)));
+	fclaw_clawpatch_options_store(glob1, opts1_1);
+	fclaw_clawpatch_options_store(glob1, opts1_2);
+	CHECK_EQ(fclaw_clawpatch_get_options(glob1), opts1_2);
 
-	fclaw_clawpatch_options_store(glob2, opts2);
-	CHECK_SC_ABORTED(fclaw_clawpatch_options_store(glob2, FCLAW_ALLOC_ZERO(fclaw_clawpatch_options_t,1)));
+	fclaw_clawpatch_options_store(glob2, opts2_1);
+	fclaw_clawpatch_options_store(glob2, opts2_2);
+	CHECK_EQ(fclaw_clawpatch_get_options(glob2), opts2_2);
 
-	fclaw_clawpatch_options_destroy(opts1);
-	fclaw_clawpatch_options_destroy(opts2);
+	fclaw_clawpatch_options_destroy(opts1_1);
+	fclaw_clawpatch_options_destroy(opts1_2);
+	fclaw_clawpatch_options_destroy(opts2_1);
+	fclaw_clawpatch_options_destroy(opts2_2);
 	fclaw_global_destroy(glob1);
 	fclaw_global_destroy(glob2);
 }

--- a/src/patches/clawpatch/fclaw_clawpatch_pillow.c
+++ b/src/patches/clawpatch/fclaw_clawpatch_pillow.c
@@ -38,8 +38,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <fclaw3d_metric.h>
 
-#include <fclaw_pointer_map.h>
-
 struct fclaw_patch_transform_data;  /* Not used here, so we leave it incomplete */
 
 static
@@ -267,9 +265,7 @@ void fclaw_clawpatch_pillow_vtable_initialize(fclaw_global_t* glob,
 
     pillow_vt->is_set = 1;
 
-    FCLAW_ASSERT(fclaw_pointer_map_get(glob->vtables, "fclaw_clawpatch_pillow_vtable") == NULL);
-    fclaw_pointer_map_insert(glob->vtables, "fclaw_clawpatch_pillow_vtable", pillow_vt, pillow_vt_destroy);
-
+    fclaw_global_vtable_store(glob, "fclaw_clawpatch_pillow_vtable", pillow_vt, pillow_vt_destroy);
 }
 
 /* ------------------------------- Public access functions ---------------------------- */
@@ -279,8 +275,8 @@ fclaw_clawpatch_pillow_vtable_t* fclaw_clawpatch_pillow_vt(fclaw_global_t* glob)
 {
 
     fclaw_clawpatch_pillow_vtable_t* pillow_vt = (fclaw_clawpatch_pillow_vtable_t*) 
-        fclaw_pointer_map_get(glob->vtables, 
-                              "fclaw_clawpatch_pillow_vtable");
+        fclaw_global_get_vtable(glob, 
+                                "fclaw_clawpatch_pillow_vtable");
 
     FCLAW_ASSERT(pillow_vt != NULL);
     FCLAW_ASSERT(pillow_vt->is_set != 0);

--- a/src/patches/metric/fclaw2d_metric.cpp
+++ b/src/patches/metric/fclaw2d_metric.cpp
@@ -35,8 +35,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "fclaw2d_metric.h"
 #include "fclaw2d_metric.hpp"
 
-#include <fclaw_pointer_map.h>
-
 #include <fclaw_global.h>
 #include <fclaw_patch.h>  
 
@@ -311,7 +309,7 @@ void metric_vt_destroy(void* vt)
 fclaw2d_metric_vtable_t* fclaw2d_metric_vt(fclaw_global_t* glob)
 {
 	fclaw2d_metric_vtable_t* metric_vt = (fclaw2d_metric_vtable_t*) 
-	   							fclaw_pointer_map_get(glob->vtables, METRIC_VTABLE_NAME);
+	   							fclaw_global_get_vtable(glob, METRIC_VTABLE_NAME);
 	FCLAW_ASSERT(metric_vt != NULL);
 	FCLAW_ASSERT(metric_vt->is_set != 0);
 	return metric_vt;
@@ -336,11 +334,7 @@ void fclaw2d_metric_vtable_initialize(fclaw_global_t* glob)
 
     metric_vt->is_set = 1;
 
-	if(fclaw_pointer_map_get(glob->vtables,METRIC_VTABLE_NAME) != NULL)
-    {
-        fclaw_abortf("Metric vtable %s already set\n",METRIC_VTABLE_NAME);
-    }
-	fclaw_pointer_map_insert(glob->vtables,METRIC_VTABLE_NAME, metric_vt, metric_vt_destroy);
+	fclaw_global_vtable_store(glob, METRIC_VTABLE_NAME, metric_vt, metric_vt_destroy);
 }
 
 

--- a/src/patches/metric/fclaw2d_metric.h.TEST.cpp
+++ b/src/patches/metric/fclaw2d_metric.h.TEST.cpp
@@ -54,15 +54,15 @@ TEST_CASE("fclaw2d_metric_vtable_initialize sets is_set flag")
 
 #ifdef FCLAW_ENABLE_DEBUG
 
-TEST_CASE("fclaw2d_metric_vtable_initialize fails if called twice on a glob")
+TEST_CASE("fclaw2d_metric_vtable_initialize called twice on a glob")
 {
 	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
 	fclaw2d_metric_vtable_initialize(glob1);
-	CHECK_SC_ABORTED(fclaw2d_metric_vtable_initialize(glob1));
+	fclaw2d_metric_vtable_initialize(glob1);
 	fclaw2d_metric_vtable_initialize(glob2);
-	CHECK_SC_ABORTED(fclaw2d_metric_vtable_initialize(glob2));
+	fclaw2d_metric_vtable_initialize(glob2);
 
 	fclaw_global_destroy(glob1);
 	fclaw_global_destroy(glob2);

--- a/src/patches/metric/fclaw3d_metric.cpp
+++ b/src/patches/metric/fclaw3d_metric.cpp
@@ -33,8 +33,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "fclaw3d_metric.h"
 #include "fclaw3d_metric.hpp"
 
-#include <fclaw_pointer_map.h>
-
 #include <fclaw_global.h>
 #include <fclaw_patch.h>  
 #include <fclaw3d_defs.h>
@@ -339,7 +337,7 @@ void metric_vt_destroy(void* vt)
 fclaw3d_metric_vtable_t* fclaw3d_metric_vt(fclaw_global_t* glob)
 {
 	fclaw3d_metric_vtable_t* metric_vt = (fclaw3d_metric_vtable_t*) 
-	   							fclaw_pointer_map_get(glob->vtables, METRIC_VTABLE_NAME);
+	   							fclaw_global_get_vtable(glob, METRIC_VTABLE_NAME);
 	FCLAW_ASSERT(metric_vt != NULL);
 	FCLAW_ASSERT(metric_vt->is_set != 0);
 	return metric_vt;
@@ -363,11 +361,7 @@ void fclaw3d_metric_vtable_initialize(fclaw_global_t* glob)
 
     metric_vt->is_set = 1;
 
-	if(fclaw_pointer_map_get(glob->vtables,METRIC_VTABLE_NAME) != NULL)
-    {
-        fclaw_abortf("Metric vtable %s already set\n",METRIC_VTABLE_NAME);
-    }
-	fclaw_pointer_map_insert(glob->vtables,METRIC_VTABLE_NAME, metric_vt, metric_vt_destroy);
+	fclaw_global_vtable_store(glob, METRIC_VTABLE_NAME, metric_vt, metric_vt_destroy);
 }
 
 

--- a/src/solvers/fc2d_clawpack4.6/fc2d_clawpack46.cpp
+++ b/src/solvers/fc2d_clawpack4.6/fc2d_clawpack46.cpp
@@ -46,8 +46,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <fclaw_options.h>
 #include <fclaw2d_defs.h>
 
-#include <fclaw_pointer_map.h>
-
 
 /* --------------------- Clawpack solver functions (required) ------------------------- */
 
@@ -543,8 +541,7 @@ void fc2d_clawpack46_solver_initialize(fclaw_global_t* glob)
 
 	claw46_vt->is_set = 1;
 
-	FCLAW_ASSERT(fclaw_pointer_map_get(glob->vtables,"fc2d_clawpack46") == NULL);
-	fclaw_pointer_map_insert(glob->vtables, "fc2d_clawpack46", claw46_vt, clawpack46_vt_destroy);
+	fclaw_global_vtable_store(glob, "fc2d_clawpack46", claw46_vt, clawpack46_vt_destroy);
 }
 
 
@@ -556,7 +553,7 @@ void fc2d_clawpack46_solver_initialize(fclaw_global_t* glob)
 fc2d_clawpack46_vtable_t* fc2d_clawpack46_vt(fclaw_global_t* glob)
 {
 	fc2d_clawpack46_vtable_t* claw46_vt = (fc2d_clawpack46_vtable_t*) 
-	   							fclaw_pointer_map_get(glob->vtables, "fc2d_clawpack46");
+	   							fclaw_global_get_vtable(glob, "fc2d_clawpack46");
 	FCLAW_ASSERT(claw46_vt != NULL);
 	FCLAW_ASSERT(claw46_vt->is_set != 0);
 	return claw46_vt;

--- a/src/solvers/fc2d_clawpack4.6/fc2d_clawpack46.h.TEST.cpp
+++ b/src/solvers/fc2d_clawpack4.6/fc2d_clawpack46.h.TEST.cpp
@@ -111,7 +111,7 @@ TEST_CASE("fc2d_clawpack46_vt fails if not intialized")
 	fclaw_global_destroy(glob2);
 }
 
-TEST_CASE("fc2d_clawpack46_vtable_initialize fails if called twice on a glob")
+TEST_CASE("fc2d_clawpack46_vtable_initialize called twice on a glob")
 {
 	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
@@ -125,21 +125,23 @@ TEST_CASE("fc2d_clawpack46_vtable_initialize fails if called twice on a glob")
 	fclaw_clawpatch_options_store(glob1, clawpatch_opts);
 	fclaw_clawpatch_options_store(glob2, clawpatch_opts);
 
-	fc2d_clawpack46_options_store(glob1, FCLAW_ALLOC_ZERO(fc2d_clawpack46_options_t,1));
-	fc2d_clawpack46_options_store(glob2, FCLAW_ALLOC_ZERO(fc2d_clawpack46_options_t,1));
+	fc2d_clawpack46_options_t * clawpack_opts = FCLAW_ALLOC_ZERO(fc2d_clawpack46_options_t,1);
+	fc2d_clawpack46_options_store(glob1, clawpack_opts);
+	fc2d_clawpack46_options_store(glob2, clawpack_opts);
 
 	fclaw_vtables_initialize(glob1);
 	fc2d_clawpack46_solver_initialize(glob1);
-	CHECK_SC_ABORTED(fc2d_clawpack46_solver_initialize(glob1));
+	fc2d_clawpack46_solver_initialize(glob1);
 
 	fclaw_vtables_initialize(glob2);
 	fc2d_clawpack46_solver_initialize(glob2);
-	CHECK_SC_ABORTED(fc2d_clawpack46_solver_initialize(glob2));
+	fc2d_clawpack46_solver_initialize(glob2);
 
 	fclaw_domain_destroy(domain);
 	fclaw_global_destroy(glob1);
 	fclaw_global_destroy(glob2);
 	fclaw_clawpatch_options_destroy(clawpatch_opts);
+	FCLAW_FREE(clawpack_opts);
 }
 
 #endif

--- a/src/solvers/fc2d_clawpack4.6/fc2d_clawpack46_options.h.TEST.cpp
+++ b/src/solvers/fc2d_clawpack4.6/fc2d_clawpack46_options.h.TEST.cpp
@@ -68,17 +68,28 @@ TEST_CASE("fc2d_clawpack46_get_options fails if not intialized")
 	fclaw_global_destroy(glob2);
 }
 
-TEST_CASE("fc2d_clawpack46_options_store fails if called twice on a glob")
+TEST_CASE("fc2d_clawpack46_options_store called twice on a glob")
 {
 	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
-	fc2d_clawpack46_options_store(glob1, FCLAW_ALLOC_ZERO(fc2d_clawpack46_options_t,1));
-	CHECK_SC_ABORTED(fc2d_clawpack46_options_store(glob1, FCLAW_ALLOC_ZERO(fc2d_clawpack46_options_t,1)));
+	fc2d_clawpack46_options_t* opts1_1 = FCLAW_ALLOC_ZERO(fc2d_clawpack46_options_t,1);
+	fc2d_clawpack46_options_t* opts1_2 = FCLAW_ALLOC_ZERO(fc2d_clawpack46_options_t,1);
+	fc2d_clawpack46_options_t* opts2_1 = FCLAW_ALLOC_ZERO(fc2d_clawpack46_options_t,1);
+	fc2d_clawpack46_options_t* opts2_2 = FCLAW_ALLOC_ZERO(fc2d_clawpack46_options_t,1);
 
-	fc2d_clawpack46_options_store(glob2, FCLAW_ALLOC_ZERO(fc2d_clawpack46_options_t,1));
-	CHECK_SC_ABORTED(fc2d_clawpack46_options_store(glob2, FCLAW_ALLOC_ZERO(fc2d_clawpack46_options_t,1)));
+	fc2d_clawpack46_options_store(glob1, opts1_1);
+	fc2d_clawpack46_options_store(glob1, opts1_2);
+	CHECK_EQ(fc2d_clawpack46_get_options(glob1), opts1_2);
 
+	fc2d_clawpack46_options_store(glob2, opts2_1);
+	fc2d_clawpack46_options_store(glob2, opts2_2);
+	CHECK_EQ(fc2d_clawpack46_get_options(glob2), opts2_2);
+
+	FCLAW_FREE(opts1_1);
+	FCLAW_FREE(opts1_2);
+	FCLAW_FREE(opts2_1);
+	FCLAW_FREE(opts2_2);
 	fclaw_global_destroy(glob1);
 	fclaw_global_destroy(glob2);
 }

--- a/src/solvers/fc2d_clawpack5/fc2d_clawpack5.cpp
+++ b/src/solvers/fc2d_clawpack5/fc2d_clawpack5.cpp
@@ -28,8 +28,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "fc2d_clawpack5_options.h"
 
 
-#include <fclaw_pointer_map.h>
-
 #include <fclaw_clawpatch.h>
 #include <fclaw_clawpatch_options.h>
 #include <fclaw_clawpatch.hpp>
@@ -493,8 +491,7 @@ void fc2d_clawpack5_solver_initialize(fclaw_global_t* glob)
 
     claw5_vt->is_set = 1;
 
-	FCLAW_ASSERT(fclaw_pointer_map_get(glob->vtables,"fc2d_clawpack5") == NULL);
-	fclaw_pointer_map_insert(glob->vtables, "fc2d_clawpack5", claw5_vt, fc2d_clawpack5_vt_destroy);
+	fclaw_global_vtable_store(glob, "fc2d_clawpack5", claw5_vt, fc2d_clawpack5_vt_destroy);
 }
 
 
@@ -506,7 +503,7 @@ void fc2d_clawpack5_solver_initialize(fclaw_global_t* glob)
 fc2d_clawpack5_vtable_t* fc2d_clawpack5_vt(fclaw_global_t* glob)
 {
     fc2d_clawpack5_vtable_t* claw5_vt = (fc2d_clawpack5_vtable_t*) 
-	   							fclaw_pointer_map_get(glob->vtables, "fc2d_clawpack5");
+	   							fclaw_global_get_vtable(glob, "fc2d_clawpack5");
 	FCLAW_ASSERT(claw5_vt != NULL);
 	FCLAW_ASSERT(claw5_vt->is_set != 0);
 	return claw5_vt;

--- a/src/solvers/fc2d_clawpack5/fc2d_clawpack5.h.TEST.cpp
+++ b/src/solvers/fc2d_clawpack5/fc2d_clawpack5.h.TEST.cpp
@@ -126,20 +126,23 @@ TEST_CASE("fc2d_clawpack5_vtable_initialize fails if called twice on a glob")
 	fclaw_clawpatch_options_store(glob2, clawpatch_opts);
 
 	/* create some empty options structures */
-	fc2d_clawpack5_options_store(glob1, FCLAW_ALLOC_ZERO(fc2d_clawpack5_options_t,1));
-	fc2d_clawpack5_options_store(glob2, FCLAW_ALLOC_ZERO(fc2d_clawpack5_options_t,1));
+	fc2d_clawpack5_options_t* opts = FCLAW_ALLOC_ZERO(fc2d_clawpack5_options_t,1);
+	fc2d_clawpack5_options_store(glob1, opts);
+	fc2d_clawpack5_options_store(glob2, opts);
 
 	fclaw_vtables_initialize(glob1);
 	fc2d_clawpack5_solver_initialize(glob1);
-	CHECK_SC_ABORTED(fc2d_clawpack5_solver_initialize(glob1));
+	fc2d_clawpack5_solver_initialize(glob1);
 
 	fclaw_vtables_initialize(glob2);
 	fc2d_clawpack5_solver_initialize(glob2);
-	CHECK_SC_ABORTED(fc2d_clawpack5_solver_initialize(glob2));
+	fc2d_clawpack5_solver_initialize(glob2);
 
 	fclaw_domain_destroy(domain);
 	fclaw_global_destroy(glob1);
 	fclaw_global_destroy(glob2);
+	fclaw_clawpatch_options_destroy(clawpatch_opts);
+	FCLAW_FREE(opts);
 }
 
 #endif

--- a/src/solvers/fc2d_clawpack5/fc2d_clawpack5_options.h.TEST.cpp
+++ b/src/solvers/fc2d_clawpack5/fc2d_clawpack5_options.h.TEST.cpp
@@ -68,16 +68,28 @@ TEST_CASE("fc2d_clawpack5_get_options fails if not intialized")
 	fclaw_global_destroy(glob2);
 }
 
-TEST_CASE("fc2d_clawpack5_options_store fails if called twice on a glob")
+TEST_CASE("fc2d_clawpack5_options_store called twice on a glob")
 {
 	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
-	fc2d_clawpack5_options_store(glob1, FCLAW_ALLOC_ZERO(fc2d_clawpack5_options_t,1));
-	CHECK_SC_ABORTED(fc2d_clawpack5_options_store(glob1, FCLAW_ALLOC_ZERO(fc2d_clawpack5_options_t,1)));
+	fc2d_clawpack5_options_t* opts1_1 = FCLAW_ALLOC_ZERO(fc2d_clawpack5_options_t,1);
+	fc2d_clawpack5_options_t* opts1_2 = FCLAW_ALLOC_ZERO(fc2d_clawpack5_options_t,1);
+	fc2d_clawpack5_options_t* opts2_1 = FCLAW_ALLOC_ZERO(fc2d_clawpack5_options_t,1);
+	fc2d_clawpack5_options_t* opts2_2 = FCLAW_ALLOC_ZERO(fc2d_clawpack5_options_t,1);
 
-	fc2d_clawpack5_options_store(glob2, FCLAW_ALLOC_ZERO(fc2d_clawpack5_options_t,1));
-	CHECK_SC_ABORTED(fc2d_clawpack5_options_store(glob2, FCLAW_ALLOC_ZERO(fc2d_clawpack5_options_t,1)));
+	fc2d_clawpack5_options_store(glob1, opts1_1);
+	fc2d_clawpack5_options_store(glob1, opts1_2);
+	CHECK_EQ(fc2d_clawpack5_get_options(glob1), opts1_2);
+
+	fc2d_clawpack5_options_store(glob2, opts2_1);
+	fc2d_clawpack5_options_store(glob2, opts2_2);
+	CHECK_EQ(fc2d_clawpack5_get_options(glob2), opts2_2);
+
+	FCLAW_FREE(opts1_1);
+	FCLAW_FREE(opts1_2);
+	FCLAW_FREE(opts2_1);
+	FCLAW_FREE(opts2_2);
 
 	fclaw_global_destroy(glob1);
 	fclaw_global_destroy(glob2);

--- a/src/solvers/fc2d_cudaclaw/fc2d_cudaclaw.cpp
+++ b/src/solvers/fc2d_cudaclaw/fc2d_cudaclaw.cpp
@@ -31,8 +31,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdlib.h>  /* For size_t */
 
-#include <fclaw_pointer_map.h>
-
 #include <fclaw_global.h>
 #include <fclaw_vtable.h>
 #include <fclaw_update_single_step.h>  
@@ -460,8 +458,7 @@ void fc2d_cudaclaw_solver_initialize(fclaw_global_t* glob)
 
     cudaclaw_vt->is_set = 1;
 
-	FCLAW_ASSERT(fclaw_pointer_map_get(glob->vtables,"fc2d_cudaclaw") == NULL);
-	fclaw_pointer_map_insert(glob->vtables, "fc2d_cudaclaw", cudaclaw_vt, cudaclaw_vt_destroy);
+	fclaw_global_vtable_store(glob, "fc2d_cudaclaw", cudaclaw_vt, cudaclaw_vt_destroy);
 }
 
 
@@ -473,7 +470,7 @@ void fc2d_cudaclaw_solver_initialize(fclaw_global_t* glob)
 fc2d_cudaclaw_vtable_t* fc2d_cudaclaw_vt(fclaw_global_t *glob)
 {
 	fc2d_cudaclaw_vtable_t* cudaclaw_vt = (fc2d_cudaclaw_vtable_t*) 
-	   							fclaw_pointer_map_get(glob->vtables, "fc2d_cudaclaw");
+	   							fclaw_global_get_vtable(glob, "fc2d_cudaclaw");
 	FCLAW_ASSERT(cudaclaw_vt != NULL);
 	FCLAW_ASSERT(cudaclaw_vt->is_set != 0);
 	return cudaclaw_vt;

--- a/src/solvers/fc2d_geoclaw/fc2d_geoclaw.cpp
+++ b/src/solvers/fc2d_geoclaw/fc2d_geoclaw.cpp
@@ -28,8 +28,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "fc2d_geoclaw_fort.h"
 #include "fc2d_geoclaw_output_ascii.h"
 
-#include <fclaw_pointer_map.h>
-
 #include <fclaw_gauges.h>
 #include "fc2d_geoclaw_gauges_default.h"
 
@@ -821,7 +819,7 @@ void fc2d_geoclaw_vt_destroy(void* vt)
 fc2d_geoclaw_vtable_t* fc2d_geoclaw_vt(fclaw_global_t* glob)
 {
 	fc2d_geoclaw_vtable_t* geoclaw_vt = (fc2d_geoclaw_vtable_t*) 
-	   							fclaw_pointer_map_get(glob->vtables, "fc2d_geoclaw");
+	   							fclaw_global_get_vtable(glob, "fc2d_geoclaw");
 	FCLAW_ASSERT(geoclaw_vt != NULL);
 	FCLAW_ASSERT(geoclaw_vt->is_set != 0);
 	return geoclaw_vt;
@@ -909,7 +907,6 @@ void fc2d_geoclaw_solver_initialize(fclaw_global_t* glob)
 
     geoclaw_vt->is_set = 1;
 
-	FCLAW_ASSERT(fclaw_pointer_map_get(glob->vtables,"fc2d_geoclaw") == NULL);
-	fclaw_pointer_map_insert(glob->vtables, "fc2d_geoclaw", geoclaw_vt, fc2d_geoclaw_vt_destroy);
+	fclaw_global_vtable_store(glob, "fc2d_geoclaw", geoclaw_vt, fc2d_geoclaw_vt_destroy);
 }
 

--- a/src/solvers/fc2d_geoclaw/fc2d_geoclaw.h.TEST.cpp
+++ b/src/solvers/fc2d_geoclaw/fc2d_geoclaw.h.TEST.cpp
@@ -122,7 +122,7 @@ TEST_CASE("fc2d_geoclaw_vt fails if not intialized")
 	fclaw_global_destroy(glob2);
 }
 
-TEST_CASE("fc2d_geoclaw_vtable_initialize fails if called twice on a glob")
+TEST_CASE("fc2d_geoclaw_vtable_initialize called twice on a glob")
 {
 	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
@@ -136,23 +136,28 @@ TEST_CASE("fc2d_geoclaw_vtable_initialize fails if called twice on a glob")
 	fclaw_clawpatch_options_store(glob2, clawpatch_opt);
 
 	/* create some empty options structures */
-	fclaw_options_store(glob1, FCLAW_ALLOC_ZERO(fclaw_options_t,1));
-	fc2d_geoclaw_options_store(glob1, FCLAW_ALLOC_ZERO(fc2d_geoclaw_options_t,1));
+	fclaw_options_t *fclaw_opt = FCLAW_ALLOC_ZERO(fclaw_options_t,1);
+	fc2d_geoclaw_options_t *geoclaw_opt = FCLAW_ALLOC_ZERO(fc2d_geoclaw_options_t,1);
+	fclaw_options_store(glob1, fclaw_opt);
+	fc2d_geoclaw_options_store(glob1, geoclaw_opt);
 
-	fclaw_options_store(glob2, FCLAW_ALLOC_ZERO(fclaw_options_t,1));
-	fc2d_geoclaw_options_store(glob2, FCLAW_ALLOC_ZERO(fc2d_geoclaw_options_t,1));
+	fclaw_options_store(glob2, fclaw_opt);
+	fc2d_geoclaw_options_store(glob2, geoclaw_opt);
 
 	fclaw_vtables_initialize(glob1);
 	fc2d_geoclaw_solver_initialize(glob1);
-	CHECK_SC_ABORTED(fc2d_geoclaw_solver_initialize(glob1));
+	fc2d_geoclaw_solver_initialize(glob1);
 
 	fclaw_vtables_initialize(glob2);
 	fc2d_geoclaw_solver_initialize(glob2);
-	CHECK_SC_ABORTED(fc2d_geoclaw_solver_initialize(glob2));
+	fc2d_geoclaw_solver_initialize(glob2);
 
 	fclaw_domain_destroy(domain);
 	fclaw_global_destroy(glob1);
 	fclaw_global_destroy(glob2);
+	fclaw_clawpatch_options_destroy(clawpatch_opt);
+	FCLAW_FREE(fclaw_opt);
+	FCLAW_FREE(geoclaw_opt);
 }
 
 #endif

--- a/src/solvers/fc2d_geoclaw/fc2d_geoclaw_options.h.TEST.cpp
+++ b/src/solvers/fc2d_geoclaw/fc2d_geoclaw_options.h.TEST.cpp
@@ -67,16 +67,28 @@ TEST_CASE("fc2d_geoclaw_get_options fails if not intialized")
 	fclaw_global_destroy(glob2);
 }
 
-TEST_CASE("fc2d_geoclaw_options_store fails if called twice on a glob")
+TEST_CASE("fc2d_geoclaw_options_store called twice on a glob")
 {
 	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
-	fc2d_geoclaw_options_store(glob1, FCLAW_ALLOC_ZERO(fc2d_geoclaw_options_t,1));
-	CHECK_SC_ABORTED(fc2d_geoclaw_options_store(glob1, FCLAW_ALLOC_ZERO(fc2d_geoclaw_options_t,1)));
+	fc2d_geoclaw_options_t* opts1_1 = FCLAW_ALLOC_ZERO(fc2d_geoclaw_options_t,1);
+	fc2d_geoclaw_options_t* opts1_2 = FCLAW_ALLOC_ZERO(fc2d_geoclaw_options_t,1);
+	fc2d_geoclaw_options_t* opts2_1 = FCLAW_ALLOC_ZERO(fc2d_geoclaw_options_t,1);
+	fc2d_geoclaw_options_t* opts2_2 = FCLAW_ALLOC_ZERO(fc2d_geoclaw_options_t,1);
 
-	fc2d_geoclaw_options_store(glob2, FCLAW_ALLOC_ZERO(fc2d_geoclaw_options_t,1));
-	CHECK_SC_ABORTED(fc2d_geoclaw_options_store(glob2, FCLAW_ALLOC_ZERO(fc2d_geoclaw_options_t,1)));
+	fc2d_geoclaw_options_store(glob1, opts1_1);
+	fc2d_geoclaw_options_store(glob1, opts1_2);
+	CHECK_EQ(fc2d_geoclaw_get_options(glob1), opts1_2);
+
+	fc2d_geoclaw_options_store(glob2, opts2_1);
+	fc2d_geoclaw_options_store(glob2, opts2_2);
+	CHECK_EQ(fc2d_geoclaw_get_options(glob2), opts2_2);
+
+	FCLAW_FREE(opts1_1);
+	FCLAW_FREE(opts1_2);
+	FCLAW_FREE(opts2_1);
+	FCLAW_FREE(opts2_2);
 
 	fclaw_global_destroy(glob1);
 	fclaw_global_destroy(glob2);

--- a/src/solvers/fc2d_thunderegg/fc2d_thunderegg.cpp
+++ b/src/solvers/fc2d_thunderegg/fc2d_thunderegg.cpp
@@ -28,8 +28,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "fc2d_thunderegg_physical_bc.h"
 #include "fc2d_thunderegg_fort.h"
 
-#include <fclaw_pointer_map.h>
-
 #include <fclaw_elliptic_solver.h>
 
 #include <fclaw_clawpatch.h>
@@ -194,8 +192,7 @@ void fc2d_thunderegg_solver_initialize(fclaw_global_t* glob)
 
 	mg_vt->is_set = 1;
 
-	FCLAW_ASSERT(fclaw_pointer_map_get(glob->vtables,"fc2d_thunderegg") == NULL);
-	fclaw_pointer_map_insert(glob->vtables, "fc2d_thunderegg", mg_vt, thunderegg_vt_destroy);
+	fclaw_global_vtable_store(glob, "fc2d_thunderegg", mg_vt, thunderegg_vt_destroy);
 }
 
 
@@ -204,7 +201,7 @@ void fc2d_thunderegg_solver_initialize(fclaw_global_t* glob)
 fc2d_thunderegg_vtable_t* fc2d_thunderegg_vt(fclaw_global_t* glob)
 {
 	fc2d_thunderegg_vtable_t* thunderegg_vt = (fc2d_thunderegg_vtable_t*) 
-	   							fclaw_pointer_map_get(glob->vtables, "fc2d_thunderegg");
+	   							fclaw_global_get_vtable(glob, "fc2d_thunderegg");
 	FCLAW_ASSERT(thunderegg_vt != NULL);
 	FCLAW_ASSERT(thunderegg_vt->is_set != 0);
 	return thunderegg_vt;

--- a/src/solvers/fc2d_thunderegg/fc2d_thunderegg.h.TEST.cpp
+++ b/src/solvers/fc2d_thunderegg/fc2d_thunderegg.h.TEST.cpp
@@ -80,7 +80,7 @@ TEST_CASE("fc2d_thunderegg_solver_initialize sets is_set flag")
 
 #ifdef FCLAW_ENABLE_DEBUG
 
-TEST_CASE("fc2d_thunderegg_vtable_initialize fails if called twice on a glob")
+TEST_CASE("fc2d_thunderegg_vtable_initialize called twice on a glob")
 {
 	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
@@ -95,11 +95,11 @@ TEST_CASE("fc2d_thunderegg_vtable_initialize fails if called twice on a glob")
 
 	fclaw_vtables_initialize(glob1);
 	fc2d_thunderegg_solver_initialize(glob1);
-	CHECK_SC_ABORTED(fc2d_thunderegg_solver_initialize(glob1));
+	fc2d_thunderegg_solver_initialize(glob1);
 
 	fclaw_vtables_initialize(glob2);
 	fc2d_thunderegg_solver_initialize(glob2);
-	CHECK_SC_ABORTED(fc2d_thunderegg_solver_initialize(glob2));
+	fc2d_thunderegg_solver_initialize(glob2);
 
 	fclaw_domain_destroy(domain);
 	fclaw_global_destroy(glob1);

--- a/src/solvers/fc2d_thunderegg/fc2d_thunderegg_options.h.TEST.cpp
+++ b/src/solvers/fc2d_thunderegg/fc2d_thunderegg_options.h.TEST.cpp
@@ -67,16 +67,28 @@ TEST_CASE("fc2d_thunderegg_get_options fails if not intialized")
 	fclaw_global_destroy(glob2);
 }
 
-TEST_CASE("fc2d_thunderegg_options_store fails if called twice on a glob")
+TEST_CASE("fc2d_thunderegg_options_store called twice on a glob")
 {
 	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
-	fc2d_thunderegg_options_store(glob1, FCLAW_ALLOC_ZERO(fc2d_thunderegg_options_t,1));
-	CHECK_SC_ABORTED(fc2d_thunderegg_options_store(glob1, FCLAW_ALLOC_ZERO(fc2d_thunderegg_options_t,1)));
+	fc2d_thunderegg_options_t* opts1_1 = FCLAW_ALLOC_ZERO(fc2d_thunderegg_options_t,1);
+	fc2d_thunderegg_options_t* opts1_2 = FCLAW_ALLOC_ZERO(fc2d_thunderegg_options_t,1);
+	fc2d_thunderegg_options_t* opts2_1 = FCLAW_ALLOC_ZERO(fc2d_thunderegg_options_t,1);
+	fc2d_thunderegg_options_t* opts2_2 = FCLAW_ALLOC_ZERO(fc2d_thunderegg_options_t,1);
 
-	fc2d_thunderegg_options_store(glob2, FCLAW_ALLOC_ZERO(fc2d_thunderegg_options_t,1));
-	CHECK_SC_ABORTED(fc2d_thunderegg_options_store(glob2, FCLAW_ALLOC_ZERO(fc2d_thunderegg_options_t,1)));
+	fc2d_thunderegg_options_store(glob1, opts1_1);
+	fc2d_thunderegg_options_store(glob1, opts1_2);
+	CHECK_EQ(fc2d_thunderegg_get_options(glob1), opts1_2);
+
+	fc2d_thunderegg_options_store(glob2, opts2_1);
+	fc2d_thunderegg_options_store(glob2, opts2_2);
+	CHECK_EQ(fc2d_thunderegg_get_options(glob2), opts2_2);
+
+	FCLAW_FREE(opts1_1);
+	FCLAW_FREE(opts1_2);
+	FCLAW_FREE(opts2_1);
+	FCLAW_FREE(opts2_2);
 
 	fclaw_global_destroy(glob1);
 	fclaw_global_destroy(glob2);

--- a/src/solvers/fc3d_clawpack46/fc3d_clawpack46.cpp
+++ b/src/solvers/fc3d_clawpack46/fc3d_clawpack46.cpp
@@ -27,8 +27,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "fc3d_clawpack46_options.h"
 #include "fc3d_clawpack46_fort.h"
 
-#include <fclaw_pointer_map.h>
-
 #include <fclaw_clawpatch.hpp>
 #include <fclaw_clawpatch.h>
 
@@ -563,8 +561,7 @@ void fc3d_clawpack46_solver_initialize(fclaw_global_t* glob)
 
 	claw46_vt->is_set = 1;
 
-	FCLAW_ASSERT(fclaw_pointer_map_get(glob->vtables,"fc3d_clawpack46") == NULL);
-	fclaw_pointer_map_insert(glob->vtables, "fc3d_clawpack46", claw46_vt, clawpack46_vt_destroy);
+	fclaw_global_vtable_store(glob, "fc3d_clawpack46", claw46_vt, clawpack46_vt_destroy);
 }
 
 
@@ -576,7 +573,7 @@ void fc3d_clawpack46_solver_initialize(fclaw_global_t* glob)
 fc3d_clawpack46_vtable_t* fc3d_clawpack46_vt(fclaw_global_t* glob)
 {
 	fc3d_clawpack46_vtable_t* claw46_vt = (fc3d_clawpack46_vtable_t*) 
-	   							fclaw_pointer_map_get(glob->vtables, "fc3d_clawpack46");
+	   							fclaw_global_get_vtable(glob, "fc3d_clawpack46");
 	FCLAW_ASSERT(claw46_vt != NULL);
 	FCLAW_ASSERT(claw46_vt->is_set != 0);
 	return claw46_vt;

--- a/src/solvers/fc3d_clawpack46/fc3d_clawpack46.h.TEST.cpp
+++ b/src/solvers/fc3d_clawpack46/fc3d_clawpack46.h.TEST.cpp
@@ -114,7 +114,7 @@ TEST_CASE("fc3d_clawpack46_vt fails if not intialized")
 	fclaw_global_destroy(glob2);
 }
 
-TEST_CASE("fc3d_clawpack46_vtable_initialize fails if called twice on a glob")
+TEST_CASE("fc3d_clawpack46_vtable_initialize called twice on a glob")
 {
 	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
@@ -126,26 +126,31 @@ TEST_CASE("fc3d_clawpack46_vtable_initialize fails if called twice on a glob")
 	fclaw_clawpatch_options_t* opts1 = fclaw_clawpatch_options_new(3);
 	fclaw_clawpatch_options_t* opts2 = fclaw_clawpatch_options_new(3);
 
+	fc3d_clawpack46_options_t* claw_opts1 = FCLAW_ALLOC_ZERO(fc3d_clawpack46_options_t,1);
+	fc3d_clawpack46_options_t* claw_opts2 = FCLAW_ALLOC_ZERO(fc3d_clawpack46_options_t,1);
+
 	/* create some empty options structures */
 	fclaw_clawpatch_options_store(glob1, opts1);
-	fc3d_clawpack46_options_store(glob1, FCLAW_ALLOC_ZERO(fc3d_clawpack46_options_t,1));
+	fc3d_clawpack46_options_store(glob1, claw_opts1);
 
 	fclaw_clawpatch_options_store(glob2, opts2);
-	fc3d_clawpack46_options_store(glob2, FCLAW_ALLOC_ZERO(fc3d_clawpack46_options_t,1));
+	fc3d_clawpack46_options_store(glob2, claw_opts2);
 
 	fclaw_vtables_initialize(glob1);
 	fc3d_clawpack46_solver_initialize(glob1);
-	CHECK_SC_ABORTED(fc3d_clawpack46_solver_initialize(glob1));
+	fc3d_clawpack46_solver_initialize(glob1);
 
 	fclaw_vtables_initialize(glob2);
 	fc3d_clawpack46_solver_initialize(glob2);
-	CHECK_SC_ABORTED(fc3d_clawpack46_solver_initialize(glob2));
+	fc3d_clawpack46_solver_initialize(glob2);
 
 	fclaw_clawpatch_options_destroy(opts1);
 	fclaw_clawpatch_options_destroy(opts2);
 	fclaw_domain_destroy(domain);
 	fclaw_global_destroy(glob1);
 	fclaw_global_destroy(glob2);
+	FCLAW_FREE(claw_opts1);
+	FCLAW_FREE(claw_opts2);
 }
 
 #endif

--- a/src/solvers/fc3d_clawpack46/fc3d_clawpack46_options.h.TEST.cpp
+++ b/src/solvers/fc3d_clawpack46/fc3d_clawpack46_options.h.TEST.cpp
@@ -67,16 +67,28 @@ TEST_CASE("fc3d_clawpack46_get_options fails if not intialized")
 	fclaw_global_destroy(glob2);
 }
 
-TEST_CASE("fc3d_clawpack46_options_store fails if called twice on a glob")
+TEST_CASE("fc3d_clawpack46_options_store called twice on a glob")
 {
 	fclaw_global_t* glob1 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 	fclaw_global_t* glob2 = fclaw_global_new_comm(sc_MPI_COMM_SELF, 1, 0);;
 
-	fc3d_clawpack46_options_store(glob1, FCLAW_ALLOC_ZERO(fc3d_clawpack46_options_t,1));
-	CHECK_SC_ABORTED(fc3d_clawpack46_options_store(glob1, FCLAW_ALLOC_ZERO(fc3d_clawpack46_options_t,1)));
+	fc3d_clawpack46_options_t* opts1_1 = FCLAW_ALLOC_ZERO(fc3d_clawpack46_options_t,1);
+	fc3d_clawpack46_options_t* opts1_2 = FCLAW_ALLOC_ZERO(fc3d_clawpack46_options_t,1);
+	fc3d_clawpack46_options_t* opts2_1 = FCLAW_ALLOC_ZERO(fc3d_clawpack46_options_t,1);
+	fc3d_clawpack46_options_t* opts2_2 = FCLAW_ALLOC_ZERO(fc3d_clawpack46_options_t,1);
 
-	fc3d_clawpack46_options_store(glob2, FCLAW_ALLOC_ZERO(fc3d_clawpack46_options_t,1));
-	CHECK_SC_ABORTED(fc3d_clawpack46_options_store(glob2, FCLAW_ALLOC_ZERO(fc3d_clawpack46_options_t,1)));
+	fc3d_clawpack46_options_store(glob1, opts1_1);
+	fc3d_clawpack46_options_store(glob1, opts1_2);
+	CHECK_EQ(fc3d_clawpack46_get_options(glob1), opts1_2);
+
+	fc3d_clawpack46_options_store(glob2, opts2_1);
+	fc3d_clawpack46_options_store(glob2, opts2_2);
+	CHECK_EQ(fc3d_clawpack46_get_options(glob2), opts2_2);
+
+	FCLAW_FREE(opts1_1);
+	FCLAW_FREE(opts1_2);
+	FCLAW_FREE(opts2_1);
+	FCLAW_FREE(opts2_2);
 
 	fclaw_global_destroy(glob1);
 	fclaw_global_destroy(glob2);


### PR DESCRIPTION
Currently, when storing vtables and options in glob, there are asserts that check that these functions are only be called once. There are some specific applications where these functions need to be called twice, so these asserts have been removed.