### PR TITLE
Fix HDF5 VTU output for large files

### DIFF
--- a/src/patches/clawpatch/fclaw_clawpatch_output_hdf5.c
+++ b/src/patches/clawpatch/fclaw_clawpatch_output_hdf5.c
@@ -1143,15 +1143,15 @@ fclaw_hdf_write_file (fclaw_global_t * glob,
 
     //get mx, my, mz, meqn from clawpatch options
     int patch_dim = clawpatch_opt->patch_dim;
-    int mx   = clawpatch_opt->mx;
-    int my   = clawpatch_opt->my;
-    int mz   = clawpatch_opt->mz;
+    int64_t mx   = clawpatch_opt->mx;
+    int64_t my   = clawpatch_opt->my;
+    int64_t mz   = clawpatch_opt->mz;
 
-    int global_num_patches = glob->domain->global_num_patches;
+    int64_t global_num_patches = glob->domain->global_num_patches;
 
-    int num_cells_per_patch;
-    int num_points_per_patch;
-    int num_points_per_cell;
+    int64_t num_cells_per_patch;
+    int64_t num_points_per_patch;
+    int64_t num_points_per_cell;
     if(clawpatch_opt->patch_dim == 2)
     {
         num_cells_per_patch = mx * my;


### PR DESCRIPTION
An integer overflow was happening the the hdf writer, some variables needed to be changed from `int` to `int64_t`