### PR TITLE
Update ThunderEgg submoule and fix ThunderEgg step in Autotools CI

### DIFF
--- a/.github/workflows/ci_automake.yml
+++ b/.github/workflows/ci_automake.yml
@@ -74,7 +74,7 @@ jobs:
           cuda: true
           cuda_11_3: true
         - name: "MPI With ThunderEgg"
-          configure_flags: "--enable-mpi --enable-thunderegg --with-thunderegg=$GITHUB_WORKSPACE/ThunderEgg"
+          configure_flags: "--enable-mpi --enable-thunderegg --with-thunderegg=$GITHUB_WORKSPACE/thunderegg_install"
           ubuntu_packages: "cmake libopenmpi-dev openmpi-bin libfftw3-dev"
           thunderegg: true
 
@@ -82,14 +82,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       name: "Checkout Source code"
-
-    - uses: actions/checkout@v4
-      name: "Checkout ThunderEgg Source code"
-      if: ${{ matrix.thunderegg }}
-      with:
-        repository: ThunderEgg/ThunderEgg
-        ref: v1.0.5
-        path: ThunderEggSrc
 
     - name: Install dependencies
       run: |
@@ -104,17 +96,17 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install cuda-toolkit-11-3
 
-    - name: Install ThunderEgg
-      if: ${{ matrix.thunderegg }}
-      run: |
-        cd ThunderEggSrc
-        cmake -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/ThunderEgg/ -DBUILD_TESTING=OFF .
-        make install
-
     - name: Init and Update Submodules
       run: |
         git submodule init
         git submodule update
+
+    - name: Install ThunderEgg
+      if: ${{ matrix.thunderegg }}
+      run: |
+        cd thunderegg
+        cmake -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/thunderegg_install/ -DBUILD_TESTING=OFF .
+        make install
 
     - name: Run bootstrap Script
       run: ./bootstrap

--- a/.github/workflows/ci_automake.yml
+++ b/.github/workflows/ci_automake.yml
@@ -104,8 +104,8 @@ jobs:
       if: ${{ matrix.thunderegg }}
       run: |
         cd thunderegg
-        cmake -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/thunderegg_install/ -DBUILD_TESTING=OFF .
-        make install
+        cmake -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/thunderegg_install/ -DThunderEgg_BUILD_TESTING=OFF .
+        cmake --build . --parallel 4 --target install
 
     - name: Run bootstrap Script
       run: ./bootstrap

--- a/.github/workflows/ci_automake.yml
+++ b/.github/workflows/ci_automake.yml
@@ -98,8 +98,7 @@ jobs:
 
     - name: Init and Update Submodules
       run: |
-        git submodule init
-        git submodule update
+        git submodule update --init --recursive
 
     - name: Install ThunderEgg
       if: ${{ matrix.thunderegg }}


### PR DESCRIPTION
Update the ThunderEgg submodule to v1.1.0. Also fixes the ThunderEgg step in the Autotools CI so that it uses the submodule.