### PR TITLE
(clawpack3) Rename 3d limiter to distinguish from 2d limiter

### DIFF
--- a/src/solvers/fc3d_clawpack46/fortran_source/fc3d_clawpack46_flux3.f
+++ b/src/solvers/fc3d_clawpack46/fortran_source/fc3d_clawpack46_flux3.f
@@ -272,7 +272,7 @@ c         -----------------------------------------------------------
      
 c     # apply limiter to waves:
       if (limit) then 
-         call clawpack46_inlinelimiter(maxm,meqn,mwaves,
+         call fc3d_clawpack46_inlinelimiter(maxm,meqn,mwaves,
      &                  mbc,mx,wave,s,mthlim)
       endif
      

--- a/src/solvers/fc3d_clawpack46/fortran_source/fc3d_clawpack46_inlinelimiter.f90
+++ b/src/solvers/fc3d_clawpack46/fortran_source/fc3d_clawpack46_inlinelimiter.f90
@@ -1,4 +1,4 @@
-subroutine clawpack46_inlinelimiter(maxm,meqn,mwaves,mbc, & 
+subroutine fc3d_clawpack46_inlinelimiter(maxm,meqn,mwaves,mbc, & 
            mx,wave,s,mthlim)
 !!     =====================================================
 
@@ -122,4 +122,4 @@ subroutine clawpack46_inlinelimiter(maxm,meqn,mwaves,mbc, &
     end do wave_loop
 
     return
-end subroutine clawpack46_inlinelimiter
+end subroutine fc3d_clawpack46_inlinelimiter


### PR DESCRIPTION
This fixes the CI issue with autoconf on MacOS. 

* This bug is a reminder that we should be careful about  using the same file name in different libraries. 