### PR TITLE
Partitioning strategies: skip refined

### DIFF
--- a/applications/demo/2d/partitioning/partitioning.cpp
+++ b/applications/demo/2d/partitioning/partitioning.cpp
@@ -273,8 +273,8 @@ main (int argc, char **argv)
 
     /* iterate through the different partitioning strategies for patch data */
     int output_patch_data = 0;
-    int checksums[4] = { 0, 0, 0, 0 };
-    for (int test_case = 0; test_case < 4; test_case++)
+    int checksums[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
+    for (int test_case = 0; test_case < 8; test_case++)
     {
         domain = fclaw2d_domain_new_brick (mpicomm, 2, 2, 0, 0, 1);
         wrap = (p4est_wrap_t *) domain->pp;

--- a/applications/demo/2d/partitioning/partitioning.cpp
+++ b/applications/demo/2d/partitioning/partitioning.cpp
@@ -154,22 +154,25 @@ main (int argc, char **argv)
                                          (test_case % 2),
                                          (test_case % 4 / 2));
 
-
         if (domain->mpisize != 1)
         {
             /* refine all patches uniformly, to ensure the skip_refined option can
              * distinguish the most recent refinement from other refinement */
-            fclaw2d_domain_iterate_patches (domain, mark_refine_uniform, NULL);
+            fclaw2d_domain_iterate_patches (domain, mark_refine_uniform,
+                                            NULL);
             refined_domain = fclaw2d_domain_adapt (domain);
             fclaw2d_domain_destroy (domain);
 
             /* partition the resulting domain */
             partitioned_domain = fclaw2d_domain_partition (refined_domain, 0);
-            if (partitioned_domain != NULL) {
+            if (partitioned_domain != NULL)
+            {
                 fclaw2d_domain_destroy (refined_domain);
                 fclaw2d_domain_complete (partitioned_domain);
                 domain = partitioned_domain;
-            } else {
+            }
+            else
+            {
                 domain = refined_domain;
             }
             refined_domain = partitioned_domain = NULL;

--- a/applications/demo/2d/partitioning/partitioning.cpp
+++ b/applications/demo/2d/partitioning/partitioning.cpp
@@ -140,16 +140,20 @@ main (int argc, char **argv)
     fclaw_global_t *glob = fclaw_global_new_comm (mpicomm, size, rank);
 
     fclaw2d_domain_t *domain, *refined_domain, *partitioned_domain;
+    p4est_wrap_t *wrap;
 
     /* iterate through the different partitioning strategies for patch data */
     int output_patch_data = 0;
-    for (int test_case = 0; test_case < 2; test_case++)
+    for (int test_case = 0; test_case < 4; test_case++)
     {
-        domain = fclaw2d_domain_new_brick (mpicomm, 2, 2, 0, 0, 2);
+        domain = fclaw2d_domain_new_brick (mpicomm, 2, 2, 0, 0, 1);
+        wrap = (p4est_wrap_t *) domain->pp;
 
         /* set partitioning options */
-        fclaw2d_domain_set_partitioning (domain, 1, (test_case % 2),
-                                         (test_case / 2));
+        fclaw2d_domain_set_partitioning (domain, !(test_case / 4),
+                                         (test_case % 2),
+                                         (test_case % 4 / 2));
+
 
         if (domain->mpisize != 1)
         {
@@ -186,8 +190,10 @@ main (int argc, char **argv)
             partitioned_domain = fclaw2d_domain_partition (refined_domain, 0);
 
             fclaw_global_productionf
-                ("Starting partitioning with skip_local = %d.\n",
-                 domain->p.skip_local);
+                ("Starting partitioning with skip_local = %d,"
+                 " skip_refined = %d and partition_for_coarsening = %d.\n",
+                 domain->p.skip_local, domain->p.skip_refined,
+                 wrap->params.partition_for_coarsening);
             fclaw2d_domain_iterate_patches (partitioned_domain,
                                             alloc_patch_data, NULL);
 

--- a/applications/demo/2d/partitioning/partitioning.cpp
+++ b/applications/demo/2d/partitioning/partitioning.cpp
@@ -361,7 +361,7 @@ main (int argc, char **argv)
                 fclaw_global_productionf
                     ("Starting partitioning with skip_local = %d,"
                      " partition_for_coarsening = %d and"
-                     "skip_refined being enabled to late.\n",
+                     " skip_refined being enabled to late.\n",
                      domain->p.skip_local,
                      wrap->params.partition_for_coarsening);
                 fclaw2d_domain_set_partitioning (domain, 0, 1, 1);
@@ -382,11 +382,11 @@ main (int argc, char **argv)
                          num_patches_packed,
                          refined_domain->local_num_patches);
 
-            fclaw2d_domain_iterate_unpack (partitioned_domain, p,
-                                           unpack_patch_data, NULL);
             fclaw2d_domain_iterate_transfer (refined_domain,
                                              partitioned_domain,
                                              transfer_patch_data, NULL);
+            fclaw2d_domain_iterate_unpack (partitioned_domain, p,
+                                           unpack_patch_data, NULL);
             fclaw2d_domain_partition_free (p);
 
             /* output patch data if required */

--- a/applications/demo/2d/partitioning/partitioning.cpp
+++ b/applications/demo/2d/partitioning/partitioning.cpp
@@ -139,7 +139,8 @@ main (int argc, char **argv)
         domain = fclaw2d_domain_new_brick (mpicomm, 2, 2, 0, 0, 2);
 
         /* set partitioning options */
-        fclaw2d_domain_set_partitioning (domain, 1, (test_case % 2));
+        fclaw2d_domain_set_partitioning (domain, 1, (test_case % 2),
+                                         (test_case / 2));
 
         if (domain->mpisize != 1)
         {

--- a/src/fclaw2d_convenience.c
+++ b/src/fclaw2d_convenience.c
@@ -152,6 +152,7 @@ fclaw2d_domain_new (p4est_wrap_t * wrap, sc_keyvalue_t * attributes)
     local_minlevel = domain->possible_maxlevel;
     local_maxlevel = -1;
     domain->p.skip_local = 1;
+    domain->p.skip_refined = 0;
 
     /* prepare propagation of refinement/coarsening marks */
     domain->p.smooth_refine = 0;

--- a/src/fclaw_initialize.c
+++ b/src/fclaw_initialize.c
@@ -218,7 +218,8 @@ void fclaw_initialize_domain_flags(fclaw_global_t *glob)
          fclaw_opt->coarsen_delay);
 
     /* set partitioning */
-    fclaw_domain_set_partitioning(glob->domain,  fclaw_opt->partition_for_coarsening, 1);
+    fclaw_domain_set_partitioning (glob->domain,
+                                   fclaw_opt->partition_for_coarsening, 1, 0);
 }
 
 static void

--- a/src/forestclaw.c
+++ b/src/forestclaw.c
@@ -698,15 +698,15 @@ fclaw_domain_set_refinement (fclaw_domain_t * domain,
 }
 
 void
-fclaw_domain_set_partitioning(fclaw_domain_t *domain, int partition_for_coarsening, int skip_local)
+fclaw_domain_set_partitioning(fclaw_domain_t *domain, int partition_for_coarsening, int skip_local, int skip_refined)
 {
     if(domain->refine_dim == 2)
     {
-        fclaw2d_domain_set_partitioning(domain->d2,partition_for_coarsening, skip_local);
+        fclaw2d_domain_set_partitioning(domain->d2,partition_for_coarsening, skip_local, skip_refined);
     }
     else if (domain->refine_dim == 3)
     {
-        fclaw3d_domain_set_partitioning(domain->d3,partition_for_coarsening, skip_local);
+        fclaw3d_domain_set_partitioning(domain->d3,partition_for_coarsening, skip_local, skip_refined);
     }
     else
     {

--- a/src/forestclaw.h
+++ b/src/forestclaw.h
@@ -866,10 +866,23 @@ void fclaw_domain_set_refinement (fclaw_domain_t * domain,
  * \param [in] skip_local       Boolean: If true, the patch data of patches that
  *                              stay local are not packed during partitioning.
  *                              Suggested default: 1.
+ * \param [in] skip_refined     Boolean: If true, the patch data of patches that
+ *                              were refined during the most recent call to
+ *                              \ref fclaw_domain_adapt is only packed for the
+ *                              patches with child id 0 in
+ *                              fclaw_domain_iterate_pack. The unpack
+ *                              callback in fclaw_domain_iterate_unpack
+ *                              will be invoked for all children of a recently
+ *                              refined patch. The provided data will be the
+ *                              data packed by the patch with child id 0.
+ *                              For this partitioning method to work as desired,
+ *                              skip_refined has to be set \b before the most
+ *                              recent call to \ref fclaw_domain_adapt .
+ *                              Suggested default: 0.
  */
 void fclaw_domain_set_partitioning (fclaw_domain_t * domain,
                                     int partition_for_coarsening,
-                                    int skip_local);
+                                    int skip_local, int skip_refined);
 
 /** Mark a patch for refinement.
  * This must ONLY be called for local patches.

--- a/src/forestclaw2d.c
+++ b/src/forestclaw2d.c
@@ -1781,6 +1781,11 @@ fclaw2d_domain_iterate_pack (fclaw2d_domain_t * domain, size_t data_size,
                  * the skip_refined && next_refined == i case below */
                 num_src -= old_puf + pul - i;   /* no data for patches that stay local */
                 i = old_puf + pul;      /* skip patches that stay local */
+                already_skipped_local = 1;
+                if (i == old_lnp)
+                {
+                    break;      /* jumped to end of array */
+                }
                 while (skip_refined && next_refined < i)
                 {
                     /* skip newly refined patches that stay local */
@@ -1788,11 +1793,7 @@ fclaw2d_domain_iterate_pack (fclaw2d_domain_t * domain, size_t data_size,
                         *(int *) sc_array_index_int (wrap->newly_refined,
                                                      nri++);
                 }
-                if (i == old_lnp)
-                {
-                    break;      /* jumped to end of array */
-                }
-                already_skipped_local = 1;
+
             }
 
             size = (int *) sc_array_index_int (p->src_sizes, i);
@@ -1807,7 +1808,9 @@ fclaw2d_domain_iterate_pack (fclaw2d_domain_t * domain, size_t data_size,
                     *(int *) sc_array_index_int (wrap->newly_refined, nri++);
             }
         }
-        FCLAW_ASSERT (!skip_refined || nri == num_nr);
+        FCLAW_ASSERT (!skip_refined || nri == num_nr
+                      || old_puf + pul == old_lnp);
+        FCLAW_ASSERT (already_skipped_local);
 
         /* adapt to recently refined families that cross process boundaries */
         if (skip_refined && !wrap->params.partition_for_coarsening)

--- a/src/forestclaw2d.c
+++ b/src/forestclaw2d.c
@@ -1819,6 +1819,10 @@ fclaw2d_domain_iterate_pack (fclaw2d_domain_t * domain, size_t data_size,
             /* the first patch for each process has to contain data */
             for (ri = first_receiver; ri <= last_receiver; ri++)
             {
+                if (ri == mpirank)
+                {
+                    continue;
+                }
                 size = (int *) sc_array_index_int (p->src_sizes,
                                                    SC_MAX (0,
                                                            new_gfq[ri] -

--- a/src/forestclaw2d.c
+++ b/src/forestclaw2d.c
@@ -1727,7 +1727,8 @@ fclaw2d_domain_iterate_pack (fclaw2d_domain_t * domain, size_t data_size,
     int mpisize = p4est->mpisize;
     int blockno, patchno, *size, i, si, nri, num_nr;
     int skip_refined;
-    int num_dest, num_src, pul, old_puf, new_puf, old_lnp, new_lnp, next_refined;
+    int num_dest, num_src, pul, old_puf, new_puf, old_lnp, new_lnp,
+        next_refined;
     int first_receiver, last_receiver, ri;
     p4est_gloidx_t *old_gfq, *new_gfq;
     fclaw2d_block_t *block;
@@ -1774,16 +1775,16 @@ fclaw2d_domain_iterate_pack (fclaw2d_domain_t * domain, size_t data_size,
             {
                 i += pul;       /* skip patches that stay local */
                 num_src -= pul; /* no data for patches that stay local */
+                if (i == old_lnp)
+                {
+                    break;      /* jumped to end of array */
+                }
                 while (skip_refined && next_refined < i)
                 {
                     /* skip newly refined patches that stay local */
                     next_refined = (nri == num_nr) ? old_lnp :
                         *(int *) sc_array_index_int (wrap->newly_refined,
                                                      nri++);
-                }
-                if (i == old_lnp)
-                {
-                    continue;   /* jumped to end of array */
                 }
             }
 

--- a/src/forestclaw2d.c
+++ b/src/forestclaw2d.c
@@ -1401,12 +1401,15 @@ fclaw2d_domain_set_refinement (fclaw2d_domain_t * domain,
 void
 fclaw2d_domain_set_partitioning (fclaw2d_domain_t * domain,
                                  int partition_for_coarsening,
-                                 int skip_local)
+                                 int skip_local, int skip_refined)
 {
     p4est_wrap_t *wrap = (p4est_wrap_t *) domain->pp;
 
     wrap->params.partition_for_coarsening = partition_for_coarsening;
     domain->p.skip_local = skip_local;
+    domain->p.skip_refined = skip_refined;
+    /* store recently adapted patches, if skip_refined is enabled */
+    wrap->params.store_adapted = skip_refined;
 }
 
 void

--- a/src/forestclaw2d.c
+++ b/src/forestclaw2d.c
@@ -1903,8 +1903,8 @@ fclaw2d_domain_iterate_pack (fclaw2d_domain_t * domain, size_t data_size,
     num_dest = new_lnp;
     if (skip_refined)
     {
-        p4est_transfer_fixed_end ((p4est_transfer_context_t *) p->
-                                  async_state);
+        p4est_transfer_fixed_end ((p4est_transfer_context_t *)
+                                  p->async_state);
         /* update num_dest */
         for (i = 0; i < new_lnp; i++)
         {
@@ -1934,7 +1934,7 @@ fclaw2d_domain_iterate_pack (fclaw2d_domain_t * domain, size_t data_size,
 
     /* start transfering patch data according to the new partition */
     p->dest_data = sc_array_new_count (data_size, num_dest);
-    if (!domain->p.skip_local)
+    if (!domain->p.skip_local && !skip_refined)
     {
         /* we packed all patches resulting in a fixed data size */
         p->async_state = (void *)
@@ -2009,23 +2009,29 @@ fclaw2d_domain_iterate_unpack (fclaw2d_domain_t * domain,
 {
     int blockno, patchno;
     size_t zz;
+    p4est_wrap_t *wrap = (p4est_wrap_t *) domain->pp;
     fclaw2d_block_t *block;
     fclaw2d_patch_t *patch;
     int dpuf, dpul, bnpb;
+    int skip_refined;
 
     /* this routine should only be called for the new domain of a changed
      * partition */
     FCLAW_ASSERT (domain->pp_owned);
     FCLAW_ASSERT (p->inside_async);
 
+    skip_refined = domain->p.skip_refined && wrap->newly_refined != NULL;
+
     /* wait for transfer of patch data to complete */
-    if (!domain->p.skip_local)
+    if (!domain->p.skip_local && !skip_refined)
     {
-        p4est_transfer_fixed_end ((p4est_transfer_context_t *) p->async_state);
+        p4est_transfer_fixed_end ((p4est_transfer_context_t *) p->
+                                  async_state);
     }
     else
     {
-        p4est_transfer_custom_end ((p4est_transfer_context_t *) p->async_state);
+        p4est_transfer_custom_end ((p4est_transfer_context_t *) p->
+                                   async_state);
     }
 
     p->async_state = NULL;

--- a/src/forestclaw2d.c
+++ b/src/forestclaw2d.c
@@ -1798,9 +1798,14 @@ fclaw2d_domain_iterate_pack (fclaw2d_domain_t * domain, size_t data_size,
                 {
                     break;      /* jumped to end of array */
                 }
+                /* skip newly refined patches that stay local */
                 while (skip_refined && next_refined < i)
                 {
-                    /* skip newly refined patches that stay local */
+                    if (next_refined + P4EST_CHILDREN > i) {
+                        /* i is a newly refined sibling patch */
+                        num_src -= next_refined + P4EST_CHILDREN - i;
+                        i = next_refined + P4EST_CHILDREN;
+                    }
                     next_refined = (nri == num_nr) ? old_lnp :
                         *(int *) sc_array_index_int (wrap->newly_refined,
                                                      nri++);

--- a/src/forestclaw2d.h
+++ b/src/forestclaw2d.h
@@ -159,6 +159,21 @@ typedef struct fclaw2d_domain_persist
     int skip_local;             /**< Boolean: If true the patch data of patches
                                      that stay local is not packed during
                                      partitioning. */
+    int skip_refined;           /**< Boolean: If true, the patch data of patches
+                                     that were refined during the most recent
+                                     call to \ref fclaw2d_domain_adapt is only
+                                     packed for the patches with child id 0 in
+                                     \ref fclaw2d_domain_iterate_pack. The
+                                     unpack callback in
+                                     \ref fclaw2d_domain_iterate_unpack will
+                                     be invoked for all children of a recently
+                                     refined patch. The provided data will be
+                                     the data packed by the patch with
+                                     child id 0.
+                                     For this partitioning method to work as
+                                     desired skip_refined has to be set before
+                                     the most recent call to
+                                     \ref fclaw2d_domain_adapt. */
 }
 fclaw2d_domain_persist_t;
 
@@ -681,10 +696,23 @@ void fclaw2d_domain_set_refinement (fclaw2d_domain_t * domain,
  * \param [in] skip_local       Boolean: If true, the patch data of patches that
  *                              stay local are not packed during partitioning.
  *                              Suggested default: 1.
+ * \param [in] skip_refined     Boolean: If true, the patch data of patches that
+ *                              were refined during the most recent call to
+ *                              \ref fclaw2d_domain_adapt is only packed for the
+ *                              patches with child id 0 in
+ *                              \ref fclaw2d_domain_iterate_pack. The unpack
+ *                              callback in \ref fclaw2d_domain_iterate_unpack
+ *                              will be invoked for all children of a recently
+ *                              refined patch. The provided data will be the
+ *                              data packed by the patch with child id 0.
+ *                              For this partitioning method to work as desired
+ *                              skip_refined has to be set \b before the most
+ *                              recent call to \ref fclaw2d_domain_adapt .
+ *                              Suggested default: 0.
  */
 void fclaw2d_domain_set_partitioning (fclaw2d_domain_t * domain,
                                       int partition_for_coarsening,
-                                      int skip_local);
+                                      int skip_local, int skip_refined);
 
 /** Mark a patch for refinement.
  * This must ONLY be called for local patches.

--- a/src/forestclaw2d.h
+++ b/src/forestclaw2d.h
@@ -698,13 +698,16 @@ void fclaw2d_domain_set_refinement (fclaw2d_domain_t * domain,
  *                              Suggested default: 1.
  * \param [in] skip_refined     Boolean: If true, the patch data of patches that
  *                              were refined during the most recent call to
- *                              \ref fclaw2d_domain_adapt is only packed for one
- *                              of the siblings by invoking
+ *                              \ref fclaw2d_domain_adapt is only packed for the
+ *                              first sibling by invoking
  *                              \ref fclaw2d_domain_iterate_pack. The unpack
  *                              callback in \ref fclaw2d_domain_iterate_unpack
  *                              will be invoked for all children of a recently
  *                              refined patch. The provided data will be the
  *                              data packed previously by one of the siblings.
+ *                              For each first patch sent to a specific process,
+ *                              \ref fclaw2d_domain_iterate_pack will be invoked
+ *                              regardless of its child id.
  *                              For this partitioning method to work as desired
  *                              skip_refined has to be set \b before the most
  *                              recent call to \ref fclaw2d_domain_adapt .
@@ -848,8 +851,9 @@ typedef struct fclaw2d_domain_partition
 fclaw2d_domain_partition_t;
 
 /** Callback to pack patch data after partitioning.
- * We traverse every local patch in the old partition. If that patch has to be
- * packed for the new partition, we invoke this callback.
+ * The function \ref fclaw2d_domain_iterate_pack traverses every local patch in
+ * the old partition. If that patch has to be packed for the new partition, it
+ * invokes this callback.
  * \param [in,out] domain   Domain before partition.
  * \param [in,out] patch    Patch from the domain. Its user data should be
                             packed into \b pack_data_here.
@@ -864,12 +868,10 @@ typedef void (*fclaw2d_pack_callback_t) (fclaw2d_domain_t * domain,
                                          void *user);
 
 /** Start asynchronous transfer of patch data after partition.
- * The function iterates over the local patches of old partition and determines
- * patches that have to be packed by use of \b patch_pack and send to the new
- * partition. If skip_local is set to false in the domain, \b patch_pack is
- * called for every local patch. If skip_local is true (default), \b patch_pack
- * is called only for local patches that are sent to a different process during
- * partitioning.
+ * This function iterates over the local patches of old partition and determines
+ * patches that have to be packed by use of \b patch_pack based on the options
+ * skip_local, skip_refined and partition_for_coarsening (see
+ * \ref fclaw2d_domain_set_partitioning). Then, the patches are packed and sent.
  * This function must be followed by a call to \ref fclaw2d_domain_iterate_unpack.
  * \param [in,out] domain       The domain before partitioning.
  * \param [in] data_size        The number of bytes of user data that has to be
@@ -887,9 +889,9 @@ fclaw2d_domain_partition_t
                                    void *user);
 
 /** Transfer data of patches still local after partition.
- * The function iterates over all pairs of local patches in the domain before
+ * This function iterates over all pairs of local patches in the domain before
  * and after partitioning and invokes the transfer of their user-data via
- * \ref patch_transfer.
+ * \b patch_transfer.
  * It may be called before, between or after \ref fclaw2d_domain_iterate_pack
  * and \ref fclaw2d_domain_iterate_unpack. It is recommended to call it between
  * packing and unpacking, to overlap communication with computation.
@@ -906,7 +908,8 @@ void fclaw2d_domain_iterate_transfer (fclaw2d_domain_t * old_domain,
                                       patch_transfer, void *user);
 
 /** Callback to unpack patch data after partitioning.
- * We traverse every local patch, that was not local before partitioning.
+ * The function \ref fclaw2d_domain_iterate_unpack traverses every local patch,
+ * that was not local before partitioning and invokes this callback.
  * \param [in,out] domain   Domain after partition.
  * \param [in,out] patch    Patch from the domain. Its user data should be
                             unpacked from \b unpack_data_from_here.
@@ -923,8 +926,10 @@ typedef void (*fclaw2d_unpack_callback_t) (fclaw2d_domain_t * domain,
                                            void *user);
 
 /** Complete asynchronous transfer of patch data after partition.
- * The function iterates over all local patches of new partition and determines
- * patches that have to be unpacked by use of \b patch_unpack.
+ * This function iterates over all local patches of the new partition and
+ * determines patches that have to be unpacked by use of \b patch_unpack based
+ * on the options skip_local, skip_refined and partition_for_coarsening (see
+ * \ref fclaw2d_domain_set_partitioning).
  * It must be preceded by a call to \ref fclaw2d_domain_iterate_unpack and
  * provided with the corresponding \ref fclaw2d_domain_partition_t \b p.
  * \param [in,out] domain       The domain after partitioning.

--- a/src/forestclaw2d.h
+++ b/src/forestclaw2d.h
@@ -698,13 +698,13 @@ void fclaw2d_domain_set_refinement (fclaw2d_domain_t * domain,
  *                              Suggested default: 1.
  * \param [in] skip_refined     Boolean: If true, the patch data of patches that
  *                              were refined during the most recent call to
- *                              \ref fclaw2d_domain_adapt is only packed for the
- *                              patches with child id 0 in
+ *                              \ref fclaw2d_domain_adapt is only packed for one
+ *                              of the siblings by invoking
  *                              \ref fclaw2d_domain_iterate_pack. The unpack
  *                              callback in \ref fclaw2d_domain_iterate_unpack
  *                              will be invoked for all children of a recently
  *                              refined patch. The provided data will be the
- *                              data packed by the patch with child id 0.
+ *                              data packed previously by one of the siblings.
  *                              For this partitioning method to work as desired
  *                              skip_refined has to be set \b before the most
  *                              recent call to \ref fclaw2d_domain_adapt .

--- a/src/forestclaw3d.h
+++ b/src/forestclaw3d.h
@@ -821,13 +821,13 @@ void fclaw3d_domain_set_refinement (fclaw3d_domain_t * domain,
  *                              Suggested default: 1.
  * \param [in] skip_refined     Boolean: If true, the patch data of patches that
  *                              were refined during the most recent call to
- *                              \ref fclaw3d_domain_adapt is only packed for the
- *                              patches with child id 0 in
+ *                              \ref fclaw3d_domain_adapt is only packed for one
+ *                              of the siblings by invoking
  *                              \ref fclaw3d_domain_iterate_pack. The unpack
  *                              callback in \ref fclaw3d_domain_iterate_unpack
  *                              will be invoked for all children of a recently
  *                              refined patch. The provided data will be the
- *                              data packed by the patch with child id 0.
+ *                              data packed previously by one of the siblings.
  *                              For this partitioning method to work as desired
  *                              skip_refined has to be set \b before the most
  *                              recent call to \ref fclaw3d_domain_adapt .

--- a/src/forestclaw3d.h
+++ b/src/forestclaw3d.h
@@ -162,6 +162,21 @@ typedef struct fclaw3d_domain_persist
     int skip_local;             /**< Boolean: If true the patch data of patches
                                      that stay local is not packed during
                                      partitioning. */
+    int skip_refined;           /**< Boolean: If true, the patch data of patches
+                                     that were refined during the most recent
+                                     call to \ref fclaw3d_domain_adapt is only
+                                     packed for the patches with child id 0 in
+                                     \ref fclaw3d_domain_iterate_pack. The
+                                     unpack callback in
+                                     \ref fclaw3d_domain_iterate_unpack will
+                                     be invoked for all children of a recently
+                                     refined patch. The provided data will be
+                                     the data packed by the patch with
+                                     child id 0.
+                                     For this partitioning method to work as
+                                     desired skip_refined has to be set before
+                                     the most recent call to
+                                     \ref fclaw3d_domain_adapt. */
 }
 fclaw3d_domain_persist_t;
 
@@ -804,10 +819,23 @@ void fclaw3d_domain_set_refinement (fclaw3d_domain_t * domain,
  * \param [in] skip_local       Boolean: If true, the patch data of patches that
  *                              stay local are not packed during partitioning.
  *                              Suggested default: 1.
+ * \param [in] skip_refined     Boolean: If true, the patch data of patches that
+ *                              were refined during the most recent call to
+ *                              \ref fclaw3d_domain_adapt is only packed for the
+ *                              patches with child id 0 in
+ *                              \ref fclaw3d_domain_iterate_pack. The unpack
+ *                              callback in \ref fclaw3d_domain_iterate_unpack
+ *                              will be invoked for all children of a recently
+ *                              refined patch. The provided data will be the
+ *                              data packed by the patch with child id 0.
+ *                              For this partitioning method to work as desired
+ *                              skip_refined has to be set \b before the most
+ *                              recent call to \ref fclaw3d_domain_adapt .
+ *                              Suggested default: 0.
  */
 void fclaw3d_domain_set_partitioning (fclaw3d_domain_t * domain,
                                       int partition_for_coarsening,
-                                      int skip_local);
+                                      int skip_local, int skip_refined);
 
 /** Mark a patch for refinement.
  * This must ONLY be called for local patches.


### PR DESCRIPTION
This PR adds a skip_refined flag as described in https://github.com/ForestClaw/forestclaw/pull/335 to the domain_persist_t.

The flag defaults to 0 and can be set with `fclaw2d_domain_set_partitioning`.
If true, the patch data of patches that were refined during the most recent call to `fclaw3d_domain_adapt` is only packed for the sibling with child id 0. Additionally, when a newly refined family is split between multiple processes in the new partition, the patch data will be packed for the first patch sent to each of these processes. In `fclaw2d_domain_iterate_unpack` every sibling of the newly refined family will be supplied with the data packed by the sibling with child id 0. This option allows to delay the computation/allocation of the siblings' patch data until after the partitioning in memory-intensive runs.

The partitioning demo is adapted to the new option. It now contains a workflow that allocates the siblings' patch data only after partitioning. Furthermore, we add a more sophisticated patch data structure and compute checksums of the local patch data to compare and verify the different partitioning strategies.