### PR TITLE
Feature Refine After Partition

### DIFF
--- a/src/fclaw2d_to_3d.h
+++ b/src/fclaw2d_to_3d.h
@@ -217,6 +217,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define fclaw2d_transfer_wrap_cb           fclaw3d_transfer_wrap_cb
 #define fclaw2d_match_wrap_cb              fclaw3d_match_wrap_cb
 #define fclaw2d_pack_wrap_cb               fclaw3d_pack_wrap_cb
+#define fclaw2d_unpack_wrap_cb             fclaw3d_unpack_wrap_cb
 #define fclaw2d_intersect_wrap_cb          fclaw3d_intersect_wrap_cb
 #define fclaw2d_interpolate_point_wrap_cb  fclaw3d_interpolate_point_wrap_cb
 #define fclaw2d_file_error_wrap            fclaw3d_file_error_wrap

--- a/src/fclaw2d_to_3d.h
+++ b/src/fclaw2d_to_3d.h
@@ -216,6 +216,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define fclaw2d_patch_wrap_cb              fclaw3d_patch_wrap_cb
 #define fclaw2d_transfer_wrap_cb           fclaw3d_transfer_wrap_cb
 #define fclaw2d_match_wrap_cb              fclaw3d_match_wrap_cb
+#define fclaw2d_pack_wrap_cb               fclaw3d_pack_wrap_cb
 #define fclaw2d_intersect_wrap_cb          fclaw3d_intersect_wrap_cb
 #define fclaw2d_interpolate_point_wrap_cb  fclaw3d_interpolate_point_wrap_cb
 #define fclaw2d_file_error_wrap            fclaw3d_file_error_wrap

--- a/src/fclaw2d_wrap.c
+++ b/src/fclaw2d_wrap.c
@@ -232,6 +232,22 @@ fclaw2d_pack_wrap_cb (fclaw2d_domain_t * domain_2d,
     wrap->pcb(domain, patch, blockno, patchno, pack_data_here, wrap->user);
 }
 
+void
+fclaw2d_unpack_wrap_cb (fclaw2d_domain_t * domain_2d,
+                        fclaw2d_patch_t * patch_2d,
+                        int blockno, int patchno,
+                        void *unpack_data_from_here,
+                        void *user)
+{
+    fclaw_unpack_wrap_user_t* wrap = 
+        (fclaw_unpack_wrap_user_t*) user;
+
+    fclaw_domain_t* domain = get_domain(domain_2d);
+    fclaw_patch_t* patch = get_patch(patch_2d);
+
+    wrap->ucb(domain, patch, blockno, patchno, unpack_data_from_here, wrap->user);
+}
+
 int 
 fclaw2d_intersect_wrap_cb (fclaw2d_domain_t * domain_2d,
                         fclaw2d_patch_t * patch_2d,

--- a/src/fclaw2d_wrap.c
+++ b/src/fclaw2d_wrap.c
@@ -216,6 +216,22 @@ fclaw2d_match_wrap_cb(fclaw2d_domain_t * old_domain_2d,
               wrap->user);
 }
 
+void
+fclaw2d_pack_wrap_cb (fclaw2d_domain_t * domain_2d,
+                      fclaw2d_patch_t * patch_2d,
+                      int blockno, int patchno,
+                      void *pack_data_here,
+                      void *user)
+{
+    fclaw_pack_wrap_user_t* wrap = 
+        (fclaw_pack_wrap_user_t*) user;
+
+    fclaw_domain_t* domain = get_domain(domain_2d);
+    fclaw_patch_t* patch = get_patch(patch_2d);
+
+    wrap->pcb(domain, patch, blockno, patchno, pack_data_here, wrap->user);
+}
+
 int 
 fclaw2d_intersect_wrap_cb (fclaw2d_domain_t * domain_2d,
                         fclaw2d_patch_t * patch_2d,

--- a/src/fclaw2d_wrap.h
+++ b/src/fclaw2d_wrap.h
@@ -91,6 +91,19 @@ fclaw2d_match_wrap_cb(fclaw2d_domain_t * old_domain,
                       int blockno,
                       int old_patchno, int new_patchno,
                       void *user);
+
+/** 
+ * @brief Wraps a partition pack callback for 2d domains.
+ * This is used by passing this callback to a function that takes a @ref fclaw2d_pack_callback_t.
+ * The user pointer should be a pointer to a @ref fclaw_pack_wrap_user_t.
+ */
+void
+fclaw2d_pack_wrap_cb(fclaw2d_domain_t * domain,
+                     fclaw2d_patch_t * patch,
+                     int blockno, int patchno,
+                     void *pack_data_here,
+                     void *user);
+
 /**
  * @brief Wraps a intersect callback for 2d domains.
  * This is used by passing this callback to a function that takes a @ref fclaw2d_intersect_callback_t.

--- a/src/fclaw2d_wrap.h
+++ b/src/fclaw2d_wrap.h
@@ -104,6 +104,18 @@ fclaw2d_pack_wrap_cb(fclaw2d_domain_t * domain,
                      void *pack_data_here,
                      void *user);
 
+/** 
+ * @brief Wraps a partition unpack callback for 2d domains.
+ * This is used by passing this callback to a function that takes a @ref fclaw2d_unpack_callback_t.
+ * The user pointer should be a pointer to a @ref fclaw_unpack_wrap_user_t.
+ */
+void
+fclaw2d_unpack_wrap_cb(fclaw2d_domain_t * domain,
+                       fclaw2d_patch_t * patch,
+                       int blockno, int patchno,
+                       void *unpack_data_from_here,
+                       void *user);
+
 /**
  * @brief Wraps a intersect callback for 2d domains.
  * This is used by passing this callback to a function that takes a @ref fclaw2d_intersect_callback_t.

--- a/src/fclaw3d_wrap.h
+++ b/src/fclaw3d_wrap.h
@@ -92,6 +92,18 @@ fclaw3d_match_wrap_cb(fclaw3d_domain_t * old_domain,
                       int old_patchno, int new_patchno,
                       void *user);
 
+/** 
+ * @brief Wraps a partition pack callback for 3d domains.
+ * This is used by passing this callback to a function that takes a @ref fclaw3d_pack_callback_t.
+ * The user pointer should be a pointer to a @ref fclaw_pack_wrap_user_t.
+ */
+void
+fclaw3d_pack_wrap_cb(fclaw3d_domain_t * domain,
+                     fclaw3d_patch_t * patch,
+                     int blockno, int patchno,
+                     void *pack_data_here,
+                     void *user);
+
 /**
  * @brief Wraps a intersect callback for 2d domains.
  * This is used by passing this callback to a function that takes a @ref fclaw2d_intersect_callback_t.

--- a/src/fclaw3d_wrap.h
+++ b/src/fclaw3d_wrap.h
@@ -104,6 +104,19 @@ fclaw3d_pack_wrap_cb(fclaw3d_domain_t * domain,
                      void *pack_data_here,
                      void *user);
 
+/** 
+ * @brief Wraps a partition unpack callback for 3d domains.
+ * This is used by passing this callback to a function that takes a @ref fclaw3d_unpack_callback_t.
+ * The user pointer should be a pointer to a @ref fclaw_unpack_wrap_user_t.
+ */
+void
+fclaw3d_unpack_wrap_cb(fclaw3d_domain_t * domain,
+                       fclaw3d_patch_t * patch,
+                       int blockno, int patchno,
+                       void *unpack_data_from_here,
+                       void *user);
+
+
 /**
  * @brief Wraps a intersect callback for 2d domains.
  * This is used by passing this callback to a function that takes a @ref fclaw2d_intersect_callback_t.

--- a/src/fclaw_domain.c
+++ b/src/fclaw_domain.c
@@ -78,7 +78,7 @@ void fclaw_domain_reset(fclaw_global_t* glob)
             /* This is here to delete any patches created during
                initialization, and not through regridding */
             fclaw_patch_t *patch = block->patches + j;
-            fclaw_patch_data_delete(glob,patch);
+            fclaw_patch_data_delete(glob,*domain,patch);
         }
         block->user = NULL;
     }

--- a/src/fclaw_initialize.c
+++ b/src/fclaw_initialize.c
@@ -168,38 +168,11 @@ void build_initial_domain(fclaw_global_t *glob)
             {
                 fclaw_global_infof(" -- Have new initial refinement\n");
 
-                /* Re-initialize new grids.   Ghost cell values needed for
-                   interpolation have already been set by initialization */
-                fclaw_timer_start (&glob->timers[FCLAW_TIMER_REGRID_BUILD]);
-                fclaw_global_iterate_adapted(glob, new_domain,
-                                               cb_fclaw_regrid_repopulate,
-                                               (void *) &domain_init);
-
-                fclaw_timer_stop (&glob->timers[FCLAW_TIMER_REGRID_BUILD]);
-
-                /* free all memory associated with old domain */
-                fclaw_domain_reset(glob);
-                *domain = new_domain;
-                new_domain = NULL;
-
-                /* Repartition domain to new processors.    */
-                fclaw_partition_domain(glob,FCLAW_TIMER_INIT);
-
-                /* refine patches (if needed) */
-                if(fclaw_opt->refine_after_parition)
-                {
-                    fclaw_timer_start (&glob->timers[FCLAW_TIMER_REGRID_BUILD]);
-                    fclaw_regrid_refine_after_partition(glob);
-                    fclaw_timer_stop (&glob->timers[FCLAW_TIMER_REGRID_BUILD]);
-                }
-
-                /* Set up ghost patches.  This probably doesn't need to be done
-                   each time we add a new level. */
-                fclaw_exchange_setup(glob,FCLAW_TIMER_INIT);
-                
-                /* This is normally called from regrid, once the initial domain
-                   has been set up */
-                fclaw_regrid_set_neighbor_types(glob);
+                fclaw_regrid_process_new_refinement(glob, 
+                                                    domain, 
+                                                    new_domain, 
+                                                    domain_init, 
+                                                    FCLAW_TIMER_INIT);
             }
             else
             {

--- a/src/fclaw_initialize.c
+++ b/src/fclaw_initialize.c
@@ -202,10 +202,10 @@ void fclaw_initialize_domain_flags(fclaw_global_t *glob)
         (glob->domain, fclaw_opt->smooth_refine, fclaw_opt->smooth_level,
          fclaw_opt->coarsen_delay);
 
-    int skip_local = fclaw_opt->regrid_mode == FCLAW_OPTIONS_REGRID_MODE_SKIP_LOCAL || 
-                     fclaw_opt->regrid_mode == FCLAW_OPTIONS_REGRID_MODE_REFINE_AFTER;
+    int skip_local = fclaw_opt->partition_mode == FCLAW_PARTITION_MODE_SKIP_LOCAL || 
+                     fclaw_opt->partition_mode == FCLAW_PARTITION_MODE_REFINE_AFTER;
     
-    int skip_refined = fclaw_opt->regrid_mode == FCLAW_OPTIONS_REGRID_MODE_REFINE_AFTER;
+    int skip_refined = fclaw_opt->partition_mode == FCLAW_PARTITION_MODE_REFINE_AFTER;
 
     /* set partitioning */
     fclaw_domain_set_partitioning (glob->domain,

--- a/src/fclaw_initialize.c
+++ b/src/fclaw_initialize.c
@@ -185,6 +185,14 @@ void build_initial_domain(fclaw_global_t *glob)
                 /* Repartition domain to new processors.    */
                 fclaw_partition_domain(glob,FCLAW_TIMER_INIT);
 
+                /* refine patches (if needed) */
+                if(fclaw_opt->refine_after_parition)
+                {
+                    fclaw_timer_start (&glob->timers[FCLAW_TIMER_REGRID_BUILD]);
+                    fclaw_regrid_refine_after_partition(glob);
+                    fclaw_timer_stop (&glob->timers[FCLAW_TIMER_REGRID_BUILD]);
+                }
+
                 /* Set up ghost patches.  This probably doesn't need to be done
                    each time we add a new level. */
                 fclaw_exchange_setup(glob,FCLAW_TIMER_INIT);

--- a/src/fclaw_initialize.c
+++ b/src/fclaw_initialize.c
@@ -64,10 +64,12 @@ void cb_initialize (fclaw_domain_t *domain,
 
 	fclaw_build_mode_t build_mode = FCLAW_BUILD_FOR_UPDATE;
 
-	fclaw_patch_build(g->glob,this_patch,
-						this_block_idx,
-						this_patch_idx,
-						&build_mode);
+	fclaw_patch_build(g->glob,
+                      domain,
+                      this_patch,
+                      this_block_idx,
+                      this_patch_idx,
+                      &build_mode);
 	fclaw_patch_initialize(g->glob,this_patch,this_block_idx,this_patch_idx);
 }
 

--- a/src/fclaw_initialize.c
+++ b/src/fclaw_initialize.c
@@ -200,9 +200,16 @@ void fclaw_initialize_domain_flags(fclaw_global_t *glob)
         (glob->domain, fclaw_opt->smooth_refine, fclaw_opt->smooth_level,
          fclaw_opt->coarsen_delay);
 
+    int skip_local = fclaw_opt->regrid_mode == FCLAW_OPTIONS_REGRID_MODE_SKIP_LOCAL || 
+                     fclaw_opt->regrid_mode == FCLAW_OPTIONS_REGRID_MODE_REFINE_AFTER;
+    
+    int skip_refined = fclaw_opt->regrid_mode == FCLAW_OPTIONS_REGRID_MODE_REFINE_AFTER;
+
     /* set partitioning */
     fclaw_domain_set_partitioning (glob->domain,
-                                   fclaw_opt->partition_for_coarsening, 1, 0);
+                                   fclaw_opt->partition_for_coarsening, 
+                                   skip_local,
+                                   skip_refined);
 }
 
 static void

