### PR TITLE
Use SC Submodule in CMake

### DIFF
--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -104,7 +104,7 @@ jobs:
 
 
   mac:
-    runs-on: macos-14
+    runs-on: macos-27
     name: CMake build on MacOS
     env:
       HOMEBREW_NO_INSTALL_CLEANUP: 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,9 +41,12 @@ include(cmake/GitSubmodule.cmake)
 
 if(FCLAW_ENABLE_SUBMODULES)
 
+  git_submodule(${CMAKE_CURRENT_SOURCE_DIR}/sc)
+  set(SC_BUILD_TESTING OFF CACHE BOOL "" FORCE)
+  add_subdirectory(sc)
+
   git_submodule(${CMAKE_CURRENT_SOURCE_DIR}/p4est)
   set(P4EST_BUILD_TESTING OFF CACHE BOOL "" FORCE)
-  set(SC_BUILD_TESTING OFF CACHE BOOL "" FORCE)
   add_subdirectory(p4est)
 
 else()


### PR DESCRIPTION
Use the top level SC submodule in CMake. This will make the behavior of the CMake build the same as the auto tools build, and will fix problems with the p4est submodule using a system install of libSC instead of the SC submodule.