### PR TITLE
CMake refinements

### DIFF
--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -9,14 +9,17 @@ on:
   release:
     types: [published]
 
+env:
+  CMAKE_BUILD_PARALLEL_LEVEL: 4
+  CTEST_NO_TESTS_ACTION: "error"
+  CMAKE_INSTALL_PREFIX: ~/local
+  CMAKE_PREFIX_PATH: ~/local
 
 jobs:
 
   linux:
     runs-on: ubuntu-20.04
     timeout-minutes: 60
-    env:
-      CTEST_PARALLEL_LEVEL: 2
 
     strategy:
       fail-fast: false
@@ -90,21 +93,20 @@ jobs:
         sudo apt-get -y install cuda-toolkit-11-3
 
     - name: CMake configure
-      run: ${{ matrix.configure_environment }} cmake --preset ci -DCMAKE_INSTALL_PREFIX=~ ${{ matrix.configure_flags }}
+      run: ${{ matrix.configure_environment }} cmake --preset ci ${{ matrix.configure_flags }}
 
     - name: CMake build
       run: cmake --build --preset ci
 
     - name: CMake test
       if: ${{ !matrix.cuda }}
-      run: ctest --parallel 2 --output-on-failure
-      working-directory: build
+      run: ctest --preset default
 
     - name: CMake install (for examples)
       run: cmake --install build
 
     - name: CMake configure examples
-      run: ${{ matrix.configure_environment }} cmake -B applications/build -S applications --preset ci -DFORESTCLAW_ROOT=~
+      run: ${{ matrix.configure_environment }} cmake -B applications/build -S applications --preset ci
 
     - name: CMake build examples
       run: cmake --build applications/build
@@ -115,7 +117,7 @@ jobs:
 
     - name: Upload package
       if: github.event.action == 'published'
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: binary-archive
         path: build/package
@@ -126,7 +128,6 @@ jobs:
     name: CMake build on MacOS
     env:
       HOMEBREW_NO_INSTALL_CLEANUP: 1
-      CTEST_PARALLEL_LEVEL: 3
       CC: gcc-11
       CXX: g++-11
       FC: gfortran-11
@@ -139,20 +140,19 @@ jobs:
       run: brew install open-mpi ninja fftw
 
     - name: CMake configure
-      run: cmake --preset mac -DCMAKE_INSTALL_PREFIX=~ -Dclawpack=on -Dgeoclaw=on -Dthunderegg=on
+      run: cmake --preset mac -Dclawpack=on -Dgeoclaw=on -Dthunderegg=on
 
     - name: CMake build
-      run: cmake --build build
+      run: cmake --build --preset default
 
     - name: CMake test
-      run: ctest --parallel 2 --output-on-failure
-      working-directory: build
+      run: ctest --preset default
 
     - name: CMake install (for examples)
       run: cmake --install build
 
     - name: CMake configure examples
-      run: cmake -B applications/build -S applications -DFORESTCLAW_ROOT=~
+      run: cmake -B applications/build -S applications
 
     - name: CMake build examples
       run: cmake --build applications/build
@@ -163,7 +163,7 @@ jobs:
 
     - name: Upload package
       if: github.event.action == 'published'
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: binary-archive
         path: build/package

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.28)
+cmake_minimum_required(VERSION 3.15...3.30)
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
   message(FATAL_ERROR "please use out-of-source build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.30)
+cmake_minimum_required(VERSION 3.19...3.30)
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
   message(FATAL_ERROR "please use out-of-source build
@@ -67,6 +67,14 @@ if(FCLAW_ENABLE_THUNDEREGG)
 endif()
 
 # --- configure
+
+# Conda's HDF5 never works with the system compiler
+if(DEFINED ENV{CONDA_PREFIX})
+  list(APPEND CMAKE_IGNORE_PREFIX_PATH $ENV{CONDA_PREFIX})
+  list(APPEND CMAKE_IGNORE_PATH $ENV{CONDA_PREFIX}/bin)
+  # need CMAKE_IGNORE_PATH for CMake < 3.23
+  # and to ensure system env var PATH doesn't interfere despite CMAKE_IGNORE_PREFIX_PATH
+endif()
 
 if(FCLAW_ENABLE_HDF5 AND NOT TARGET HDF5::HDF5)
   if(FCLAW_ENABLE_SUBMODULES)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -105,6 +105,7 @@
     "verbosity": "default"
   },
   "execution": {
+    "scheduleRandom": true,
     "noTestsAction": "error",
     "stopOnFailure": false}
 }

--- a/cmake/Modules/FindHDF5.cmake
+++ b/cmake/Modules/FindHDF5.cmake
@@ -60,12 +60,8 @@ Targets
 #]=======================================================================]
 
 include(CheckSymbolExists)