--- a/src/fclaw_options.c
+++ b/src/fclaw_options.c
@@ -382,10 +382,6 @@ fclaw_register (fclaw_options_t* fclaw_opt, sc_options_t * opt)
                           &fclaw_opt->max_refinement_ratio, 1.0,
                           "Ratio of patches to refine before paritioning and continuing refinement. [1.0]");
 
-    sc_options_add_bool(opt, 0, "refine-after-partition",
-                        &fclaw_opt->refine_after_parition, 0,
-                        "Refine the patches after the partitioning step [F]");
-
     fclaw_opt->is_registered = 1;
     fclaw_opt->is_unpacked = 0;
 

--- a/src/fclaw_options.c
+++ b/src/fclaw_options.c
@@ -382,6 +382,10 @@ fclaw_register (fclaw_options_t* fclaw_opt, sc_options_t * opt)
                           &fclaw_opt->max_refinement_ratio, 1.0,
                           "Ratio of patches to refine before paritioning and continuing refinement. [1.0]");
 
+    sc_options_add_bool(opt, 0, "refine-after-partition",
+                        &fclaw_opt->refine_after_parition, 0,
+                        "Refine the patches after the partitioning step [F]");
+
     fclaw_opt->is_registered = 1;
     fclaw_opt->is_unpacked = 0;
 

--- a/src/fclaw_options.c
+++ b/src/fclaw_options.c
@@ -382,6 +382,15 @@ fclaw_register (fclaw_options_t* fclaw_opt, sc_options_t * opt)
                           &fclaw_opt->max_refinement_ratio, 1.0,
                           "Ratio of patches to refine before paritioning and continuing refinement. [1.0]");
 
+    kv = fclaw_opt->kv_regrid_mode = sc_keyvalue_new ();
+    sc_keyvalue_set_int (kv, "old",                    FCLAW_OPTIONS_REGRID_MODE_OLD);
+    sc_keyvalue_set_int (kv, "new",                    FCLAW_OPTIONS_REGRID_MODE_NEW); 
+    sc_keyvalue_set_int (kv, "skip-local-patches",     FCLAW_OPTIONS_REGRID_MODE_SKIP_LOCAL);
+    sc_keyvalue_set_int (kv, "refine-after-partition", FCLAW_OPTIONS_REGRID_MODE_REFINE_AFTER);
+    sc_options_add_keyvalue (opt, 0, "regrid-mode", 
+                             &fclaw_opt->regrid_mode,
+                             "old", kv, "Regrid mode [old]");
+
     fclaw_opt->is_registered = 1;
     fclaw_opt->is_unpacked = 0;
 
@@ -460,6 +469,7 @@ fclaw_options_destroy(fclaw_options_t* fclaw_opt)
 
     FCLAW_ASSERT (fclaw_opt->kv_timing_verbosity != NULL);
     sc_keyvalue_destroy (fclaw_opt->kv_timing_verbosity);
+    sc_keyvalue_destroy (fclaw_opt->kv_regrid_mode);
 
     // Strings need to be freed if this was unpacked form buffer
     if(fclaw_opt->is_unpacked){

--- a/src/fclaw_options.c
+++ b/src/fclaw_options.c
@@ -383,13 +383,13 @@ fclaw_register (fclaw_options_t* fclaw_opt, sc_options_t * opt)
                           "Ratio of patches to refine before paritioning and continuing refinement. [1.0]");
 
     kv = fclaw_opt->kv_regrid_mode = sc_keyvalue_new ();
-    sc_keyvalue_set_int (kv, "old",                    FCLAW_OPTIONS_REGRID_MODE_OLD);
-    sc_keyvalue_set_int (kv, "new",                    FCLAW_OPTIONS_REGRID_MODE_NEW); 
-    sc_keyvalue_set_int (kv, "skip-local-patches",     FCLAW_OPTIONS_REGRID_MODE_SKIP_LOCAL);
+    sc_keyvalue_set_int (kv, "legacy",                 FCLAW_OPTIONS_REGRID_MODE_OLD);
+    sc_keyvalue_set_int (kv, "pack-all",               FCLAW_OPTIONS_REGRID_MODE_NEW); 
+    sc_keyvalue_set_int (kv, "skip-local",             FCLAW_OPTIONS_REGRID_MODE_SKIP_LOCAL);
     sc_keyvalue_set_int (kv, "refine-after-partition", FCLAW_OPTIONS_REGRID_MODE_REFINE_AFTER);
     sc_options_add_keyvalue (opt, 0, "regrid-mode", 
                              &fclaw_opt->regrid_mode,
-                             "old", kv, "Regrid mode [old]");
+                             "legacy", kv, "Regrid mode [legacy]");
 
     fclaw_opt->is_registered = 1;
     fclaw_opt->is_unpacked = 0;

--- a/src/fclaw_options.c
+++ b/src/fclaw_options.c
@@ -382,7 +382,7 @@ fclaw_register (fclaw_options_t* fclaw_opt, sc_options_t * opt)
                           &fclaw_opt->max_refinement_ratio, 1.0,
                           "Ratio of patches to refine before paritioning and continuing refinement. [1.0]");
 
-    kv = fclaw_opt->kv_regrid_mode = sc_keyvalue_new ();
+    kv = fclaw_opt->kv_partition_mode = sc_keyvalue_new ();
     sc_keyvalue_set_int (kv, "legacy",                 FCLAW_PARTITION_MODE_LEGACY);
     sc_keyvalue_set_int (kv, "pack-all",               FCLAW_PARTITION_MODE_PACK_ALL); 
     sc_keyvalue_set_int (kv, "skip-local",             FCLAW_PARTITION_MODE_SKIP_LOCAL);
@@ -469,7 +469,7 @@ fclaw_options_destroy(fclaw_options_t* fclaw_opt)
 
     FCLAW_ASSERT (fclaw_opt->kv_timing_verbosity != NULL);
     sc_keyvalue_destroy (fclaw_opt->kv_timing_verbosity);
-    sc_keyvalue_destroy (fclaw_opt->kv_regrid_mode);
+    sc_keyvalue_destroy (fclaw_opt->kv_partition_mode);
 
     // Strings need to be freed if this was unpacked form buffer
     if(fclaw_opt->is_unpacked){

--- a/src/fclaw_options.c
+++ b/src/fclaw_options.c
@@ -383,13 +383,13 @@ fclaw_register (fclaw_options_t* fclaw_opt, sc_options_t * opt)
                           "Ratio of patches to refine before paritioning and continuing refinement. [1.0]");
 
     kv = fclaw_opt->kv_regrid_mode = sc_keyvalue_new ();
-    sc_keyvalue_set_int (kv, "legacy",                 FCLAW_OPTIONS_REGRID_MODE_OLD);
-    sc_keyvalue_set_int (kv, "pack-all",               FCLAW_OPTIONS_REGRID_MODE_NEW); 
-    sc_keyvalue_set_int (kv, "skip-local",             FCLAW_OPTIONS_REGRID_MODE_SKIP_LOCAL);
-    sc_keyvalue_set_int (kv, "refine-after-partition", FCLAW_OPTIONS_REGRID_MODE_REFINE_AFTER);
-    sc_options_add_keyvalue (opt, 0, "regrid-mode", 
-                             &fclaw_opt->regrid_mode,
-                             "legacy", kv, "Regrid mode [legacy]");
+    sc_keyvalue_set_int (kv, "legacy",                 FCLAW_PARTITION_MODE_LEGACY);
+    sc_keyvalue_set_int (kv, "pack-all",               FCLAW_PARTITION_MODE_PACK_ALL); 
+    sc_keyvalue_set_int (kv, "skip-local",             FCLAW_PARTITION_MODE_SKIP_LOCAL);
+    sc_keyvalue_set_int (kv, "refine-after-partition", FCLAW_PARTITION_MODE_REFINE_AFTER);
+    sc_options_add_keyvalue (opt, 0, "partition-mode", 
+                             &fclaw_opt->partition_mode,
+                             "legacy", kv, "Parition mode to use. One of (legacy, pack-all, skip-local, refine-after-partition) [legacy]");
 
     fclaw_opt->is_registered = 1;
     fclaw_opt->is_unpacked = 0;

--- a/src/fclaw_options.h
+++ b/src/fclaw_options.h
@@ -254,6 +254,7 @@ struct fclaw_options
     const char * regression_check; /**< filename of regression check values */
 
     double max_refinement_ratio; /**< Maximum refinment ratio before partitioning and continuing refinement. */
+    int refine_after_parition; /**< Refine the patches after the partitioning step */
 };
 
 struct fclaw_global;

--- a/src/fclaw_options.h
+++ b/src/fclaw_options.h
@@ -254,7 +254,6 @@ struct fclaw_options
     const char * regression_check; /**< filename of regression check values */
 
     double max_refinement_ratio; /**< Maximum refinment ratio before partitioning and continuing refinement. */
-    int refine_after_parition; /**< Refine the patches after the partitioning step */
 };
 
 struct fclaw_global;

--- a/src/fclaw_options.h
+++ b/src/fclaw_options.h
@@ -112,8 +112,14 @@ void fclaw_options_convert_double_array (const char *array_string,
 void fclaw_options_destroy_array(void* array);
 
 
-/* Plan is to replace fclaw_options_t with fclaw_options_t.
-   Maybe use a macro as an intermediate step? */
+typedef enum fclaw_options_regrid_mode
+{
+    FCLAW_OPTIONS_REGRID_MODE_OLD,
+    FCLAW_OPTIONS_REGRID_MODE_NEW,
+    FCLAW_OPTIONS_REGRID_MODE_SKIP_LOCAL,
+    FCLAW_OPTIONS_REGRID_MODE_REFINE_AFTER
+} fclaw_options_regrid_mode_t;
+
 
 struct fclaw_options
 {
@@ -254,6 +260,9 @@ struct fclaw_options
     const char * regression_check; /**< filename of regression check values */
 
     double max_refinement_ratio; /**< Maximum refinment ratio before partitioning and continuing refinement. */
+
+    int regrid_mode; /**< Regrid mode */
+    sc_keyvalue_t *kv_regrid_mode; /**< sc_keyvalue needed for enum option type */
 };
 
 struct fclaw_global;

--- a/src/fclaw_options.h
+++ b/src/fclaw_options.h
@@ -112,13 +112,20 @@ void fclaw_options_convert_double_array (const char *array_string,
 void fclaw_options_destroy_array(void* array);
 
 
-typedef enum fclaw_options_regrid_mode
+/**
+ * @brief Enum for partition mode
+ */
+enum fclaw_parition_mode
 {
-    FCLAW_OPTIONS_REGRID_MODE_OLD,
-    FCLAW_OPTIONS_REGRID_MODE_NEW,
-    FCLAW_OPTIONS_REGRID_MODE_SKIP_LOCAL,
-    FCLAW_OPTIONS_REGRID_MODE_REFINE_AFTER
-} fclaw_options_regrid_mode_t;
+    /** Use legacy paritioning interface */
+    FCLAW_PARTITION_MODE_LEGACY,
+    /** Pack/unpack all patches */
+    FCLAW_PARTITION_MODE_PACK_ALL,
+    /** Skip packing of local patches */
+    FCLAW_PARTITION_MODE_SKIP_LOCAL,
+    /** Skip packing of local patches and refine after partitioning */
+    FCLAW_PARTITION_MODE_REFINE_AFTER
+};
 
 
 struct fclaw_options
@@ -261,7 +268,7 @@ struct fclaw_options
 
     double max_refinement_ratio; /**< Maximum refinment ratio before partitioning and continuing refinement. */
 
-    int regrid_mode; /**< Regrid mode */
+    int partition_mode; /**< Partition mode */
     sc_keyvalue_t *kv_regrid_mode; /**< sc_keyvalue needed for enum option type */
 };
 

