### PR TITLE
fix minor gauge bug

### DIFF
--- a/src/fclaw_gauges.c
+++ b/src/fclaw_gauges.c
@@ -235,7 +235,7 @@ void gauge_initialize(fclaw_global_t* glob, void** acc)
             {
                 /* Map gauge to global [0,1]x[0,1] space. This works for the brick
                    but not clear what happens for the cubed sphere */
-                double p[gauge_dim];
+                double p[3];
                 fclaw_gauge_normalize_coordinates(glob,block,nb,&gauges[i],&p[0],&p[1],&p[2]);
 
 


### PR DESCRIPTION
Array with 'gauge_dim' entries should have constant 3 entries to avoid problem indexing p[2]. 