-include(CheckCSourceCompiles)
-include(CheckFortranSourceCompiles)
+include(CheckSourceCompiles)
 
-# this is to help avoid unwanted Anaconda HDF5 or stray h5cc compiler script
-set(_use_sys_env_path ${CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH})
-set(CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH false)
 
 function(get_flags exec outvar)
 
@@ -656,7 +652,7 @@ endfunction(hdf5_c_wrap)
 
 function(check_c_links)
 
-list(INSERT CMAKE_REQUIRED_LIBRARIES 0 ${HDF5_C_LIBRARIES})
+list(PREPEND CMAKE_REQUIRED_LIBRARIES ${HDF5_C_LIBRARIES})
 set(CMAKE_REQUIRED_INCLUDES ${HDF5_C_INCLUDE_DIR})
 
 if(HDF5_parallel_FOUND)
@@ -699,14 +695,14 @@ else()
   ]=])
 endif(HDF5_parallel_FOUND)
 
-check_c_source_compiles("${src}" HDF5_C_links)
+check_source_compiles(C "${src}" HDF5_C_links)
 
 endfunction(check_c_links)
 
 
 function(check_fortran_links)
 
-list(INSERT CMAKE_REQUIRED_LIBRARIES 0 ${HDF5_Fortran_LIBRARIES} ${HDF5_C_LIBRARIES})
+list(PREPEND CMAKE_REQUIRED_LIBRARIES ${HDF5_Fortran_LIBRARIES} ${HDF5_C_LIBRARIES})
 set(CMAKE_REQUIRED_INCLUDES ${HDF5_Fortran_INCLUDE_DIR} ${HDF5_C_INCLUDE_DIR})
 
 if(HDF5_parallel_FOUND)
@@ -740,12 +736,21 @@ else()
   end program")
 endif()
 
-check_fortran_source_compiles(${src} HDF5_Fortran_links SRC_EXT f90)
+check_source_compiles(Fortran ${src} HDF5_Fortran_links)
 
 endfunction(check_fortran_links)
 
 
 function(check_hdf5_link)
+
+# HDF5 bug #3663 for HDF5 1.14.2, 1.14.3, ...?
+# https://github.com/HDFGroup/hdf5/issues/3663
+if(WIN32 AND CMAKE_Fortran_COMPILER_ID MATCHES "^Intel")
+if(HDF5_VERSION MATCHES "1.14.[2-3]")
+  message(VERBOSE "FindHDF5: applying workaround for HDF5 bug #3663 with Intel oneAPI on Windows")
+  list(APPEND CMAKE_REQUIRED_LIBRARIES shlwapi)
+endif()
+endif()
 
 if(NOT HDF5_C_FOUND)
   return()
@@ -789,14 +794,15 @@ if(NOT HDF5_ROOT)
   endif()
 endif()
 
+
 # --- library suffixes
 
 set(hdf5_lsuf lib hdf5/lib)  # need explicit "lib" for self-built HDF5
 if(NOT HDF5_ROOT)
-  list(INSERT hdf5_lsuf 0 hdf5/openmpi hdf5/mpich)  # Ubuntu
-  list(INSERT hdf5_lsuf 0 openmpi/lib mpich/lib)  # CentOS
+  list(PREPEND hdf5_lsuf hdf5/openmpi hdf5/mpich)  # Ubuntu
+  list(PREPEND hdf5_lsuf openmpi/lib mpich/lib)  # CentOS
   if(NOT parallel IN_LIST HDF5_FIND_COMPONENTS)
-    list(INSERT hdf5_lsuf 0 hdf5/serial)  # Ubuntu
+    list(PREPEND hdf5_lsuf hdf5/serial)  # Ubuntu
   endif()
 endif()
 
@@ -811,13 +817,13 @@ else()
 endif()
 
 # Ubuntu
-list(INSERT hdf5_isuf 0 hdf5/openmpi hdf5/mpich)
-list(INSERT hdf5_msuf 0 hdf5/openmpi hdf5/mpich)
+list(PREPEND hdf5_isuf hdf5/openmpi hdf5/mpich)
+list(PREPEND hdf5_msuf hdf5/openmpi hdf5/mpich)
 
 if(NOT parallel IN_LIST HDF5_FIND_COMPONENTS)
   # Ubuntu