--- a/src/fclaw_options.h
+++ b/src/fclaw_options.h
@@ -269,7 +269,7 @@ struct fclaw_options
     double max_refinement_ratio; /**< Maximum refinment ratio before partitioning and continuing refinement. */
 
     int partition_mode; /**< Partition mode */
-    sc_keyvalue_t *kv_regrid_mode; /**< sc_keyvalue needed for enum option type */
+    sc_keyvalue_t *kv_partition_mode; /**< sc_keyvalue needed for enum option type */
 };
 
 struct fclaw_global;

--- a/src/fclaw_partition.c
+++ b/src/fclaw_partition.c
@@ -56,6 +56,11 @@ void patch_unpack_cb(fclaw_domain_t * domain,
     fclaw_patch_partition_unpack(glob,domain,patch,
                                  blockno,patchno,
                                  unpack_data_from_here);
+    /* Reason for the following two lines: the glob contains the old domain 
+    which is incremented in ddata_old  but we really want to increment the 
+    new domain. */
+    --glob->domain->count_set_patch;
+    ++domain->count_set_patch; 
 }
 
 static
@@ -255,6 +260,14 @@ void partition_domain(fclaw_global_t* glob,
 
         fclaw_domain_iterate_unpack(new_domain, p, patch_unpack_cb, (void *) glob);
         fclaw_domain_partition_free(p);
+
+        /* then the old domain is no longer necessary */
+        fclaw_domain_reset(glob);
+        *domain = new_domain;
+        new_domain = NULL;
+
+        /* internal clean up */
+        fclaw_domain_complete(*domain);
     }
 
     fclaw_timer_stop (&glob->timers[FCLAW_TIMER_PARTITION]);

--- a/src/fclaw_partition.c
+++ b/src/fclaw_partition.c
@@ -34,31 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <fclaw_options.h>
 
 static
