### PR TITLE
(clawpatch) Update tagging routines for Clawpack 5.x

### DIFF
--- a/src/patches/clawpatch/fort_4.6/fclaw2d_clawpatch46_tag4refinement.f
+++ b/src/patches/clawpatch/fort_4.6/fclaw2d_clawpatch46_tag4refinement.f
@@ -19,15 +19,12 @@ c--------------------------------------------------------------------
       double precision tag_threshold
       double precision q(1-mbc:mx+mbc,1-mbc:my+mbc,meqn)      
 
-
-      integer i,j, mq
+      integer i,j, mq, ii, jj
       double precision qmin(meqn), qmax(meqn)
-
-      integer exceeds_th, fclaw2d_clawpatch_tag_criteria
-      integer ii,jj
       double precision xc,yc,quad(-1:1,-1:1,meqn), qval(meqn)
+      integer exceeds_th, fclaw2d_clawpatch_tag_criteria
 
-      logical(kind=4) :: is_ghost, fclaw2d_clawpatch46_is_ghost
+      logical :: is_ghost, fclaw2d_clawpatch46_is_ghost
 
 c     # Assume that we won't refine      
       tag_patch = 0
@@ -85,11 +82,11 @@ c> @param[in] i,j the index
 c> @param[in] mx,my dimensions of grid
 c> @return if the index is a ghost index
 c--------------------------------------------------------------------
-      logical(kind=4) function fclaw2d_clawpatch46_is_ghost(i,j,mx,my)
+      logical function fclaw2d_clawpatch46_is_ghost(i,j,mx,my)
          implicit none
 
          integer i, j, mx, my
-         logical(kind=4) :: is_ghost
+         logical :: is_ghost
 
          is_ghost = .false.
          if (i .lt. 1 .or. j .lt. 1) then

--- a/src/patches/clawpatch/fort_5.0/fclaw2d_clawpatch5_tag4coarsening.f
+++ b/src/patches/clawpatch/fort_5.0/fclaw2d_clawpatch5_tag4coarsening.f
@@ -97,7 +97,7 @@ c--------------------------------------------------------------------
 
       integer i,j, ii, jj, mq
 
-      logical(kind=4) is_ghost, fclaw2d_clawpatch5_is_ghost
+      logical is_ghost, fclaw2d_clawpatch5_is_ghost
 
       do i = 1-mbc,mx+mbc
          do j = 1-mbc,my+mbc


### PR DESCRIPTION
This fixes a bug that had apparently been around for a while.   The tagging routines for 5.x hadn't been updated for compatibility with the latest "exceeds threshold" routines. 