-  list(INSERT hdf5_isuf 0 hdf5/serial)
-  list(INSERT hdf5_msuf 0 hdf5/serial)
+  list(PREPEND hdf5_isuf hdf5/serial)
+  list(PREPEND hdf5_msuf hdf5/serial)
 endif()
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64|AMD64)")
@@ -829,7 +835,7 @@ endif()
 if(NOT HDF5_ROOT AND CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
   # CentOS paths
   if(parallel IN_LIST HDF5_FIND_COMPONENTS)
-    list(INSERT hdf5_msuf 0 gfortran/modules/openmpi gfortran/modules/mpich)
+    list(PREPEND hdf5_msuf gfortran/modules/openmpi gfortran/modules/mpich)
   else()
     list(APPEND hdf5_msuf gfortran/modules)
   endif()
@@ -874,7 +880,6 @@ check_hdf5_link()
 
 set(CMAKE_REQUIRED_LIBRARIES)
 set(CMAKE_REQUIRED_INCLUDES)
-set(CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH ${_use_sys_env_path})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(HDF5

--- a/cmake/compilers.cmake
+++ b/cmake/compilers.cmake
@@ -15,6 +15,5 @@ if (CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
 elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
   add_compile_options(
     "$<$<COMPILE_LANGUAGE:Fortran>:-Wall>"
-    "$<$<COMPILE_LANGUAGE:Fortran>:-Wno-unused-dummy-argument,-Wno-unused-variable,-Wno-unused-label>"
     )
 endif()

--- a/cmake/hdf5.cmake
+++ b/cmake/hdf5.cmake
@@ -19,10 +19,9 @@ set(hdf5_cmake_args
 -DHDF5_BUILD_FORTRAN:BOOL=true
 -DHDF5_BUILD_CPP_LIB:BOOL=false
 -DHDF5_BUILD_EXAMPLES:BOOL=false
--DHDF5_BUILD_TOOLS:BOOL=$<NOT:$<BOOL:${hdf5_parallel}>>
+-DHDF5_BUILD_TOOLS:BOOL=false
 -DHDF5_ENABLE_PARALLEL:BOOL=$<BOOL:${hdf5_parallel}>
 )
-# https://github.com/HDFGroup/hdf5/issues/818  for broken ph5diff in HDF5_BUILD_TOOLS
 if(MPI_ROOT)
   list(APPEND hdf5_cmake_args -DMPI_ROOT:PATH=${MPI_ROOT})
 endif()

--- a/cmake/libraries.json
+++ b/cmake/libraries.json
@@ -1,9 +1,9 @@
 {
   "zlib": {
     "url" : "https://github.com/zlib-ng/zlib-ng.git",
-    "tag": "2.1.5"
+    "tag": "2.2.1"
   },
   "hdf5": {
-    "url": "https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5-1_14_3.tar.gz"
+    "url": "https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5_1.14.4.3.tar.gz"
   }
 }

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -2,7 +2,7 @@ option(FCLAW_ENABLE_MPI "use MPI library" ${mpi})
 option(FCLAW_ENABLE_OPENMP "use OpenMP" ${openmp})
 option(FCLAW_ENABLE_HDF5 "use HDF5 library" ${hdf5})
 
-if(NOT DEFINED applications AND ${PROJECT_IS_TOP_LEVEL})
+if(NOT DEFINED applications AND FORESTCLAW_IS_TOP_LEVEL)
   set(applications ON)
 endif()
 option(FCLAW_ENABLE_APPLICATIONS "build applications" ${applications})
@@ -22,25 +22,10 @@ option(FCLAW_ENABLE_SUBMODULES "use submodules for depedencies" ${submodules})
 
 option(CMAKE_TLS_VERIFY "verify TLS cert" on)
 
-# --- default install directory under build/local
-# users can specify like "cmake -B build -DCMAKE_INSTALL_PREFIX=~/mydir"
-if(CMAKE_VERSION VERSION_LESS 3.21)
-  get_property(_not_top DIRECTORY PROPERTY PARENT_DIRECTORY)
-  if(NOT _not_top)
-    set(FORESTCLAW_IS_TOP_LEVEL true)
-  endif()
-endif()
-
-if(FORESTCLAW_IS_TOP_LEVEL AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  # will not take effect without FORCE
-  set(CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}/local" CACHE PATH "Install top-level directory" FORCE)
-endif()
-
-unset(${PROJECT_NAME}_stdfs_link_flags)
 if( (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.1.0") OR
-  (LINUX AND CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "23") OR
+  (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "23") OR
   (CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "23.11") )
-set(${PROJECT_NAME}_stdfs_link_flags stdc++fs stdc++)
+set(FORESTCLAW_stdfs_link_flags stdc++fs stdc++)
 endif()
 # GCC < 9.1 needs -lstdc++ to avoid C main program link error
 # NVHPC at least 23.11 and newer doesn't need the flags, but at least 23.5 and older do.


### PR DESCRIPTION
* per Donna, don't set fancy -W options, let the user script do that.
* like p4est/libsc, don't set default install prefix
* use CMake >= 3.19 for robustness of finding packages. Older CMake generally doesn't work on modern systems anyway.
* use latest HDF5 for numerous bugfixes and robustness
* CI: use CMake presets for deduplication 

Each of this commits is independent, but made one PR to catch-up with p4est and other of our repos.