-void patch_pack_cb(fclaw_domain_t * domain,
-                   fclaw_patch_t * patch, int blockno,
-                   int patchno, void *pack_data_here,
-                   void *user)
-{
-    fclaw_global_t *glob = (fclaw_global_t *) user;
-    fclaw_patch_partition_pack(glob,patch,
-                               blockno,patchno,
-                               pack_data_here);
-}
-
-static
-void patch_unpack_cb(fclaw_domain_t * domain,
-                     fclaw_patch_t * patch,
-                     int blockno, int patchno,
-                     void *unpack_data_from_here,
-                     void *user)
-{
-    fclaw_global_t *glob = (fclaw_global_t *) user;
-    fclaw_patch_partition_unpack(glob,domain,patch,
-                                 blockno,patchno,
-                                 unpack_data_from_here);
-}
-
-static
 void cb_partition_pack(fclaw_domain_t *domain,
                        fclaw_patch_t *patch,
                        int blockno,
@@ -99,6 +74,7 @@ void  cb_transfer(fclaw_domain_t * old_domain,
 
     fclaw_patch_shallow_copy(glob,old_domain,old_patch,new_domain,new_patch,
                              blockno,old_patchno,new_patchno);
+    fclaw_patch_data_delete(glob,old_domain,old_patch);
 }
 
 static
@@ -219,6 +195,33 @@ void partition_domain_legacy(fclaw_global_t* glob,
 
     fclaw_timer_stop (&glob->timers[FCLAW_TIMER_PARTITION]);
 }
+
+static
+void patch_pack_cb(fclaw_domain_t * domain,
+                   fclaw_patch_t * patch, int blockno,
+                   int patchno, void *pack_data_here,
+                   void *user)
+{
+    fclaw_global_t *glob = (fclaw_global_t *) user;
+    fclaw_patch_partition_pack(glob,patch,
+                               blockno,patchno,
+                               pack_data_here);
+    fclaw_patch_data_delete(glob,domain,patch);
+}
+
+static
+void patch_unpack_cb(fclaw_domain_t * domain,
+                     fclaw_patch_t * patch,
+                     int blockno, int patchno,
+                     void *unpack_data_from_here,
+                     void *user)
+{
+    fclaw_global_t *glob = (fclaw_global_t *) user;
+    fclaw_patch_partition_unpack(glob,domain,patch,
+                                 blockno,patchno,
+                                 unpack_data_from_here);
+}
+
 
 static
 void partition_domain(fclaw_global_t* glob,

--- a/src/fclaw_partition.c
+++ b/src/fclaw_partition.c
@@ -138,7 +138,7 @@ void  cb_transfer_and_unpack(fclaw_domain_t * old_domain,
 
 /* old partitioning interface, kept for comparison */
 static
-void partition_domain_old(fclaw_global_t* glob,
+void partition_domain_legacy(fclaw_global_t* glob,
                           fclaw_timer_names_t running)
 {
     fclaw_domain_t** domain = &glob->domain;
@@ -265,9 +265,9 @@ void partition_domain(fclaw_global_t* glob,
 void fclaw_partition_domain(fclaw_global_t* glob,
                               fclaw_timer_names_t running)
 {
-    if(fclaw_get_options(glob)->regrid_mode == FCLAW_OPTIONS_REGRID_MODE_OLD)
+    if(fclaw_get_options(glob)->partition_mode == FCLAW_PARTITION_MODE_LEGACY)
     {
-        partition_domain_old(glob,running);
+        partition_domain_legacy(glob,running);
     }
     else
     {

--- a/src/fclaw_patch.c
+++ b/src/fclaw_patch.c
@@ -1313,3 +1313,24 @@ void fclaw_patch_clear_all_considered_for_refinement(struct fclaw_global *glob)
 {
 	fclaw_global_iterate_patches(glob, clear_considred_for_refinement_cb, NULL);
 }
+
+void fclaw_patch_has_coarse_data_set(struct fclaw_global *glob,
+                                     struct fclaw_patch* patch)
+{
+	fclaw_patch_data_t *pdata = get_patch_data(patch);
+	pdata->flags |= FCLAW_PATCH_DATA_HAS_COARSE_DATA;
+}
+
+void fclaw_patch_has_coarse_data_clear(struct fclaw_global *glob,
+                                       struct fclaw_patch* patch)
+{
+	fclaw_patch_data_t *pdata = get_patch_data(patch);
+	pdata->flags &= ~FCLAW_PATCH_DATA_HAS_COARSE_DATA;
+}
+
+int fclaw_patch_has_coarse_data(struct fclaw_global *glob,
+                                struct fclaw_patch* patch)
+{
+	fclaw_patch_data_t *pdata = get_patch_data(patch);
+	return pdata->flags & FCLAW_PATCH_DATA_HAS_COARSE_DATA;
+}

--- a/src/fclaw_patch.c
+++ b/src/fclaw_patch.c
@@ -639,6 +639,23 @@ void fclaw_patch_average2coarse(fclaw_global_t *glob,
 							 blockno,fine0_patchno,coarse_patchno);
 }
 
+void fclaw_patch_store_coarse_in_fine(struct fclaw_global *glob,
+                                       struct fclaw_patch *coarse_patch,
+                                       struct fclaw_patch *fine_patch,
+                                       int blockno, int coarse_patchno,
+                                       int fine_patchno)
+{
+
+}
+
+void fclaw_patch_get_coarse_from_fine(struct fclaw_global *glob,
+                                       struct fclaw_patch *fine_patch,
+                                       struct fclaw_patch *coarse_patch,
+                                       int blockno, int fine_patchno)
+{
+
+}
+
 void fclaw_patch_interpolate2fine(fclaw_global_t* glob,
 									fclaw_patch_t* coarse_patch,
 									fclaw_patch_t* fine_patches,

--- a/src/fclaw_patch.c
+++ b/src/fclaw_patch.c
@@ -23,7 +23,6 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "forestclaw.h"
 #include <fclaw_patch.h>
 #include <fclaw_global.h>
 #include <fclaw_domain.h>
@@ -874,40 +873,93 @@ void fclaw_patch_partition_unpack(fclaw_global_t *glob,
         int igrid = fclaw_patch_childid(patch);
         double width = patch->xupper - patch->xlower;
         double height = patch->yupper - patch->ylower;
+        double depth = patch->zupper - patch->zlower;
         fclaw2d_patch_t artificial_patch_2d;
-        artificial_patch_2d.level  = patch->level-1;
-        artificial_patch_2d.xlower = patch->xlower;
-        artificial_patch_2d.ylower = patch->ylower;
-        artificial_patch_2d.xupper = patch->xupper;
-        artificial_patch_2d.yupper = patch->yupper;
-        artificial_patch_2d.flags  = patch->d2->flags;
-        int lower_x_axis = !(igrid & 0x1);
-        if(lower_x_axis)
-        {
-            artificial_patch_2d.xupper += width;
-        }
-        else
-        {
-            artificial_patch_2d.xlower -= width;
-        }
-        int lower_y_axis = !(igrid & 0x2);
-        if(lower_y_axis)
-        {
-            artificial_patch_2d.yupper += height;
-        }
-        else
-        {
-            artificial_patch_2d.ylower -= height;
-        }
+        fclaw3d_patch_t artificial_patch_3d;
         fclaw_patch_t artificial_patch;
-        artificial_patch.level  = artificial_patch_2d.level;
-        artificial_patch.xlower = artificial_patch_2d.xlower;
-        artificial_patch.ylower = artificial_patch_2d.ylower;
-        artificial_patch.xupper = artificial_patch_2d.xupper;
-        artificial_patch.yupper = artificial_patch_2d.yupper;
-        artificial_patch.d2 = &artificial_patch_2d;
-        artificial_patch.refine_dim = 2;
-        artificial_patch_2d.user = &artificial_patch;
+		if(patch->refine_dim == 2)
+		{
+        	artificial_patch_2d.level  = patch->level-1;
+        	artificial_patch_2d.xlower = patch->xlower;
+        	artificial_patch_2d.ylower = patch->ylower;
+        	artificial_patch_2d.xupper = patch->xupper;
+        	artificial_patch_2d.yupper = patch->yupper;
+        	artificial_patch_2d.flags  = patch->d2->flags;
+        	int lower_x_axis = !(igrid & 0x1);
+        	if(lower_x_axis)
+        	{
+        	    artificial_patch_2d.xupper += width;
+        	}
+        	else
+        	{
+        	    artificial_patch_2d.xlower -= width;
+        	}
+        	int lower_y_axis = !(igrid & 0x2);
+        	if(lower_y_axis)
+        	{
+        	    artificial_patch_2d.yupper += height;
+        	}
+        	else
+        	{
+        	    artificial_patch_2d.ylower -= height;
+        	}
+        	artificial_patch.level  = artificial_patch_2d.level;
+        	artificial_patch.xlower = artificial_patch_2d.xlower;
+        	artificial_patch.ylower = artificial_patch_2d.ylower;
+        	artificial_patch.xupper = artificial_patch_2d.xupper;
+        	artificial_patch.yupper = artificial_patch_2d.yupper;
+        	artificial_patch.d2 = &artificial_patch_2d;
+        	artificial_patch.refine_dim = 2;
+        	artificial_patch_2d.user = &artificial_patch;
+		}
+		else
+		{
+			artificial_patch_3d.level  = patch->level-1;
+			artificial_patch_3d.xlower = patch->xlower;
+			artificial_patch_3d.ylower = patch->ylower;
+			artificial_patch_3d.zlower = patch->zlower;
+			artificial_patch_3d.xupper = patch->xupper;
+			artificial_patch_3d.yupper = patch->yupper;
+			artificial_patch_3d.zupper = patch->zupper;
+			artificial_patch_3d.flags  = patch->d3->flags;
+			int lower_x_axis = !(igrid & 0x1);
+			if(lower_x_axis)
+			{
+			    artificial_patch_3d.xupper += width;
+			}
+			else
+			{
+			    artificial_patch_3d.xlower -= width;
+			}
+			int lower_y_axis = !(igrid & 0x2);
+			if(lower_y_axis)
+			{
+			    artificial_patch_3d.yupper += height;
+			}
+			else
+			{
+			    artificial_patch_3d.ylower -= height;
+			}
+			int lower_z_axis = !(igrid & 0x4);
+			if(lower_z_axis)
+			{
+			    artificial_patch_3d.zupper += depth;
+			}
+			else
+			{
+			    artificial_patch_3d.zlower -= depth;
+			}
+			artificial_patch.level  = artificial_patch_3d.level;
+			artificial_patch.xlower = artificial_patch_3d.xlower;
+			artificial_patch.ylower = artificial_patch_3d.ylower;
+			artificial_patch.zlower = artificial_patch_3d.zlower;
+			artificial_patch.xupper = artificial_patch_3d.xupper;
+			artificial_patch.yupper = artificial_patch_3d.yupper;
+			artificial_patch.zupper = artificial_patch_3d.zupper;
+			artificial_patch.d3 = &artificial_patch_3d;
+			artificial_patch.refine_dim = 3;
+			artificial_patch_3d.user = &artificial_patch;
+		}
 
 		//shallow pach data
 		fclaw_patch_shallow_copy(glob,

--- a/src/fclaw_patch.c
+++ b/src/fclaw_patch.c
@@ -658,16 +658,16 @@ void fclaw_patch_get_coarse_from_fine(struct fclaw_global *glob,
 
 void fclaw_patch_interpolate2fine(fclaw_global_t* glob,
 									fclaw_patch_t* coarse_patch,
-									fclaw_patch_t* fine_patches,
+									fclaw_patch_t* fine_patch,
 									int this_blockno, int coarse_patchno,
-									int fine0_patchno)
+									int fine_patchno, int igrid)
 {
 	fclaw_patch_vtable_t *patch_vt = fclaw_patch_vt(glob);
 	FCLAW_ASSERT(patch_vt->interpolate2fine != NULL);
 
-	patch_vt->interpolate2fine(glob,coarse_patch,fine_patches,
+	patch_vt->interpolate2fine(glob,coarse_patch,fine_patch,
 							   this_blockno,coarse_patchno,
-							   fine0_patchno);
+							   fine_patchno, igrid);
 }
 
 /* ---------------------------- Ghost patches (local and remote) ---------------------- */

--- a/src/fclaw_patch.c
+++ b/src/fclaw_patch.c
@@ -696,23 +696,6 @@ void fclaw_patch_average2coarse(fclaw_global_t *glob,
 							 blockno,fine0_patchno,coarse_patchno);
 }
 
-void fclaw_patch_store_coarse_in_fine(struct fclaw_global *glob,
-                                       struct fclaw_patch *coarse_patch,
-                                       struct fclaw_patch *fine_patch,
-                                       int blockno, int coarse_patchno,
-                                       int fine_patchno)
-{
-
-}
-
-void fclaw_patch_get_coarse_from_fine(struct fclaw_global *glob,
-                                       struct fclaw_patch *fine_patch,
-                                       struct fclaw_patch *coarse_patch,
-                                       int blockno, int fine_patchno)
-{
-
-}
-
 void fclaw_patch_interpolate2fine(fclaw_global_t* glob,
 									fclaw_patch_t* coarse_patch,
 									fclaw_patch_t* fine_patch,

--- a/src/fclaw_patch.h
+++ b/src/fclaw_patch.h
@@ -690,6 +690,37 @@ int fclaw_patch_intersects_region(struct fclaw_global *glob,
                                   int refine_flag);
 
 /**
+ * @brief Store coarse patch data in a fine patch.
+ *
+ * The data will then be retrieved later when it is needed to interpolate.
+ * 
+ * @param glob the global context
+ * @param coarse_patch the coarse patch
+ * @param fine_patch the fine patch
+ * @param blockno the block number
+ * @param coarse_patchno the coarse patch number
+ * @param fine_patchno the fine patch number
+ */
+void fclaw_patch_store_coarse_in_fine(struct fclaw_global *glob,
+                                       struct fclaw_patch *coarse_patch,
+                                       struct fclaw_patch *fine_patch,
+                                       int blockno, int coarse_patchno,
+                                       int fine_patchno);
+
+/**
+ * @brief 
+ * 
+ * @param glob 
+ * @param fine_patch 
+ * @param coarse_patch 
+ * @param blockno 
+ * @param fine_patchno 
+ */
+void fclaw_patch_get_coarse_from_fine(struct fclaw_global *glob,
+                                       struct fclaw_patch *fine_patch,
+                                       struct fclaw_patch *coarse_patch,
+                                       int blockno, int fine_patchno);
+/**
  * @brief Interpolates a set of patches from a coarse patch
  * 
  * @param[in] glob the global context

--- a/src/fclaw_patch.h
+++ b/src/fclaw_patch.h
@@ -65,6 +65,12 @@ typedef enum
 } fclaw_build_mode_t;
 
 
+typedef enum
+{
+    /** Patch considered for refinement */
+    FCLAW_PATCH_DATA_CONSIDERED_FOR_REFINEMENT = 0x1,
+
+} fclaw_patch_data_flags_t;
 
 /**
  * @brief Structure for user patch data
@@ -100,8 +106,8 @@ struct fclaw_patch_data
     /** Block index */
     int block_idx;
 
-    /** True if patch has been considered for refinement */
-    int considered_for_refinement;
+    /** Boolean flags */
+    fclaw_patch_data_flags_t flags;
 
     /** User defined patch structure */
     void *user_patch;

--- a/src/fclaw_patch.h
+++ b/src/fclaw_patch.h
@@ -69,6 +69,8 @@ typedef enum
 {
     /** Patch considered for refinement */
     FCLAW_PATCH_DATA_CONSIDERED_FOR_REFINEMENT = 0x1,
+    /** Patch has coarse data and it's family needs to be refined */
+    FCLAW_PATCH_DATA_HAS_COARSE_DATA = 0x2,
 
 } fclaw_patch_data_flags_t;
 
@@ -2199,6 +2201,12 @@ void fclaw_patch_set_block_corner_count(struct fclaw_global *glob,
                                           struct fclaw_patch* this_patch,
                                           int icorner, int block_corner_count);
 
+///@}
+/* ------------------------------------------------------------------------------------ */
+///                                 @name Patch Flags
+/* ------------------------------------------------------------------------------------ */
+///@{
+
 /**
  * @brief Set that this patch has been considered for refinement
  * 
@@ -2240,6 +2248,33 @@ int fclaw_patch_all_considered_for_refinement(struct fclaw_global *glob);
  * @param glob the global context
  */
 void fclaw_patch_clear_all_considered_for_refinement(struct fclaw_global *glob);
+
+/**
+ * @brief Set that this patch has coarse data
+ * 
+ * @param glob the global context
+ * @param patch the patch context
+ */
+void fclaw_patch_has_coarse_data_set(struct fclaw_global *glob,
+                                     struct fclaw_patch* patch);
+/**
+ * @brief Clear the flag that this patch has coarse data
+ * 
+ * @param glob the global context
+ * @param patch the patch context
+ */
+void fclaw_patch_has_coarse_data_clear(struct fclaw_global *glob,
+                                       struct fclaw_patch* patch);
+
+/**
+ * @brief Returns true if a patch has coarse data
+ * 
+ * @param glob the global context
+ * @param patch the patch context
+ * @return int true if a patch has coarse data
+ */
+int fclaw_patch_has_coarse_data(struct fclaw_global *glob,
+                                struct fclaw_patch* patch);
 
 ///@}
 

--- a/src/fclaw_patch.h
+++ b/src/fclaw_patch.h
@@ -736,13 +736,14 @@ void fclaw_patch_get_coarse_from_fine(struct fclaw_global *glob,
  * @param[in,out] fine_patches the fine patch contexts
  * @param[in] blockno the block number
  * @param[in] coarse_patchno the patch number of the coarse patch
- * @param[in] fine0_patchno the patch number of the first fine patch
+ * @param[in] fine_patchno the patch number of the fine patch
+ * @param[in] igrid the index of the fine patch in the child array
  */
 void fclaw_patch_interpolate2fine(struct fclaw_global *glob,
                                     struct fclaw_patch* coarse_patch,
-                                    struct fclaw_patch* fine_patches,
+                                    struct fclaw_patch* fine_patch,
                                     int this_blockno, int coarse_patchno,
-                                    int fine0_patchno);
+                                    int fine_patchno, int igrid);
 
 /**
  * @brief Averages from a set of fine patches to a coarse patch
@@ -1501,13 +1502,14 @@ typedef int (*fclaw_patch_intersects_region_t)(struct fclaw_global *glob,
  * @param[in,out] fine_patches the fine patch contexts
  * @param[in] blockno the block number
  * @param[in] coarse_patchno the patch number of the coarse patch
- * @param[in] fine_patchno the patch number of the first fine patch
+ * @param[in] fine_patchno the patch number of the fine patch
+ * @param[in] igrid the index of the fine patch in the child array
  */
 typedef void (*fclaw_patch_interpolate2fine_t)(struct fclaw_global *glob,
                                                  struct fclaw_patch *coarse_patch,
-                                                 struct fclaw_patch* fine_patches,
+                                                 struct fclaw_patch* fine_patch,
                                                  int blockno, int coarse_patchno,
-                                                 int fine_patchno);
+                                                 int fine_patchno, int igrid);
 /**
  * @brief Averages from a set of fine patches to a coarse patch
  * 

--- a/src/fclaw_patch.h
+++ b/src/fclaw_patch.h
@@ -71,6 +71,8 @@ typedef enum
     FCLAW_PATCH_DATA_CONSIDERED_FOR_REFINEMENT = 0x1,
     /** Patch has coarse data and it's family needs to be refined */
     FCLAW_PATCH_DATA_HAS_COARSE_DATA = 0x2,
+    /** Patch is currently being unpacked during partitioning */
+    FCLAW_PATCH_DATA_UNPACKING = 0x4,
 
 } fclaw_patch_data_flags_t;
 

--- a/src/fclaw_patch.h
+++ b/src/fclaw_patch.h
@@ -220,30 +220,35 @@ struct fclaw_region;
  * @brief Deallocate the user data pointer for a patch
  * 
  * @param[in] glob the global context 
+ * @param[in] domain the domain
  * @param[in,out] patch the patch context, user data pointer is set to NULL on return
  */
 void fclaw_patch_data_delete(struct fclaw_global *glob,
-                               struct fclaw_patch *patch);
+                             struct fclaw_domain *domain,
+                             struct fclaw_patch *patch);
 
 /**
  * @brief Construct a new patch object
  * 
  * @param[in] glob the global context
+ * @param[in] domain the domain
  * @param[in,out] this_patch the patch context
  * @param[in] blockno the block number
  * @param[in] patchno the patch number
  * @param[in,out] user user data pointer
  */
 void fclaw_patch_build(struct fclaw_global *glob,
-                         struct fclaw_patch *this_patch,
-                         int blockno,
-                         int patchno,
-                         void *user);
+                       struct fclaw_domain *domain,
+                       struct fclaw_patch *this_patch,
+                       int blockno,
+                       int patchno,
+                       void *user);
 
 /**
  * @brief Construct a new patch object from a set of fine patches
  * 
  * @param[in] glob the global context
+ * @param[in] domain the domain
  * @param[in] fine_patches the fine patch contexts
  * @param[in,out] coarse_patches the coarse patch context
  * @param[in] blockno the block number
@@ -252,12 +257,13 @@ void fclaw_patch_build(struct fclaw_global *glob,
  * @param[in] build_mode the build mode
  */
 void fclaw_patch_build_from_fine(struct fclaw_global *glob,
-                                   struct fclaw_patch *fine_patches,
-                                   struct fclaw_patch *coarse_patch,
-                                   int blockno,
-                                   int coarse_patchno,
-                                   int fine0_patchno,
-                                   fclaw_build_mode_t build_mode);
+                                 struct fclaw_domain *domain,
+                                 struct fclaw_patch *fine_patches,
+                                 struct fclaw_patch *coarse_patch,
+                                 int blockno,
+                                 int coarse_patchno,
+                                 int fine0_patchno,
+                                 fclaw_build_mode_t build_mode);
 
 
 ///@}

--- a/src/fclaw_patch.h
+++ b/src/fclaw_patch.h
@@ -109,7 +109,7 @@ struct fclaw_patch_data
     int block_idx;
 
     /** Boolean flags */
-    fclaw_patch_data_flags_t flags;
+    int flags;
 
     /** User defined patch structure */
     void *user_patch;

--- a/src/fclaw_patch.h
+++ b/src/fclaw_patch.h
@@ -110,6 +110,8 @@ struct fclaw_patch_data
 
     /** Boolean flags */
     int flags;
+    /** Number of fclaw_patch_t objects that have this patch set as patch->user */
+    int num_owners;
 
     /** User defined patch structure */
     void *user_patch;
@@ -265,6 +267,26 @@ void fclaw_patch_build_from_fine(struct fclaw_global *glob,
                                  int fine0_patchno,
                                  fclaw_build_mode_t build_mode);
 
+/**
+ * @brief Create a shallow copy of a patch
+ * 
+ * @param[in] glob the global context
+ * @param[in] src_domain the source domain
+ * @param[in] src_patch the source patch 
+ * @param[in] dst_domain the destination domain
+ * @param[in,out] dst_patch the destination patch
+ * @param[in] blockno the block number
+ * @param[in] src_patchno the source patch number
+ * @param[in] dst_patchno the destination patch number
+ */
+void fclaw_patch_shallow_copy(struct fclaw_global *glob,
+                              struct fclaw_domain *src_domain,
+                              struct fclaw_patch *src_patch,
+                              struct fclaw_domain *dst_domain,
+                              struct fclaw_patch *dst_patch,
+							  int blockno,
+							  int old_patchno,
+							  int new_patchno);
 
 ///@}
 /* ------------------------------------------------------------------------------------ */

--- a/src/fclaw_patch.h
+++ b/src/fclaw_patch.h
@@ -728,37 +728,6 @@ int fclaw_patch_intersects_region(struct fclaw_global *glob,
                                   int refine_flag);
 
 /**
- * @brief Store coarse patch data in a fine patch.
- *
- * The data will then be retrieved later when it is needed to interpolate.
- * 
- * @param glob the global context
- * @param coarse_patch the coarse patch
- * @param fine_patch the fine patch
- * @param blockno the block number
- * @param coarse_patchno the coarse patch number
- * @param fine_patchno the fine patch number
- */
-void fclaw_patch_store_coarse_in_fine(struct fclaw_global *glob,
-                                       struct fclaw_patch *coarse_patch,
-                                       struct fclaw_patch *fine_patch,
-                                       int blockno, int coarse_patchno,
-                                       int fine_patchno);
-
-/**
- * @brief 
- * 
- * @param glob 
- * @param fine_patch 
- * @param coarse_patch 
- * @param blockno 
- * @param fine_patchno 
- */
-void fclaw_patch_get_coarse_from_fine(struct fclaw_global *glob,
-                                       struct fclaw_patch *fine_patch,
-                                       struct fclaw_patch *coarse_patch,
-                                       int blockno, int fine_patchno);
-/**
  * @brief Interpolates a set of patches from a coarse patch
  * 
  * @param[in] glob the global context

--- a/src/fclaw_regrid.c
+++ b/src/fclaw_regrid.c
@@ -194,6 +194,11 @@ void refine_patch(fclaw_global_t *glob,
 
 }
 
+void fclaw_regrid_refine_after_partition(fclaw_global_t * glob)
+{
+
+}
+
 /* ----------------------------------------------------------------
    Public interface
    -------------------------------------------------------------- */
@@ -373,6 +378,14 @@ void fclaw_regrid(fclaw_global_t *glob)
 
             /* Repartition for load balancing.  Second arg (mode) for vtk output */
             fclaw_partition_domain(glob,FCLAW_TIMER_REGRID);
+
+            /* Refine patches (if needed)*/
+            if(fclaw_opt->refine_after_parition)
+            {
+                fclaw_timer_start (&glob->timers[FCLAW_TIMER_REGRID_BUILD]);
+                fclaw_regrid_refine_after_partition(glob);
+                fclaw_timer_stop (&glob->timers[FCLAW_TIMER_REGRID_BUILD]);
+            }
 
             /* Set up ghost patches. Communication happens for indirect ghost exchanges. */
 

--- a/src/fclaw_regrid.c
+++ b/src/fclaw_regrid.c
@@ -154,7 +154,7 @@ void refine_patch(fclaw_global_t *glob,
     /* don't try to refine this patch in the next round of refinement */
     fclaw_patch_considered_for_refinement_set(glob, fine_patch);
 
-    if(fclaw_opt->refine_after_parition)
+    if(0)
     {
         fclaw_patch_store_coarse_in_fine(glob,coarse_patch,fine_patch,
                                          blockno,old_patchno,fine_patchno);
@@ -314,14 +314,6 @@ void fclaw_regrid_process_new_refinement(fclaw_global_t *glob,
 
     /* Repartition for load balancing.  Second arg (mode) for vtk output */
     fclaw_partition_domain(glob,timer);
-
-    /* Refine patches (if needed)*/
-    if(fclaw_opt->refine_after_parition)
-    {
-        fclaw_timer_start (&glob->timers[FCLAW_TIMER_REGRID_BUILD]);
-        fclaw_regrid_refine_after_partition(glob);
-        fclaw_timer_stop (&glob->timers[FCLAW_TIMER_REGRID_BUILD]);
-    }
 
     /* Set up ghost patches. Communication happens for indirect ghost exchanges. */
 

--- a/src/fclaw_regrid.c
+++ b/src/fclaw_regrid.c
@@ -329,15 +329,28 @@ void process_new_refinement_old(fclaw_global_t *glob,
 }
 
 static
-void patch_pack_cb (fclaw_domain_t * domain,
-                      fclaw_patch_t * patch, int blockno,
-                      int patchno, void *pack_data_here,
-                      void *user)
+void patch_pack_cb(fclaw_domain_t * domain,
+                   fclaw_patch_t * patch, int blockno,
+                   int patchno, void *pack_data_here,
+                   void *user)
 {
     fclaw_global_t *glob = (fclaw_global_t *) user;
     fclaw_patch_partition_pack(glob,patch,
                                blockno,patchno,
                                pack_data_here);
+}
+
+static
+void patch_unpack_cb(fclaw_domain_t * domain,
+                     fclaw_patch_t * patch,
+                     int blockno, int patchno,
+                     void *unpack_data_from_here,
+                     void *user)
+{
+    fclaw_global_t *glob = (fclaw_global_t *) user;
+    fclaw_patch_partition_unpack(glob,domain,patch,
+                                 blockno,patchno,
+                                 unpack_data_from_here);
 }
 
 /* use new regridding interface */
@@ -354,6 +367,8 @@ void process_new_refinement_new(fclaw_global_t *glob,
                                                             psize,
                                                             patch_pack_cb,
                                                             (void *) glob);
+
+    fclaw_domain_iterate_unpack(new_domain, p, patch_unpack_cb, (void *) glob);
 }
 
 void fclaw_regrid_process_new_refinement(fclaw_global_t *glob,

--- a/src/fclaw_regrid.c
+++ b/src/fclaw_regrid.c
@@ -135,8 +135,25 @@ void refine_patch(fclaw_global_t *glob,
     fclaw_patch_t *fine_siblings = new_patch;
     fclaw_patch_t *coarse_patch = old_patch;
 
+    /* Set up first patch in family */
+    fclaw_patch_t *fine_patch = &fine_siblings[0];
+    int fine_patchno = new_patchno;
+    /* Reason for the following two lines: the glob contains the old domain which is incremented in ddata_old 
+       but we really want to increment the new domain. This will be fixed! */
+    --old_domain->count_set_patch;
+    ++new_domain->count_set_patch;
+
+    fclaw_patch_build(glob,fine_patch,blockno,
+                      fine_patchno,(void*) &build_mode);
+    if (domain_init)
+    {
+        fclaw_patch_initialize(glob,fine_patch,blockno,fine_patchno);//new_domain
+    }
+    /* don't try to refine this patch in the next round of refinement */
+    fclaw_patch_considered_for_refinement_set(glob, fine_patch);
+
     int i;
-    for (i = 0; i < fclaw_domain_num_siblings(old_domain); i++)
+    for (i = 1; i < fclaw_domain_num_siblings(old_domain); i++)
     {
         fclaw_patch_t *fine_patch = &fine_siblings[i];
         int fine_patchno = new_patchno + i;

--- a/src/fclaw_regrid.c
+++ b/src/fclaw_regrid.c
@@ -292,16 +292,12 @@ void cb_fclaw_regrid_repopulate(fclaw_domain_t * old_domain,
     fclaw_patch_neighbors_reset(new_patch);
 }
 
-/* regrid using old interface */
-static
-void process_new_refinement_old(fclaw_global_t *glob,
-                                fclaw_domain_t **domain,
-                                fclaw_domain_t *new_domain,
-                                int domain_init,
-                                fclaw_timer_names_t timer)
+void fclaw_regrid_process_new_refinement(fclaw_global_t *glob,
+                                         fclaw_domain_t **domain,
+                                         fclaw_domain_t *new_domain,
+                                         int domain_init,
+                                         fclaw_timer_names_t timer)
 {
-    fclaw_options_t *fclaw_opt = fclaw_get_options(glob);
-
     /* Average to new coarse grids and interpolate to new fine grids */
     fclaw_timer_start (&glob->timers[FCLAW_TIMER_REGRID_BUILD]);
     fclaw_global_iterate_adapted(glob, new_domain,
@@ -326,66 +322,6 @@ void process_new_refinement_old(fclaw_global_t *glob,
     /* Get new neighbor information.  This is used to short circuit
        ghost filling procedures in some cases */
     fclaw_regrid_set_neighbor_types(glob);
-}
-
-static
-void patch_pack_cb(fclaw_domain_t * domain,
-                   fclaw_patch_t * patch, int blockno,
-                   int patchno, void *pack_data_here,
-                   void *user)
-{
-    fclaw_global_t *glob = (fclaw_global_t *) user;
-    fclaw_patch_partition_pack(glob,patch,
-                               blockno,patchno,
-                               pack_data_here);
-}
-
-static
-void patch_unpack_cb(fclaw_domain_t * domain,
-                     fclaw_patch_t * patch,
-                     int blockno, int patchno,
-                     void *unpack_data_from_here,
-                     void *user)
-{
-    fclaw_global_t *glob = (fclaw_global_t *) user;
-    fclaw_patch_partition_unpack(glob,domain,patch,
-                                 blockno,patchno,
-                                 unpack_data_from_here);
-}
-
-/* use new regridding interface */
-static
-void process_new_refinement_new(fclaw_global_t *glob,
-                                fclaw_domain_t **domain,
-                                fclaw_domain_t *new_domain,
-                                int domain_init,
-                                fclaw_timer_names_t timer)
-{
-
-    size_t psize = fclaw_patch_partition_packsize(glob);
-    fclaw_domain_partition_t *p = fclaw_domain_iterate_pack(*domain, 
-                                                            psize,
-                                                            patch_pack_cb,
-                                                            (void *) glob);
-
-    fclaw_domain_iterate_unpack(new_domain, p, patch_unpack_cb, (void *) glob);
-    fclaw_domain_partition_free(p);
-}
-
-void fclaw_regrid_process_new_refinement(fclaw_global_t *glob,
-                                         fclaw_domain_t **domain,
-                                         fclaw_domain_t *new_domain,
-                                         int domain_init,
-                                         fclaw_timer_names_t timer)
-{
-    if (fclaw_get_options(glob)->regrid_mode == FCLAW_OPTIONS_REGRID_MODE_OLD)
-    {
-        process_new_refinement_old(glob, domain, new_domain, domain_init, timer);
-    }
-    else
-    {
-        process_new_refinement_new(glob, domain, new_domain, domain_init, timer);
-    }
 }
 
 /* ----------------------------------------------------------------

--- a/src/fclaw_regrid.c
+++ b/src/fclaw_regrid.c
@@ -158,6 +158,7 @@ void refine_patch(fclaw_global_t *glob,
     {
         fclaw_patch_store_coarse_in_fine(glob,coarse_patch,fine_patch,
                                          blockno,old_patchno,fine_patchno);
+        fclaw_patch_has_coarse_data_set(glob, fine_patch);
     }
     else
     {

--- a/src/fclaw_regrid.c
+++ b/src/fclaw_regrid.c
@@ -328,6 +328,18 @@ void process_new_refinement_old(fclaw_global_t *glob,
     fclaw_regrid_set_neighbor_types(glob);
 }
 
+static
+void patch_pack_cb (fclaw_domain_t * domain,
+                      fclaw_patch_t * patch, int blockno,
+                      int patchno, void *pack_data_here,
+                      void *user)
+{
+    fclaw_global_t *glob = (fclaw_global_t *) user;
+    fclaw_patch_partition_pack(glob,patch,
+                               blockno,patchno,
+                               pack_data_here);
+}
+
 /* use new regridding interface */
 static
 void process_new_refinement_new(fclaw_global_t *glob,
@@ -337,6 +349,11 @@ void process_new_refinement_new(fclaw_global_t *glob,
                                 fclaw_timer_names_t timer)
 {
 
+    size_t psize = fclaw_patch_partition_packsize(glob);
+    fclaw_domain_partition_t *p = fclaw_domain_iterate_pack(*domain, 
+                                                            psize,
+                                                            patch_pack_cb,
+                                                            (void *) glob);
 }
 
 void fclaw_regrid_process_new_refinement(fclaw_global_t *glob,

--- a/src/fclaw_regrid.c
+++ b/src/fclaw_regrid.c
@@ -369,6 +369,7 @@ void process_new_refinement_new(fclaw_global_t *glob,
                                                             (void *) glob);
 
     fclaw_domain_iterate_unpack(new_domain, p, patch_unpack_cb, (void *) glob);
+    fclaw_domain_partition_free(p);
 }
 
 void fclaw_regrid_process_new_refinement(fclaw_global_t *glob,

--- a/src/fclaw_regrid.c
+++ b/src/fclaw_regrid.c
@@ -154,7 +154,7 @@ void refine_patch(fclaw_global_t *glob,
     /* don't try to refine this patch in the next round of refinement */
     fclaw_patch_considered_for_refinement_set(glob, fine_patch);
 
-    if(0)
+    if(fclaw_opt->regrid_mode == FCLAW_OPTIONS_REGRID_MODE_REFINE_AFTER)
     {
         fclaw_patch_store_coarse_in_fine(glob,coarse_patch,fine_patch,
                                          blockno,old_patchno,fine_patchno);
@@ -292,11 +292,13 @@ void cb_fclaw_regrid_repopulate(fclaw_domain_t * old_domain,
     fclaw_patch_neighbors_reset(new_patch);
 }
 
-void fclaw_regrid_process_new_refinement(fclaw_global_t *glob,
-                                         fclaw_domain_t **domain,
-                                         fclaw_domain_t *new_domain,
-                                         int domain_init,
-                                         fclaw_timer_names_t timer)
+/* regrid using old interface */
+static
+void process_new_refinement_old(fclaw_global_t *glob,
+                                fclaw_domain_t **domain,
+                                fclaw_domain_t *new_domain,
+                                int domain_init,
+                                fclaw_timer_names_t timer)
 {
     fclaw_options_t *fclaw_opt = fclaw_get_options(glob);
 
@@ -325,6 +327,34 @@ void fclaw_regrid_process_new_refinement(fclaw_global_t *glob,
        ghost filling procedures in some cases */
     fclaw_regrid_set_neighbor_types(glob);
 }
+
+/* use new regridding interface */
+static
+void process_new_refinement_new(fclaw_global_t *glob,
+                                fclaw_domain_t **domain,
+                                fclaw_domain_t *new_domain,
+                                int domain_init,
+                                fclaw_timer_names_t timer)
+{
+
+}
+
+void fclaw_regrid_process_new_refinement(fclaw_global_t *glob,
+                                         fclaw_domain_t **domain,
+                                         fclaw_domain_t *new_domain,
+                                         int domain_init,
+                                         fclaw_timer_names_t timer)
+{
+    if (fclaw_get_options(glob)->regrid_mode == FCLAW_OPTIONS_REGRID_MODE_OLD)
+    {
+        process_new_refinement_old(glob, domain, new_domain, domain_init, timer);
+    }
+    else
+    {
+        process_new_refinement_new(glob, domain, new_domain, domain_init, timer);
+    }
+}
+
 /* ----------------------------------------------------------------
    Public interface
    -------------------------------------------------------------- */

--- a/src/fclaw_regrid.c
+++ b/src/fclaw_regrid.c
@@ -253,7 +253,8 @@ void cb_refine_after_partition(fclaw_domain_t *domain,
                                          blockno,-1,patchno,igrid);
         
             fclaw_patch_data_delete(g->glob,domain, &artificial_patch);
-        
+
+            fclaw_patch_considered_for_refinement_set(g->glob, patch);
         }
 
         fclaw_patch_has_coarse_data_clear(g->glob, patch);

--- a/src/fclaw_regrid.c
+++ b/src/fclaw_regrid.c
@@ -140,7 +140,7 @@ void refine_patch(fclaw_global_t *glob,
         int fine_patchno = fine0_patchno + i;
 
         /* set the data */
-        if (fclaw_opt->regrid_mode != FCLAW_OPTIONS_REGRID_MODE_REFINE_AFTER)
+        if (fclaw_opt->partition_mode != FCLAW_PARTITION_MODE_REFINE_AFTER)
         {
             fclaw_build_mode_t build_mode = FCLAW_BUILD_FOR_UPDATE;
             fclaw_patch_build(glob,new_domain,fine_patch,blockno,
@@ -169,7 +169,7 @@ void refine_patch(fclaw_global_t *glob,
         /* don't try to refine this patch in the next round of refinement */
         fclaw_patch_considered_for_refinement_set(glob, fine_patch);
 
-        if(fclaw_opt->regrid_mode == FCLAW_OPTIONS_REGRID_MODE_REFINE_AFTER)
+        if(fclaw_opt->partition_mode == FCLAW_PARTITION_MODE_REFINE_AFTER)
         {
             fclaw_patch_has_coarse_data_set(glob, fine_patch);
         }
@@ -372,7 +372,7 @@ void fclaw_regrid_process_new_refinement(fclaw_global_t *glob,
     fclaw_partition_domain(glob,timer);
 
     /* refine after partition (if_needed) */
-    if(fclaw_opt->regrid_mode == FCLAW_OPTIONS_REGRID_MODE_REFINE_AFTER)
+    if(fclaw_opt->partition_mode == FCLAW_PARTITION_MODE_REFINE_AFTER)
     {
         fclaw_global_iterate_patches(glob, cb_refine_after_partition,
                                      (void *) &domain_init);

--- a/src/fclaw_regrid.c
+++ b/src/fclaw_regrid.c
@@ -352,7 +352,7 @@ void fclaw_regrid_process_new_refinement(fclaw_global_t *glob,
                                          fclaw_domain_t **domain,
                                          fclaw_domain_t *new_domain,
                                          int domain_init,
-                                         int timer)
+                                         fclaw_timer_names_t timer)
 {
     fclaw_options_t *fclaw_opt = fclaw_get_options(glob);
 

--- a/src/fclaw_regrid.c
+++ b/src/fclaw_regrid.c
@@ -280,10 +280,8 @@ void cb_fclaw_regrid_repopulate(fclaw_domain_t * old_domain,
     {
         FCLAW_ASSERT(0 <= blockno && blockno < new_domain->num_blocks);
         FCLAW_ASSERT(0 <= new_patchno && new_patchno < new_domain->local_num_patches);
-        new_patch->user = old_patch->user;
-        old_patch->user = NULL;
-        ++old_domain->count_delete_patch;
-        ++new_domain->count_set_patch;
+        fclaw_patch_shallow_copy(g->glob, old_domain, old_patch, new_domain, new_patch,
+                                 blockno, old_patchno, new_patchno);
     }
     else if (newsize == FCLAW_PATCH_HALFSIZE)
     {

--- a/src/fclaw_regrid.c
+++ b/src/fclaw_regrid.c
@@ -41,6 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <fclaw_patch.h>
 
 #include <forestclaw2d.h>
+#include <forestclaw3d.h>
 
 /* This is also called from fclaw2d_initialize, so is not made static */
 void cb_fclaw_regrid_tag4refinement(fclaw_domain_t *domain,
@@ -205,40 +206,94 @@ void cb_refine_after_partition(fclaw_domain_t *domain,
             int igrid = fclaw_patch_childid(patch);
             double width = patch->xupper - patch->xlower;
             double height = patch->yupper - patch->ylower;
+            double depth = patch->zupper - patch->zlower;
             fclaw2d_patch_t artificial_patch_2d;
-            artificial_patch_2d.level  = patch->level-1;
-            artificial_patch_2d.xlower = patch->xlower;
-            artificial_patch_2d.ylower = patch->ylower;
-            artificial_patch_2d.xupper = patch->xupper;
-            artificial_patch_2d.yupper = patch->yupper;
-            artificial_patch_2d.flags  = patch->d2->flags;
-            int lower_x_axis = !(igrid & 0x1);
-            if(lower_x_axis)
-            {
-                artificial_patch_2d.xupper += width;
-            }
-            else
-            {
-                artificial_patch_2d.xlower -= width;
-            }
-            int lower_y_axis = !(igrid & 0x2);
-            if(lower_y_axis)
-            {
-                artificial_patch_2d.yupper += height;
-            }
-            else
-            {
-                artificial_patch_2d.ylower -= height;
-            }
+            fclaw3d_patch_t artificial_patch_3d;
             fclaw_patch_t artificial_patch;
-            artificial_patch.level  = artificial_patch_2d.level;
-            artificial_patch.xlower = artificial_patch_2d.xlower;
-            artificial_patch.ylower = artificial_patch_2d.ylower;
-            artificial_patch.xupper = artificial_patch_2d.xupper;
-            artificial_patch.yupper = artificial_patch_2d.yupper;
-            artificial_patch.d2 = &artificial_patch_2d;
-            artificial_patch.refine_dim = 2;
-            artificial_patch_2d.user = &artificial_patch;
+    		if(patch->refine_dim == 2)
+    		{
+            	artificial_patch_2d.level  = patch->level-1;
+            	artificial_patch_2d.xlower = patch->xlower;
+            	artificial_patch_2d.ylower = patch->ylower;
+            	artificial_patch_2d.xupper = patch->xupper;
+            	artificial_patch_2d.yupper = patch->yupper;
+            	artificial_patch_2d.flags  = patch->d2->flags;
+            	int lower_x_axis = !(igrid & 0x1);
+            	if(lower_x_axis)
+            	{
+            	    artificial_patch_2d.xupper += width;
+            	}
+            	else
+            	{
+            	    artificial_patch_2d.xlower -= width;
+            	}
+            	int lower_y_axis = !(igrid & 0x2);
+            	if(lower_y_axis)
+            	{
+            	    artificial_patch_2d.yupper += height;
+            	}
+            	else
+            	{
+            	    artificial_patch_2d.ylower -= height;
+            	}
+            	artificial_patch.level  = artificial_patch_2d.level;
+            	artificial_patch.xlower = artificial_patch_2d.xlower;
+            	artificial_patch.ylower = artificial_patch_2d.ylower;
+            	artificial_patch.xupper = artificial_patch_2d.xupper;
+            	artificial_patch.yupper = artificial_patch_2d.yupper;
+            	artificial_patch.d2 = &artificial_patch_2d;
+            	artificial_patch.refine_dim = 2;
+            	artificial_patch_2d.user = &artificial_patch;
+    		}
+    		else
+    		{
+    			artificial_patch_3d.level  = patch->level-1;
+    			artificial_patch_3d.xlower = patch->xlower;
+    			artificial_patch_3d.ylower = patch->ylower;
+    			artificial_patch_3d.zlower = patch->zlower;
+    			artificial_patch_3d.xupper = patch->xupper;
+    			artificial_patch_3d.yupper = patch->yupper;
+    			artificial_patch_3d.zupper = patch->zupper;
+    			artificial_patch_3d.flags  = patch->d3->flags;
+    			int lower_x_axis = !(igrid & 0x1);
+    			if(lower_x_axis)
+    			{
+    			    artificial_patch_3d.xupper += width;
+    			}
+    			else
+    			{
+    			    artificial_patch_3d.xlower -= width;
+    			}
+    			int lower_y_axis = !(igrid & 0x2);
+    			if(lower_y_axis)
+    			{
+    			    artificial_patch_3d.yupper += height;
+    			}
+    			else
+    			{
+    			    artificial_patch_3d.ylower -= height;
+    			}
+    			int lower_z_axis = !(igrid & 0x4);
+    			if(lower_z_axis)
+    			{
+    			    artificial_patch_3d.zupper += depth;
+    			}
+    			else
+    			{
+    			    artificial_patch_3d.zlower -= depth;
+    			}
+    			artificial_patch.level  = artificial_patch_3d.level;
+    			artificial_patch.xlower = artificial_patch_3d.xlower;
+    			artificial_patch.ylower = artificial_patch_3d.ylower;
+    			artificial_patch.zlower = artificial_patch_3d.zlower;
+    			artificial_patch.xupper = artificial_patch_3d.xupper;
+    			artificial_patch.yupper = artificial_patch_3d.yupper;
+    			artificial_patch.zupper = artificial_patch_3d.zupper;
+    			artificial_patch.d3 = &artificial_patch_3d;
+    			artificial_patch.refine_dim = 3;
+    			artificial_patch_3d.user = &artificial_patch;
+    		}
+
 
 
             fclaw_patch_shallow_copy(g->glob,domain,patch,domain,&artificial_patch,

--- a/src/fclaw_regrid.h
+++ b/src/fclaw_regrid.h
@@ -109,15 +109,6 @@ void fclaw_regrid_process_new_refinement(struct fclaw_global *glob,
                                          fclaw_domain_t *new_domain,
                                          int domain_init,
                                          int timer);
-/**
- * @brief Perform refinenment of patches that have been delayed until after
- *        partitioning.
- * 
- * @param glob the global context
- */
-void fclaw_regrid_refine_after_partition(struct fclaw_global * glob);
-
-
 
 #ifdef __cplusplus
 #if 0

--- a/src/fclaw_regrid.h
+++ b/src/fclaw_regrid.h
@@ -92,6 +92,13 @@ void fclaw_regrid(struct fclaw_global *glob);
 
 void fclaw_regrid_set_neighbor_types(struct fclaw_global *glob);
 
+/**
+ * @brief Perform refinenment of patches that have been delayed until after
+ *        partitioning.
+ * 
+ * @param glob the global context
+ */
+void fclaw_regrid_refine_after_partition(struct fclaw_global * glob);
 
 
 

--- a/src/fclaw_regrid.h
+++ b/src/fclaw_regrid.h
@@ -93,6 +93,23 @@ void fclaw_regrid(struct fclaw_global *glob);
 void fclaw_regrid_set_neighbor_types(struct fclaw_global *glob);
 
 /**
+ * @brief Process new refinement.
+ *
+ * This is to be called with the new domain that fclaw_domain_adapt returns.
+ * THis will perform any coarsening and refinment and will repartition the domain.
+ * 
+ * @param glob the global context
+ * @param domain the old domain
+ * @param new_domain the new domain returned by fclaw_domain_adapt
+ * @param domain_init true if this is the first time the domain is being initialized
+ * @param timer the timer to use
+ */
+void fclaw_regrid_process_new_refinement(struct fclaw_global *glob,
+                                         fclaw_domain_t **domain,
+                                         fclaw_domain_t *new_domain,
+                                         int domain_init,
+                                         int timer);
+/**
  * @brief Perform refinenment of patches that have been delayed until after
  *        partitioning.
  * 

--- a/src/fclaw_regrid.h
+++ b/src/fclaw_regrid.h
@@ -26,6 +26,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef FCLAW_REGRID_H
 #define FCLAW_REGRID_H
 
+#include "fclaw_timer.h"
 #include <forestclaw.h>    /* Needed to define fclaw2d_patch_relation_t */
 
 #ifdef __cplusplus
@@ -108,7 +109,7 @@ void fclaw_regrid_process_new_refinement(struct fclaw_global *glob,
                                          fclaw_domain_t **domain,
                                          fclaw_domain_t *new_domain,
                                          int domain_init,
-                                         int timer);
+                                         fclaw_timer_names_t timer);
 
 #ifdef __cplusplus
 #if 0

--- a/src/fclaw_regrid.h
+++ b/src/fclaw_regrid.h
@@ -26,8 +26,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef FCLAW_REGRID_H
 #define FCLAW_REGRID_H
 
-#include "fclaw_timer.h"
 #include <forestclaw.h>    /* Needed to define fclaw2d_patch_relation_t */
+#include <fclaw_timer.h>
 
 #ifdef __cplusplus
 extern "C"

--- a/src/fclaw_restart.c
+++ b/src/fclaw_restart.c
@@ -398,7 +398,7 @@ set_patches(fclaw_domain_t * domain, fclaw_patch_t * patch, int blockno, int pat
 
     if(user_data->pointerno == 0)
     {
-	    fclaw_patch_build(user_data->glob, patch, blockno, patchno,(void*) &build_mode);
+	    fclaw_patch_build(user_data->glob, domain, patch, blockno, patchno,(void*) &build_mode);
     }
 
     void* data = fclaw_patch_checkpoint_get_pointer(user_data->glob, patch, blockno, patchno, user_data->pointerno);

--- a/src/fclaw_wrap.h
+++ b/src/fclaw_wrap.h
@@ -112,6 +112,29 @@ typedef struct fclaw_match_wrap_user
     void *user;
 } fclaw_match_wrap_user_t;
 
+/** 
+ * @brief Callback wrapper struct for pack callbacks.
+ *
+ * This allows callbacks with dimension independent types to be 
+ * called from dimension dependent code.
+ *
+ * This type should be passed in as the user pointer alongside
+ * @ref fclaw2d_pack_wrap_cb or @ref fclaw3d_pack_wrap_cb
+ * to the function that takes a dimensioned callback.
+ *
+ * @ref fclaw2d_pack_wrap_cb or @ref fclaw3d_pack_wrap_cb
+ * will then call the dimension independent callback specified in the struct,
+ * passing the user pointer specified in the struct.
+ * 
+ */
+typedef struct fclaw_pack_wrap_user
+{
+    /** Dimension independent pack callback to call */
+    fclaw_pack_callback_t pcb;
+    /** User pointer to pass to dimension independent callback */
+    void *user;
+} fclaw_pack_wrap_user_t;
+
 /**
  * @brief Callback wrapper struct for match callbacks.
  *

--- a/src/fclaw_wrap.h
+++ b/src/fclaw_wrap.h
@@ -135,6 +135,29 @@ typedef struct fclaw_pack_wrap_user
     void *user;
 } fclaw_pack_wrap_user_t;
 
+/** 
+ * @brief Callback wrapper struct for unpack callbacks.
+ *
+ * This allows callbacks with dimension independent types to be 
+ * called from dimension dependent code.
+ *
+ * This type should be passed in as the user pointer alongside
+ * @ref fclaw2d_unpack_wrap_cb or @ref fclaw3d_unpack_wrap_cb
+ * to the function that takes a dimensioned callback.
+ *
+ * @ref fclaw2d_unpack_wrap_cb or @ref fclaw3d_unpack_wrap_cb
+ * will then call the dimension independent callback specified in the struct,
+ * passing the user pointer specified in the struct.
+ * 
+ */
+typedef struct fclaw_unpack_wrap_user
+{
+    /** Dimension independent unpack callback to call */
+    fclaw_unpack_callback_t ucb;
+    /** User pointer to pass to dimension independent callback */
+    void *user;
+} fclaw_unpack_wrap_user_t;
+
 /**
  * @brief Callback wrapper struct for match callbacks.
  *

--- a/src/forestclaw.c
+++ b/src/forestclaw.c
@@ -881,6 +881,37 @@ fclaw_domain_partition_t
     return partition;
 }
 
+void fclaw_domain_iterate_unpack (fclaw_domain_t * domain,
+                                  fclaw_domain_partition_t * partition,
+                                  fclaw_unpack_callback_t patch_unpack,
+                                  void *user)
+{
+    FCLAW_ASSERT(domain->refine_dim == partition->refine_dim);
+
+    fclaw_unpack_wrap_user_t wrap;
+    wrap.ucb = patch_unpack;
+    wrap.user = user;
+
+    if(domain->refine_dim == 2)
+    {
+        fclaw2d_domain_iterate_unpack(domain->d2,
+                                      partition->d2,
+                                      fclaw2d_unpack_wrap_cb,
+                                      &wrap);
+    }
+    else if (domain->refine_dim == 3)
+    {
+        fclaw3d_domain_iterate_unpack(domain->d3,
+                                      partition->d3,
+                                      fclaw3d_unpack_wrap_cb,
+                                      &wrap);
+    }
+    else
+    {
+        SC_ABORT_NOT_REACHED();
+    }
+}
+
 void fclaw_domain_free_after_partition(fclaw_domain_t *domain, void ***patch_data)
 {
     if(domain->refine_dim == 2)

--- a/src/forestclaw.c
+++ b/src/forestclaw.c
@@ -912,6 +912,23 @@ void fclaw_domain_iterate_unpack (fclaw_domain_t * domain,
     }
 }
 
+void fclaw_domain_partition_free (fclaw_domain_partition_t * partition)
+{
+    if(partition->refine_dim == 2)
+    {
+        fclaw2d_domain_partition_free(partition->d2);
+    }
+    else if (partition->refine_dim == 3)
+    {
+        fclaw3d_domain_partition_free(partition->d3);
+    }
+    else
+    {
+        SC_ABORT_NOT_REACHED();
+    }
+    FCLAW_FREE(partition);
+}
+
 void fclaw_domain_free_after_partition(fclaw_domain_t *domain, void ***patch_data)
 {
     if(domain->refine_dim == 2)

--- a/src/forestclaw.c
+++ b/src/forestclaw.c
@@ -881,6 +881,38 @@ fclaw_domain_partition_t
     return partition;
 }
 
+void fclaw_domain_iterate_transfer (fclaw_domain_t * old_domain,
+                                    fclaw_domain_t * new_domain,
+                                    fclaw_transfer_callback_t
+                                    patch_transfer, void *user)
+{
+    FCLAW_ASSERT(old_domain->refine_dim == new_domain->refine_dim);
+
+    fclaw_transfer_wrap_user_t wrap;
+    wrap.tcb = patch_transfer;
+    wrap.user = user;
+
+    if(old_domain->refine_dim == 2)
+    {
+        fclaw2d_domain_iterate_transfer(old_domain->d2,
+                                        new_domain->d2,
+                                        fclaw2d_transfer_wrap_cb,
+                                        &wrap);
+    }
+    else if(old_domain->refine_dim == 3)
+    {
+        fclaw3d_domain_iterate_transfer(old_domain->d3,
+                                        new_domain->d3,
+                                        fclaw3d_transfer_wrap_cb,
+                                        &wrap);
+    }
+    else
+    {
+        SC_ABORT_NOT_REACHED();
+    }
+
+}
+
 void fclaw_domain_iterate_unpack (fclaw_domain_t * domain,
                                   fclaw_domain_partition_t * partition,
                                   fclaw_unpack_callback_t patch_unpack,

--- a/src/forestclaw.c
+++ b/src/forestclaw.c
@@ -837,6 +837,50 @@ void fclaw_domain_iterate_partitioned(fclaw_domain_t *old_domain, fclaw_domain_t
     }
 }
 
+struct fclaw_domain_partition
+{
+
+    int refine_dim;
+    fclaw2d_domain_partition_t *d2;
+    fclaw3d_domain_partition_t *d3;
+    fclaw_pack_wrap_user_t wrap;
+};
+
+fclaw_domain_partition_t
+    * fclaw_domain_iterate_pack (fclaw_domain_t * domain,
+                                 size_t data_size,
+                                 fclaw_pack_callback_t patch_pack,
+                                 void *user)
+{
+    fclaw_domain_partition_t *partition = FCLAW_ALLOC(fclaw_domain_partition_t, 1);
+    partition->wrap.pcb = patch_pack;
+    partition->wrap.user = user;
+    if(domain->refine_dim == 2)
+    {
+        partition->refine_dim = 2;
+        partition->d2 = fclaw2d_domain_iterate_pack(domain->d2,
+                                                    data_size,
+                                                    fclaw2d_pack_wrap_cb,
+                                                    &partition->wrap);
+        partition->d3 = NULL;
+    }
+    else if (domain->refine_dim == 3)
+    {
+        partition->refine_dim = 3;
+        partition->d2 = NULL;
+        partition->d3 = fclaw3d_domain_iterate_pack(domain->d3,
+                                                    data_size,
+                                                    fclaw3d_pack_wrap_cb,
+                                                    &partition->wrap);
+    }
+    else
+    {
+        SC_ABORT_NOT_REACHED();
+    }
+
+    return partition;
+}
+
 void fclaw_domain_free_after_partition(fclaw_domain_t *domain, void ***patch_data)
 {
     if(domain->refine_dim == 2)

--- a/src/forestclaw.h
+++ b/src/forestclaw.h
@@ -1002,19 +1002,7 @@ void fclaw_domain_iterate_partitioned (fclaw_domain_t * old_domain,
                                        void *user);
 
 /** Data structure for storing allocated data for partition transfer. */
-typedef struct fclaw_domain_partition
-{
-    sc_array_t *src_data; /**< The patch data to send */
-    sc_array_t *src_sizes; /**< The patch data sizes to send */
-    sc_array_t *dest_data; /**< The patch data to receive */
-    sc_array_t *dest_sizes; /**< The patch data sizes to receive */
-    /** Temporary storage required for asynchronous patch data transfer.
-     * It is allocated and freed by the begin/end calls below.
-     */
-    void *async_state;
-    int inside_async;           /**< Between asynchronous begin and end? */
-}
-fclaw_domain_partition_t;
+typedef struct fclaw_domain_partition fclaw_domain_partition_t;
 
 /** Callback to pack patch data after partitioning.
  * The function \ref fclaw_domain_iterate_pack traverses every local patch in

--- a/src/patches/clawpatch/fclaw_clawpatch.h.3d.TEST.cpp
+++ b/src/patches/clawpatch/fclaw_clawpatch.h.3d.TEST.cpp
@@ -285,7 +285,7 @@ TEST_CASE("3d fclaw_clawpatch patch_build")
         fclaw_clawpatch_vtable_initialize(glob, 4);
 
                 CHECK(domain->blocks[0].patches[0].user == nullptr);
-        fclaw_patch_build(glob, &domain->blocks[0].patches[0], 0, 0, &build_mode);
+        fclaw_patch_build(glob,domain, &domain->blocks[0].patches[0], 0, 0, &build_mode);
         CHECK(domain->blocks[0].patches[0].user != nullptr);
 
         fclaw_clawpatch_t* cp = fclaw_clawpatch_get_clawpatch(&domain->blocks[0].patches[0]);
@@ -343,7 +343,7 @@ TEST_CASE("3d fclaw_clawpatch patch_build")
             CHECK_BOX_DIMENSIONS(cp->elliptic_soln, opts->mbc, opts->mx, opts->my, opts->mz, opts->rhs_fields);
         }
 
-        fclaw_patch_data_delete(glob, &domain->blocks[0].patches[0]);
+        fclaw_patch_data_delete(glob,domain, &domain->blocks[0].patches[0]);
         fclaw_clawpatch_options_destroy(opts);
         fclaw_domain_destroy(domain);
         fclaw_map_destroy(map);

--- a/src/patches/clawpatch/fclaw_clawpatch.h.3d.TEST.cpp
+++ b/src/patches/clawpatch/fclaw_clawpatch.h.3d.TEST.cpp
@@ -960,7 +960,7 @@ namespace{
     fclaw_clawpatch_t* i2f_cp1;
     fclaw_clawpatch_t* i2f_cp2;
     fclaw_clawpatch_t* i2f_cp3;
-    std::bitset<8> i2f_igrids;
+    int i2f_igrid;
     int i2f_manifold;
 }
 TEST_CASE("3d fclaw_clawpatch interpolate2fine")
@@ -1015,15 +1015,16 @@ TEST_CASE("3d fclaw_clawpatch interpolate2fine")
         }
 #endif
 
-        CHECK(i2f_igrids[*igrid] == false);
-        i2f_igrids[*igrid] = true;
+        CHECK_EQ(*igrid, i2f_igrid);
         CHECK(*manifold == i2f_manifold);
     };
 
-    fclaw_patch_interpolate2fine(coarse_test_data.glob,
-                                   &coarse_test_data.domain->blocks[0].patches[0],
-                                   &fine_test_data.domain->blocks[0].patches[0],
-                                   0, 0, 0);
-
-    CHECK(i2f_igrids.all());
+    for(int i = 0; i < 8; i++)
+    {
+        i2f_igrid = i;
+        fclaw_patch_interpolate2fine(coarse_test_data.glob,
+                                       &coarse_test_data.domain->blocks[0].patches[0],
+                                       &fine_test_data.domain->blocks[0].patches[i],
+                                       0, 0, 0, i);
+    }
 }

--- a/src/patches/clawpatch/fclaw_clawpatch.h.3dx.TEST.cpp
+++ b/src/patches/clawpatch/fclaw_clawpatch.h.3dx.TEST.cpp
@@ -282,7 +282,7 @@ TEST_CASE("3dx fclaw_clawpatch patch_build")
         fclaw_clawpatch_vtable_initialize(glob, 4);
 
                 CHECK(domain->blocks[0].patches[0].user == nullptr);
-        fclaw_patch_build(glob, &domain->blocks[0].patches[0], 0, 0, &build_mode);
+        fclaw_patch_build(glob,domain, &domain->blocks[0].patches[0], 0, 0, &build_mode);
         CHECK(domain->blocks[0].patches[0].user != nullptr);
 
         fclaw_clawpatch_t* cp = fclaw_clawpatch_get_clawpatch(&domain->blocks[0].patches[0]);
@@ -340,7 +340,7 @@ TEST_CASE("3dx fclaw_clawpatch patch_build")
             CHECK_BOX_DIMENSIONS(cp->elliptic_soln, opts->mbc, opts->mx, opts->my, opts->mz, opts->rhs_fields);
         }
 
-        fclaw_patch_data_delete(glob, &domain->blocks[0].patches[0]);
+        fclaw_patch_data_delete(glob,domain, &domain->blocks[0].patches[0]);
         fclaw_clawpatch_options_destroy(opts);
         fclaw_domain_destroy(domain);
         fclaw_map_destroy(map);

--- a/src/patches/clawpatch/fclaw_clawpatch.h.3dx.TEST.cpp
+++ b/src/patches/clawpatch/fclaw_clawpatch.h.3dx.TEST.cpp
@@ -944,7 +944,7 @@ namespace{
     fclaw_clawpatch_t* i2f_cp1;
     fclaw_clawpatch_t* i2f_cp2;
     fclaw_clawpatch_t* i2f_cp3;
-    std::bitset<4> i2f_igrids;
+    int i2f_igrid;
     int i2f_manifold;
 }
 TEST_CASE("3dx fclaw_clawpatch interpolate2fine")
@@ -999,15 +999,17 @@ TEST_CASE("3dx fclaw_clawpatch interpolate2fine")
         }
 #endif
 
-        CHECK(i2f_igrids[*igrid] == false);
-        i2f_igrids[*igrid] = true;
+        CHECK_EQ(*igrid, i2f_igrid);
+
         CHECK(*manifold == i2f_manifold);
     };
 
-    fclaw_patch_interpolate2fine(coarse_test_data.glob,
-                                   &coarse_test_data.domain->blocks[0].patches[0],
-                                   &fine_test_data.domain->blocks[0].patches[0],
-                                   0, 0, 0);
-
-    CHECK(i2f_igrids.all());
+    for(int i = 0; i < 4; i++)
+    {
+        i2f_igrid = i;
+        fclaw_patch_interpolate2fine(coarse_test_data.glob,
+                                     &coarse_test_data.domain->blocks[0].patches[0],
+                                     &fine_test_data.domain->blocks[0].patches[i],
+                                     0, 0, 0, i);
+    }
 }

--- a/src/solvers/fc2d_geoclaw/fc2d_geoclaw.cpp
+++ b/src/solvers/fc2d_geoclaw/fc2d_geoclaw.cpp
@@ -516,10 +516,11 @@ int geoclaw_patch_tag4coarsening(fclaw_global_t *glob,
 static
 void geoclaw_interpolate2fine(fclaw_global_t *glob,
                               fclaw_patch_t *coarse_patch,
-                              fclaw_patch_t *fine_patches,
+                              fclaw_patch_t *fine_patch,
                               int blockno, 
                               int coarse_patchno,
-                              int fine0_patchno)
+                              int fine_patchno,
+                              int igrid)
 
 {
     int mx,my,mbc;
@@ -535,20 +536,14 @@ void geoclaw_interpolate2fine(fclaw_global_t *glob,
     double *auxcoarse;
     fclaw_clawpatch_aux_data(glob,coarse_patch,&auxcoarse,&maux);
 
-    /* Loop over four siblings (z-ordering) */
-    for (int igrid = 0; igrid < 4; igrid++)
-    {
-        fclaw_patch_t* fine_patch = &fine_patches[igrid];
+    double *qfine;
+    fclaw_clawpatch_soln_data(glob,fine_patch,&qfine,&meqn);
 
-        double *qfine;
-        fclaw_clawpatch_soln_data(glob,fine_patch,&qfine,&meqn);
+    double *auxfine;
+    fclaw_clawpatch_aux_data(glob,fine_patch,&auxfine,&maux);
 
-        double *auxfine;
-        fclaw_clawpatch_aux_data(glob,fine_patch,&auxfine,&maux);
-
-        FC2D_GEOCLAW_FORT_INTERPOLATE2FINE(&mx,&my,&mbc,&meqn,qcoarse,qfine,
-                                           &maux,auxcoarse,auxfine, &igrid);
-    }
+    FC2D_GEOCLAW_FORT_INTERPOLATE2FINE(&mx,&my,&mbc,&meqn,qcoarse,qfine,
+                                       &maux,auxcoarse,auxfine, &igrid);
 }
 
 static

--- a/src/solvers/fc2d_thunderegg/fc2d_thunderegg_vector_TEST.cpp
+++ b/src/solvers/fc2d_thunderegg/fc2d_thunderegg_vector_TEST.cpp
@@ -93,16 +93,16 @@ struct QuadDomain {
     }
     void setup(){
         fclaw_build_mode_t build_mode = FCLAW_BUILD_FOR_UPDATE;
-        fclaw_patch_build(glob, &domain->blocks[0].patches[0], 0, 0, &build_mode);
-        fclaw_patch_build(glob, &domain->blocks[0].patches[1], 0, 1, &build_mode);
-        fclaw_patch_build(glob, &domain->blocks[0].patches[2], 0, 2, &build_mode);
-        fclaw_patch_build(glob, &domain->blocks[0].patches[3], 0, 3, &build_mode);
+        fclaw_patch_build(glob,domain, &domain->blocks[0].patches[0], 0, 0, &build_mode);
+        fclaw_patch_build(glob,domain, &domain->blocks[0].patches[1], 0, 1, &build_mode);
+        fclaw_patch_build(glob,domain, &domain->blocks[0].patches[2], 0, 2, &build_mode);
+        fclaw_patch_build(glob,domain, &domain->blocks[0].patches[3], 0, 3, &build_mode);
     }
     ~QuadDomain(){
-        fclaw_patch_data_delete(glob, &domain->blocks[0].patches[0]);
-        fclaw_patch_data_delete(glob, &domain->blocks[0].patches[1]);
-        fclaw_patch_data_delete(glob, &domain->blocks[0].patches[2]);
-        fclaw_patch_data_delete(glob, &domain->blocks[0].patches[3]);
+        fclaw_patch_data_delete(glob,domain, &domain->blocks[0].patches[0]);
+        fclaw_patch_data_delete(glob,domain, &domain->blocks[0].patches[1]);
+        fclaw_patch_data_delete(glob,domain, &domain->blocks[0].patches[2]);
+        fclaw_patch_data_delete(glob,domain, &domain->blocks[0].patches[3]);
         fclaw_clawpatch_options_destroy(opts);
         fclaw_map_destroy(map);
         fclaw_domain_destroy(domain);
@@ -157,16 +157,16 @@ struct QuadDomainBrick {
             }
     void setup(){
         fclaw_build_mode_t build_mode = FCLAW_BUILD_FOR_UPDATE;
-        fclaw_patch_build(glob, &domain->blocks[0].patches[0], 0, 0, &build_mode);
-        fclaw_patch_build(glob, &domain->blocks[1].patches[0], 1, 0, &build_mode);
-        fclaw_patch_build(glob, &domain->blocks[2].patches[0], 2, 0, &build_mode);
-        fclaw_patch_build(glob, &domain->blocks[3].patches[0], 3, 0, &build_mode);
+        fclaw_patch_build(glob,domain, &domain->blocks[0].patches[0], 0, 0, &build_mode);
+        fclaw_patch_build(glob,domain, &domain->blocks[1].patches[0], 1, 0, &build_mode);
+        fclaw_patch_build(glob,domain, &domain->blocks[2].patches[0], 2, 0, &build_mode);
+        fclaw_patch_build(glob,domain, &domain->blocks[3].patches[0], 3, 0, &build_mode);
     }
     ~QuadDomainBrick(){
-        fclaw_patch_data_delete(glob, &domain->blocks[0].patches[0]);
-        fclaw_patch_data_delete(glob, &domain->blocks[1].patches[0]);
-        fclaw_patch_data_delete(glob, &domain->blocks[2].patches[0]);
-        fclaw_patch_data_delete(glob, &domain->blocks[3].patches[0]);
+        fclaw_patch_data_delete(glob,domain, &domain->blocks[0].patches[0]);
+        fclaw_patch_data_delete(glob,domain, &domain->blocks[1].patches[0]);
+        fclaw_patch_data_delete(glob,domain, &domain->blocks[2].patches[0]);
+        fclaw_patch_data_delete(glob,domain, &domain->blocks[3].patches[0]);
         fclaw_clawpatch_options_destroy(opts);
         fclaw_map_destroy(map);
         fclaw_domain_destroy(domain);

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -27,6 +27,9 @@ void throw_exception()
         expect_abort=false;
         std::longjmp(jump_buffer, 1);
     }
+    else{
+        FAIL("An abort was called");
+    }
 }
 
 void fclaw_test_expect_abort()


### PR DESCRIPTION
This implements the new partitioning interface and adds a `partition-mode` option.

The `partition-mode` option can have the following values:

- `legacy` use the old partition interface in `forestclaw.h`
- `pack-all` pack and unpack all patches regardless of whether they remain local or not 
-  `skip-local` skip the packing and unpack of patches that remain local
- `refine-after-partition` skip the packing and unpacking of patches that remain local, and delay the refinement of patches until after the partitioning step

**Other Key Changes** 

- Change `fclaw_patch_interpolate2fine` to accept one patch at a time instead of a family of patches to interpolate to. 
- Introduce the concept of a shallow copy and a reference counter for user patches. When the `refine-after-partion` option is used, coarse patch gets shallow copied to the family of fine patches in regrid step in order to save on memory before the partition step.
- add a `fclaw_regrid_process_new_refinement` function in order to deduplicate some code shared between `fclaw_initialize` and `fclaw_regrid`
- add a `domain` argument to all patch creation / deletion functions in order to fix some issues with diagnostic counters
- add a flag to patches to indicate if they contain coarse data. This flag gets packed and unpacked, so after the partition step, we know which patches need to be refined.

**Future work**

In `fclaw_regrid.c` and `fclaw_patch.c`, I need to create a temporary 'artificial' coarse patch, so I can pass a coarse patch to `claw_patch_interpolate2fine`. The main reason this is necessary is because metric data may necessary for interpolation routines. The metric patch needs to be built with a patch that has the extents of the coarse patch. I've hacked together an artificial patch, but I know some things in this patch are set incorrectly, like `patch->flags`, so a more robust solution is probably needed.