### PR TITLE
Add Matlab reader for VTU files

### DIFF
--- a/matlab/readamrdata_forestclaw_vtu.m
+++ b/matlab/readamrdata_forestclaw_vtu.m
@@ -135,8 +135,7 @@ for ng = 1:num_patches
 
     % read meqn
     meqn = read_by_name(h, h.VTKFile.UnstructuredGrid.Piece.CellData.DataArray, 'meqn', cell_start, cell_start + ncells_per_patch - 1);
-    % reorder from meqn(m,i) to meqn(i,m)
-    amrdata.data = permute(meqn, [2, 1]);
+    amrdata.data = meqn;
 
     amr(ng) = amrdata;
 end

--- a/matlab/readamrdata_forestclaw_vtu.m
+++ b/matlab/readamrdata_forestclaw_vtu.m
@@ -1,0 +1,507 @@
+function [amr,t] = readamrdata_forestclaw_vtu(dim,Frame,dir)
+
+% Read ForestClaw VTU output and return AMR patch data.
+%
+%   [amr,t] = readamrdata_forestclaw_vtu(dim,Frame,dir)
+%
+%   Input:
+%     dim   - Patch dimension (2 or 3).
+%     Frame - Output frame number.
+%     dir   - Directory containing fort_frame_####.vtu (optional).
+%
+%   Output:
+%     amr   - Struct array with fields compatible with legacy ForestClaw
+%             MATLAB readers: gridno, level, blockno, mpirank,
+%             mx/my/(mz), xlow/ylow/(zlow), dx/dy/(dz), data.
+%     t     - Time from fort.t#### when available; otherwise Frame.
+%
+%   Notes:
+%     - VTU data is read from AppendedData encoding="raw" sections.
+%     - Data columns in amr(ng).data are patch cells; rows are concatenated
+%       in order: meqn, aux, rhs, soln, error (when present).
+
+if nargin < 3
+    dir = '';
+end
+
+if ~isempty(dir)
+    lastch = dir(end);
+    if ~(lastch == '/' || lastch == '\\')
+        % Normalize directory input so filename concatenation is robust.
+        dir = [dir filesep];
+    end
+end
+
+filename = [dir, sprintf('fort_frame_%04d.vtu', Frame)];
+if ~exist(filename, 'file')
+    amr = [];
+    t = [];
+    disp(' ');
+    disp(['Frame ',num2str(Frame),' (',filename,') does not exist ***']);
+    disp(' ');
+    return
+end
+
+disp(['Reading data from ',filename]);
+
+% Use legacy fort.tXXXX time if available, otherwise fall back to frame index.
+t = Frame;
+tname = [dir, sprintf('fort.t%04d', Frame)];
+if exist(tname, 'file')
+    tfid = fopen(tname, 'r');
+    if tfid >= 0
+        tval = fscanf(tfid, '%g', 1);
+        fclose(tfid);
+        if ~isempty(tval)
+            t = tval;
+        end
+    end
+end
+
+bytes = read_file_bytes(filename);
+[header_text, appended_start] = split_vtu_header(bytes);
+
+piece = parse_piece_counts(header_text);
+arrays = parse_data_arrays(header_text);
+
+values = decode_appended_arrays(bytes, appended_start, arrays);
+
+required_fields = {'Position','connectivity','types','mpirank','blockno','meqn'};
+for ireq = 1:numel(required_fields)
+    if ~isfield(values, required_fields{ireq})
+        error('Required VTU DataArray "%s" is missing in %s.', required_fields{ireq}, filename);
+    end
+end
+
+% Convert VTK connectivity to 1-based indexing for MATLAB array access.
+points = reshape(values.Position, 3, []).';
+connectivity = double(values.connectivity) + 1;
+connectivity = reshape(connectivity, [], piece.num_cells);
+types = double(values.types(:));
+
+if dim == 2
+    expected_type = 9;
+    verts_per_cell = 4;
+else
+    expected_type = 12;
+    verts_per_cell = 8;
+end
+
+if ~all(types == expected_type)
+    error('Unexpected VTK cell type in %s.', filename);
+end
+
+if size(connectivity,1) ~= verts_per_cell
+    error('Connectivity width does not match expected %d vertices per cell.', verts_per_cell);
+end
+
+if size(points,1) ~= piece.num_points
+    error('Point count mismatch while reading %s.', filename);
+end
+
+if size(connectivity,2) ~= piece.num_cells
+    error('Cell count mismatch while reading %s.', filename);
+end
+
+% ForestClaw VTU writes patches as disconnected connectivity components.
+component_labels = connected_cell_components(connectivity, size(points,1));
+roots = unique(component_labels, 'stable');
+num_patches = numel(roots);
+amr = struct('gridno', {}, ...
+             'level', {}, ...
+             'blockno', {}, ...
+             'mpirank', {}, ...
+             'mx', {}, ...
+             'my', {}, ...
+             'mz', {}, ...
+             'xlow', {}, ...
+             'ylow', {}, ...
+             'zlow', {}, ...
+             'dx', {}, ...
+             'dy', {}, ...
+             'dz', {}, ...
+             'data', {});
+
+field_order = {'meqn', 'aux', 'rhs', 'soln', 'error'};
+
+for ng = 1:num_patches
+    amrdata = struct('gridno', [], ...
+                     'level', [], ...
+                     'blockno', [], ...
+                     'mpirank', [], ...
+                     'mx', [], ...
+                     'my', [], ...
+                     'mz', [], ...
+                     'xlow', [], ...
+                     'ylow', [], ...
+                     'zlow', [], ...
+                     'dx', [], ...
+                     'dy', [], ...
+                     'dz', [], ...
+                     'data', []);
+    comp_id = roots(ng);
+    cell_ids = find(component_labels == comp_id);
+
+    patch_conn = connectivity(:, cell_ids);
+    patch_pts_ids = unique(patch_conn(:));
+    patch_pts = points(patch_pts_ids, :);
+
+    if dim == 2
+        [mx,my] = infer_2d_shape(patch_conn, points);
+        mz = [];
+    else
+        [mx,my,mz] = infer_3d_shape(patch_conn, points);
+    end
+
+    [xlow,dx] = infer_axis_spacing(patch_pts(:,1));
+    [ylow,dy] = infer_axis_spacing(patch_pts(:,2));
+    if dim > 2
+        [zlow,dz] = infer_axis_spacing(patch_pts(:,3));
+    end
+
+    % Fill legacy AMR metadata expected by plotting/post-processing scripts.
+    amrdata.gridno = ng;
+    amrdata.blockno = int_mode(values.blockno(cell_ids));
+    amrdata.mpirank = int_mode(values.mpirank(cell_ids));
+    amrdata.mx = mx;
+    amrdata.my = my;
+    if dim > 2
+        amrdata.mz = mz;
+    else
+        amrdata.mz = [];
+    end
+
+    amrdata.xlow = xlow;
+    amrdata.ylow = ylow;
+    if dim > 2
+        amrdata.zlow = zlow;
+    else
+        amrdata.zlow = [];
+    end
+
+    amrdata.dx = dx;
+    amrdata.dy = dy;
+    if dim > 2
+        amrdata.dz = dz;
+    else
+        amrdata.dz = [];
+    end
+
+    patch_data = [];
+    for k = 1:numel(field_order)
+        fname_k = field_order{k};
+        if isfield(values, fname_k)
+            field_raw = values.(fname_k);
+            % Each field is stored as [ncomp x ncells] after reshape.
+            field_data = reshape(float_array(field_raw), [], piece.num_cells);
+            patch_data = [patch_data; field_data(:, cell_ids)]; %#ok<AGROW>
+        end
+    end
+    amrdata.data = patch_data;
+
+    if isfield(values, 'patchno')
+        amrdata.gridno = int_mode(values.patchno(cell_ids)) + 1;
+    end
+
+    amr(ng) = amrdata; %#ok<AGROW>
+end
+
+amr = assign_levels_from_spacing(amr, dim);
+
+end
+
+% Read complete file contents as raw bytes.
+function bytes = read_file_bytes(filename)
+fid = fopen(filename, 'r');
+if fid < 0
+    error('Unable to open %s', filename);
+end
+bytes = fread(fid, inf, '*uint8');
+fclose(fid);
+end
+
+% Split XML header from raw appended payload location.
+function [header_text, appended_start] = split_vtu_header(bytes)
+needle = uint8('<AppendedData');
+idx = strfind(bytes.', needle);
+if isempty(idx)
+    error('No AppendedData section found in VTU file.');
+end
+start_idx = idx(1);
+tail = bytes(start_idx:min(numel(bytes), start_idx + 2048));
+u_idx = find(tail == uint8('_'), 1, 'first');
+if isempty(u_idx)
+    error('AppendedData payload marker "_" not found.');
+end
+% appended_start is the byte index of the '_' marker in AppendedData.
+appended_start = start_idx + u_idx - 1;
+header_text = char(bytes(1:appended_start-1)).';
+end
+
+% Parse global point/cell counts declared in the VTU Piece tag.
+function piece = parse_piece_counts(header_text)
+tok = regexp(header_text, '<Piece\s+[^>]*NumberOfPoints="(\d+)"\s+NumberOfCells="(\d+)"', 'tokens', 'once');
+if isempty(tok)
+    error('VTU Piece metadata is missing NumberOfPoints/NumberOfCells.');
+end
+piece.num_points = str2double(tok{1});
+piece.num_cells = str2double(tok{2});
+end
+
+% Parse appended DataArray metadata (name, type, offset, components).
+function arrays = parse_data_arrays(header_text)
+tags = regexp(header_text, '<DataArray\s+([^>]*)>', 'tokens');
+arrays = struct('Name', {}, 'type', {}, 'offset', {}, 'num_components', {});
+for i = 1:numel(tags)
+    attrs = tags{i}{1};
+    name = read_attr(attrs, 'Name');
+    if isempty(name)
+        continue;
+    end
+    fmt = read_attr(attrs, 'format');
+    if ~strcmp(fmt, 'appended')
+        continue;
+    end
+
+    a.Name = name;
+    a.type = read_attr(attrs, 'type');
+    a.offset = str2double(read_attr(attrs, 'offset'));
+
+    nc = read_attr(attrs, 'NumberOfComponents');
+    if isempty(nc)
+        a.num_components = 1;
+    else
+        a.num_components = str2double(nc);
+    end
+    arrays(end+1) = a; %#ok<AGROW>
+end
+end
+
+% Read one XML attribute value from an attribute string.
+function value = read_attr(attrs, key)
+pat = [key, '="([^"]+)"'];
+tok = regexp(attrs, pat, 'tokens', 'once');
+if isempty(tok)
+    value = '';
+else
+    value = tok{1};
+end
+end
+
+% Decode all appended arrays using declared offsets and VTK data types.
+function values = decode_appended_arrays(bytes, appended_start, arrays)
+values = struct();
+for i = 1:numel(arrays)
+    a = arrays(i);
+    % Offsets are measured from the byte immediately after '_'.
+    payload_pos = appended_start + 1 + a.offset;
+    nbytes = read_uint64_le(bytes, payload_pos);
+    data_start = payload_pos + 8;
+    data_end = data_start + double(nbytes) - 1;
+
+    if data_end > numel(bytes)
+        error('AppendedData offset/size exceeds file bounds for %s.', a.Name);
+    end
+
+    raw = bytes(data_start:data_end);
+    values.(a.Name) = cast_appended(raw, a.type, a.num_components);
+end
+end
+
+% Read little-endian UInt64 length prefix used by VTU AppendedData blocks.
+function u = read_uint64_le(bytes, pos)
+u = uint64(0);
+for k = 0:7
+    u = bitor(u, bitshift(uint64(bytes(pos+k)), 8*k));
+end
+end
+
+% Convert raw byte payload into MATLAB numeric arrays based on VTK type.
+function out = cast_appended(raw, vtk_type, ncomp)
+switch vtk_type
+    case 'Float64'
+        out = typecast(raw, 'double');
+    case 'Float32'
+        out = typecast(raw, 'single');
+    case 'Int32'
+        out = typecast(raw, 'int32');
+    case 'Int64'
+        out = typecast(raw, 'int64');
+    case 'UInt8'
+        out = uint8(raw);
+    otherwise
+        error('Unsupported VTK type: %s', vtk_type);
+end
+
+if ncomp > 1
+    out = reshape(out, ncomp, []);
+end
+end
+
+% Build connected components of cells that share vertices.
+function labels = connected_cell_components(connectivity, npoints)
+ncells = size(connectivity, 2);
+parent = 1:ncells;
+owner = zeros(npoints, 1);
+
+for c = 1:ncells
+    verts = connectivity(:, c);
+    for iv = 1:numel(verts)
+        v = verts(iv);
+        if owner(v) == 0
+            owner(v) = c;
+        else
+            % Union-Find merge when two cells touch the same point.
+            parent = unite(parent, c, owner(v));
+        end
+    end
+end
+
+labels = zeros(ncells,1);
+for c = 1:ncells
+    labels(c) = find_root(parent, c);
+end
+end
+
+% Union operation for cell component labels.
+function parent = unite(parent, a, b)
+ra = find_root(parent, a);
+rb = find_root(parent, b);
+if ra ~= rb
+    parent(rb) = ra;
+end
+end
+
+% Find operation for cell component labels.
+function r = find_root(parent, x)
+r = x;
+while parent(r) ~= r
+    r = parent(r);
+end
+end
+
+% Infer (mx,my) assuming patch points lie on a Cartesian x/y grid.
+function [mx,my] = infer_2d_shape(patch_conn, points)
+patch_point_ids = unique(patch_conn(:));
+patch_xy = double(points(patch_point_ids, 1:2));
+
+nx = numel(unique(patch_xy(:,1)));
+ny = numel(unique(patch_xy(:,2)));
+
+if nx * ny ~= numel(patch_point_ids)
+    error('2D patch points do not form a rectangular Cartesian lattice.');
+end
+
+ncells = size(patch_conn, 2);
+mx = nx - 1;
+my = ny - 1;
+if mx * my ~= ncells
+    error('Cartesian-grid inference mismatch: mx*my does not equal cell count.');
+end
+end
+
+% Infer (mx,my,mz) assuming patch points lie on a Cartesian x/y/z grid.
+function [mx,my,mz] = infer_3d_shape(patch_conn, points)
+patch_point_ids = unique(patch_conn(:));
+patch_xyz = double(points(patch_point_ids, 1:3));
+
+nx = numel(unique(patch_xyz(:,1)));
+ny = numel(unique(patch_xyz(:,2)));
+nz = numel(unique(patch_xyz(:,3)));
+
+if nx * ny * nz ~= numel(patch_point_ids)
+    error('3D patch points do not form a rectangular Cartesian lattice.');
+end
+
+mx = nx - 1;
+my = ny - 1;
+mz = nz - 1;
+
+ncells = size(patch_conn, 2);
+if mx * my * mz ~= ncells
+    error('Cartesian-grid inference mismatch: mx*my*mz does not equal cell count.');
+end
+end
+
+% Estimate axis origin and spacing from unique coordinate values.
+function [x0,dx] = infer_axis_spacing(vals)
+u = unique(sort(double(vals(:))));
+if numel(u) < 2
+    x0 = u(1);
+    dx = 0;
+    return
+end
+d = diff(u);
+tol = max(1e-12, max(abs(u)) * 1e-10);
+d = d(d > tol);
+if isempty(d)
+    x0 = u(1);
+    dx = 0;
+else
+    x0 = u(1);
+    dx = min(d);
+end
+end
+
+% Return mode for integer metadata that should be constant per patch.
+function m = int_mode(v)
+v = double(v(:));
+if isempty(v)
+    m = 0;
+    return
+end
+uv = unique(v);
+counts = zeros(size(uv));
+for i = 1:numel(uv)
+    counts(i) = sum(v == uv(i));
+end
+[~,idx] = max(counts);
+m = uv(idx);
+end
+
+% Convert numeric arrays to double and normalize orientation for reshape.
+function arr = float_array(v)
+arr = double(v);
+if isvector(arr)
+    arr = arr(:).';
+end
+end
+
+% Assign AMR levels from relative spacing tiers.
+function amr = assign_levels_from_spacing(amr, dim)
+if isempty(amr)
+    return
+end
+
+all_dx = zeros(numel(amr),1);
+for i = 1:numel(amr)
+    all_dx(i) = amr(i).dx;
+end
+
+levels = spacing_to_levels(all_dx);
+for i = 1:numel(amr)
+    amr(i).level = levels(i);
+    if dim == 2
+        if ~isfield(amr(i), 'mz')
+            amr(i).mz = [];
+        end
+        if ~isfield(amr(i), 'zlow')
+            amr(i).zlow = [];
+        end
+        if ~isfield(amr(i), 'dz')
+            amr(i).dz = [];
+        end
+    end
+end
+end
+
+% Convert unique spacing values to level indices (coarsest -> level 1).
+function levels = spacing_to_levels(dx)
+udx = unique(sort(dx, 'descend'));
+levels = zeros(size(dx));
+for i = 1:numel(dx)
+    [~,idx] = min(abs(udx - dx(i)));
+    levels(i) = idx;
+end
+end
+

--- a/matlab/readamrdata_forestclaw_vtu.m
+++ b/matlab/readamrdata_forestclaw_vtu.m
@@ -19,6 +19,8 @@ function [amr,t] = readamrdata_forestclaw_vtu(dim,Frame,dir)
 %     - VTU data is read from AppendedData encoding="raw" sections.
 %     - Data columns in amr(ng).data are patch cells; rows are concatenated
 %       in order: meqn, aux, rhs, soln, error (when present).
+%     - Local helper read_by_name(h, arrays, name, startIdx, endIdx)
+%       accepts an optional 1-based inclusive tuple range.
 
 if nargin < 3
     dir = '';
@@ -26,7 +28,7 @@ end
 
 if ~isempty(dir)
     lastch = dir(end);
-    if ~(lastch == '/' || lastch == '\\')
+    if ~(lastch == "/" || lastch == "\\")
         % Normalize directory input so filename concatenation is robust.
         dir = [dir filesep];
     end
@@ -45,71 +47,32 @@ end
 disp(['Reading data from ',filename]);
 
 h = parse_vtu_header(filename);
-fid_cleanup = onCleanup(@() fclose(h.fid)); %#ok<NASGU>
+fid_cleanup = onCleanup(@() fclose(h.fid));
 
 have_field_data = isfield(h.VTKFile.UnstructuredGrid, 'FieldData');
 
-% Set time
+% Global Variables
+num_points = h.VTKFile.UnstructuredGrid.Piece.NumberOfPoints;
+num_cells  = h.VTKFile.UnstructuredGrid.Piece.NumberOfCells;
+mx = 0;
 if have_field_data
     t = find_by_name(h.VTKFile.UnstructuredGrid.FieldData.DataArray, 'TimeValue').data;
+    patch_dimension = find_by_name(h.VTKFile.UnstructuredGrid.FieldData.DataArray, 'patch_dimension').data;
+    mx = patch_dimension(1);
+    my = patch_dimension(2);
+    if dim == 3 
+        mz = patch_dimension(3);
+    end
+    patch_starts = read_by_name(h, h.VTKFile.UnstructuredGrid.FieldData.DataArray, 'patch_starts');
+    patch_spacings = read_by_name(h, h.VTKFile.UnstructuredGrid.FieldData.DataArray, 'patch_spacings');
+    levels = read_by_name(h, h.VTKFile.UnstructuredGrid.FieldData.DataArray, 'levels');
+    num_patches = numel(levels);
 else
     t = Frame;
 end
 
-num_points = h.VTKFile.UnstructuredGrid.Piece.NumberOfPoints;
-num_cells  = h.VTKFile.UnstructuredGrid.Piece.NumberOfCells;
-arrays = collect_appended_arrays(h.VTKFile);
-
-% Phase 1: read only topology arrays (geometry + metadata, not field data).
-% Include explicit metadata arrays written by newer versions of the VTU writer.
-topo_names = {'Position', 'connectivity', 'types', 'mpirank', 'blockno', 'patchno', ...
-              'patch_dimension', 'levels', 'patch_starts', 'patch_spacings', 'TimeValue'};
-topo = decode_specific_arrays(h.fid, h.payload_start, arrays, topo_names);
-
-required_fields = {'Position','connectivity','types','mpirank','blockno','patchno'};
-for ireq = 1:numel(required_fields)
-    if ~isfield(topo, required_fields{ireq})
-        error('Required VTU DataArray "%s" is missing in %s.', required_fields{ireq}, filename);
-    end
-end
-
-% Convert VTK connectivity to 1-based indexing for MATLAB array access.
-points = reshape(topo.Position, 3, []).';
-connectivity = double(topo.connectivity) + 1;
-connectivity = reshape(connectivity, [], num_cells);
-types = double(topo.types(:));
-
-if dim == 2
-    expected_type = 9;
-    verts_per_cell = 4;
-else
-    expected_type = 12;
-    verts_per_cell = 8;
-end
-
-if ~all(types == expected_type)
-    error('Unexpected VTK cell type in %s.', filename);
-end
-
-if size(connectivity,1) ~= verts_per_cell
-    error('Connectivity width does not match expected %d vertices per cell.', verts_per_cell);
-end
-
-if size(points,1) ~= piece.num_points
-    error('Point count mismatch while reading %s.', filename);
-end
-
-if size(connectivity,2) ~= piece.num_cells
-    error('Cell count mismatch while reading %s.', filename);
-end
-
 % All patches have the same number of cells; compute patch map by arithmetic.
-num_patches = numel(unique(double(topo.patchno(:)), 'sorted'));
-ncells_per_patch = piece.num_cells / num_patches;
-if ncells_per_patch ~= floor(ncells_per_patch)
-    error('num_cells (%d) is not evenly divisible by num_patches (%d) in %s.', ...
-          piece.num_cells, num_patches, filename);
-end
+ncells_per_patch = num_cells / num_patches;
 amr = struct('gridno', {}, ...
              'level', {}, ...
              'blockno', {}, ...
@@ -124,20 +87,6 @@ amr = struct('gridno', {}, ...
              'dy', {}, ...
              'dz', {}, ...
              'data', {});
-
-field_order = {'meqn', 'aux', 'rhs', 'soln', 'error'};
-
-% Extract global patch_dimension metadata (same for all patches)
-if isfield(topo, 'patch_dimension')
-    mxmymz_global = reshape(double(topo.patch_dimension), 3, []);
-    mx_global = mxmymz_global(1, 1);
-    my_global = mxmymz_global(2, 1);
-    if dim > 2
-        mz_global = mxmymz_global(3, 1);
-    else
-        mz_global = [];
-    end
-end
 
 for ng = 1:num_patches
     amrdata = struct('gridno', [], ...
@@ -155,68 +104,13 @@ for ng = 1:num_patches
                      'dz', [], ...
                      'data', []);
     % Compute this patch's 1-based cell index range directly from uniform size.
-    cell_start_0 = (ng-1) * ncells_per_patch;  % 0-based offset into flat arrays
-    cell_ids = (cell_start_0+1 : cell_start_0+ncells_per_patch);  % 1-based MATLAB indices
+    cell_start= (ng-1) * ncells_per_patch + 1;  % 0-based offset into flat arrays
 
-    patch_conn = connectivity(:, cell_ids);
-    patch_pts_ids = unique(patch_conn(:));
-    patch_pts = points(patch_pts_ids, :);
-
-    % Patch shape (mx, my, mz): use global metadata (same for all patches) or fall back to inference.
-    if isfield(topo, 'patch_dimension')
-        mx = mx_global;
-        my = my_global;
-        mz = mz_global;
-    else
-        if dim == 2
-            [mx,my] = infer_2d_shape(patch_conn, points);
-            mz = [];
-        else
-            [mx,my,mz] = infer_3d_shape(patch_conn, points);
-        end
-    end
-
-    % Patch origin and spacing: prefer explicit FieldData; fall back to inference.
-    if isfield(topo, 'patch_starts')
-        xyz_low_arr = reshape(double(topo.patch_starts), 3, []);
-        xlow = xyz_low_arr(1, ng);
-        ylow = xyz_low_arr(2, ng);
-        if dim > 2
-            zlow = xyz_low_arr(3, ng);
-        else
-            zlow = [];
-        end
-    else
-        [xlow,~] = infer_axis_spacing(patch_pts(:,1));
-        [ylow,~] = infer_axis_spacing(patch_pts(:,2));
-        if dim > 2
-            [zlow,~] = infer_axis_spacing(patch_pts(:,3));
-        end
-    end
-    
-    if isfield(topo, 'patch_spacings')
-        dxdydz_arr = reshape(double(topo.patch_spacings), 3, []);
-        dx = dxdydz_arr(1, ng);
-        dy = dxdydz_arr(2, ng);
-        if dim > 2
-            dz = dxdydz_arr(3, ng);
-        else
-            dz = [];
-        end
-    else
-        [~,dx] = infer_axis_spacing(patch_pts(:,1));
-        [~,dy] = infer_axis_spacing(patch_pts(:,2));
-        if dim > 2
-            [~,dz] = infer_axis_spacing(patch_pts(:,3));
-        else
-            dz = [];
-        end
-    end
-
-    % Fill legacy AMR metadata expected by plotting/post-processing scripts.
-    amrdata.gridno = double(topo.patchno(cell_ids(1))) + 1;
-    amrdata.blockno = double(topo.blockno(cell_ids(1)));
-    amrdata.mpirank = double(topo.mpirank(cell_ids(1)));
+    % Fill AMR metadata
+    amrdata.gridno = read_by_name(h, h.VTKFile.UnstructuredGrid.Piece.CellData.DataArray, 'patchno', cell_start, cell_start);
+    amrdata.level = double(levels(ng));
+    amrdata.blockno = read_by_name(h, h.VTKFile.UnstructuredGrid.Piece.CellData.DataArray, 'blockno', cell_start, cell_start);
+    amrdata.mpirank = read_by_name(h, h.VTKFile.UnstructuredGrid.Piece.CellData.DataArray, 'mpirank', cell_start, cell_start);
     amrdata.mx = mx;
     amrdata.my = my;
     if dim > 2
@@ -225,60 +119,28 @@ for ng = 1:num_patches
         amrdata.mz = [];
     end
 
-    amrdata.xlow = xlow;
-    amrdata.ylow = ylow;
+    amrdata.xlow = patch_starts(1, ng);
+    amrdata.ylow = patch_starts(2, ng);
     if dim > 2
-        amrdata.zlow = zlow;
+        amrdata.zlow = patch_starts(3, ng);
     else
         amrdata.zlow = [];
     end
 
-    amrdata.dx = dx;
-    amrdata.dy = dy;
+    amrdata.dx = patch_spacings(1, ng);
+    amrdata.dy = patch_spacings(2, ng);
     if dim > 2
-        amrdata.dz = dz;
+        amrdata.dz = patch_spacings(3, ng);
     else
         amrdata.dz = [];
     end
 
-    % Phase 2: seek to this patch's cell slice in each field array and read it.
-    patch_data = [];
-    for k = 1:numel(field_order)
-        fname_k = field_order{k};
-        fa = find_array(arrays, fname_k);
-        if ~isempty(fa)
-            raw = read_array_cells(h.fid, h.payload_start, fa, cell_ids(1)-1, numel(cell_ids));
-            field_data = reshape(float_array(cast_appended(raw, fa.type, fa.num_components)), [], numel(cell_ids));
-            patch_data = [patch_data; field_data]; %#ok<AGROW>
-        end
-    end
-    amrdata.data = patch_data;
+    % read meqn
+    meqn = read_by_name(h, h.VTKFile.UnstructuredGrid.Piece.CellData.DataArray, 'meqn', cell_start, cell_start + ncells_per_patch - 1);
+    % reorder from meqn(m,i) to meqn(i,m)
+    amrdata.data = permute(meqn, [2, 1]);
 
-    amr(ng) = amrdata; %#ok<AGROW>
-end
-
-% If explicit level data was written by the VTU writer, use it directly;
-% otherwise infer AMR levels from relative cell spacing (legacy files).
-if ~isfield(topo, 'levels')
-    amr = assign_levels_from_spacing(amr, dim);
-else
-    for ng = 1:numel(amr)
-        amr(ng).level = double(topo.levels(ng));
-    end
-end
-
-if dim == 2
-    for ng = 1:numel(amr)
-        if ~isfield(amr(ng), 'mz')
-            amr(ng).mz   = [];
-        end
-        if ~isfield(amr(ng), 'zlow')
-            amr(ng).zlow = [];
-        end
-        if ~isfield(amr(ng), 'dz')
-            amr(ng).dz   = [];
-        end
-    end
+    amr(ng) = amrdata;
 end
 
 end
@@ -294,33 +156,124 @@ for i = 1:numel(arrays)
 end
 end
 
-% Read only the named DataArrays from the appended section; skip all others.
-function values = decode_specific_arrays(fid, payload_start, arrays, names)
-values = struct();
-for i = 1:numel(arrays)
-    if any(strcmp(arrays(i).Name, names))
-        a = arrays(i);
-        if fseek(fid, payload_start + a.offset, 'bof') ~= 0
-            error('Seek failed for DataArray "%s".', a.Name);
+% Read a named DataArray by Name from either FieldData or Piece sections.
+% Accepts raw XML DataArray structs or normalized entries from collect_appended_arrays.
+% Optional startIdx/endIdx select an inclusive 1-based tuple range to minimize disk I/O.
+function values = read_by_name(h, arrays, name, startIdx, endIdx)
+values = [];
+da = find_by_name(arrays, name);
+if isempty(da)
+    return;
+end
+
+ncomp = data_array_num_components(da);
+
+have_range = (nargin >= 4 && ~isempty(startIdx)) || (nargin >= 5 && ~isempty(endIdx));
+if nargin < 4 || isempty(startIdx)
+    startIdx = 1;
+end
+if nargin < 5 || isempty(endIdx)
+    endIdx = [];
+end
+
+da_format = data_array_format(da);
+if strcmp(da_format, 'appended')
+    if have_range
+        % Read only the requested tuple range to minimize disk I/O
+        if isempty(endIdx)
+            % Need total tuple count; read full length prefix
+            if fseek(h.fid, h.payload_start + da.offset, 'bof') ~= 0
+                error('Seek failed for DataArray "%s".', da.Name);
+            end
+            nbytes = double(read_uint64_le_from_fid(h.fid));
+            elem_size = vtk_type_size(da.type);
+            ntuples = nbytes / (elem_size * ncomp);
+            endIdx = ntuples;
         end
-        nbytes = double(read_uint64_le_from_fid(fid));
-        raw = fread(fid, nbytes, '*uint8');
+        % Validate range
+        validate_range_indices(da.Name, startIdx, endIdx);
+        % Seek to first tuple and read only requested range
+        raw = read_data_array_range(h, da, startIdx, endIdx);
+    else
+        % Read full array
+        if fseek(h.fid, h.payload_start + da.offset, 'bof') ~= 0
+            error('Seek failed for DataArray "%s".', da.Name);
+        end
+        nbytes = double(read_uint64_le_from_fid(h.fid));
+        raw = fread(h.fid, nbytes, '*uint8');
         if numel(raw) < nbytes
-            error('Unexpected end of file reading DataArray "%s".', a.Name);
+            error('Unexpected end of file reading DataArray "%s".', da.Name);
         end
-        values.(a.Name) = cast_appended(raw, a.type, a.num_components);
+    end
+    values = cast_appended(raw, da.type, ncomp);
+elseif strcmp(da_format, 'ascii')
+    values = da.data;
+    if have_range
+        if isempty(endIdx)
+            if ncomp > 1 && ismatrix(values) && size(values,1) == ncomp
+                endIdx = size(values,2);
+            else
+                endIdx = numel(values);
+            end
+        end
+        validate_range_indices(da.Name, startIdx, endIdx);
+        if ncomp > 1 && ismatrix(values) && size(values,1) == ncomp
+            values = values(:, startIdx:endIdx);
+        else
+            values = values(startIdx:endIdx);
+        end
     end
 end
 end
 
-% Return the arrays entry whose Name matches, or [] if not found.
-function a = find_array(arrays, name)
-a = [];
-for i = 1:numel(arrays)
-    if strcmp(arrays(i).Name, name)
-        a = arrays(i);
-        return;
-    end
+% Read only a range of tuples from an appended DataArray by seeking.
+% startIdx/endIdx are 1-based inclusive tuple indices.
+function raw = read_data_array_range(h, da, startIdx, endIdx)
+elem_size = vtk_type_size(da.type);
+bytes_per_tuple = elem_size * data_array_num_components(da);
+% Seek past 8-byte length prefix, then to startIdx-th tuple (1-based to 0-based).
+data_offset = h.payload_start + da.offset + 8 + (startIdx - 1) * bytes_per_tuple;
+if fseek(h.fid, data_offset, 'bof') ~= 0
+    error('Seek failed reading range from DataArray "%s".', da.Name);
+end
+nbytes_to_read = (endIdx - startIdx + 1) * bytes_per_tuple;
+raw = fread(h.fid, nbytes_to_read, '*uint8');
+if numel(raw) < nbytes_to_read
+    error('Unexpected end of file reading range from DataArray "%s".', da.Name);
+end
+end
+
+% Return DataArray tuple width with compatibility for alternate field names.
+function ncomp = data_array_num_components(da)
+if isfield(da, 'NumberOfComponents') && ~isempty(da.NumberOfComponents)
+    ncomp = da.NumberOfComponents;
+else
+    ncomp = 1;
+end
+end
+
+% Return DataArray format; normalized appended arrays may omit this field.
+function fmt = data_array_format(da)
+if isfield(da, 'format') && ~isempty(da.format)
+    fmt = da.format;
+else
+    fmt = '';
+end
+end
+
+% Validate a requested inclusive tuple range for a named DataArray.
+function validate_range_indices(name, startIdx, endIdx)
+if ~isscalar(startIdx) || ~isnumeric(startIdx) || ~isfinite(startIdx) || startIdx ~= floor(startIdx)
+    error('Invalid startIdx for DataArray "%s": expected a finite integer scalar.', name);
+end
+if ~isscalar(endIdx) || ~isnumeric(endIdx) || ~isfinite(endIdx) || endIdx ~= floor(endIdx)
+    error('Invalid endIdx for DataArray "%s": expected a finite integer scalar.', name);
+end
+if startIdx < 1
+    error('Invalid range for DataArray "%s": startIdx=%d must be >= 1.', name, startIdx);
+end
+if endIdx < startIdx
+    error('Invalid range for DataArray "%s": startIdx=%d must be <= endIdx=%d.', name, startIdx, endIdx);
 end
 end
 
@@ -335,41 +288,6 @@ switch vtk_type
         n = 1;
     otherwise
         error('Unknown VTK type "%s".', vtk_type);
-end
-end
-
-% Read a contiguous range of cells from a flat appended DataArray by seeking.
-% cell_start is 0-based; ncells is the count to read.
-function raw = read_array_cells(fid, payload_start, a, cell_start, ncells)
-elem_size = vtk_type_size(a.type);
-bytes_per_cell = a.num_components * elem_size;
-% Skip 8-byte length prefix then jump to cell_start within the data.
-data_offset = payload_start + a.offset + 8 + cell_start * bytes_per_cell;
-if fseek(fid, data_offset, 'bof') ~= 0
-    error('Seek failed reading cells from DataArray "%s".', a.Name);
-end
-nbytes_to_read = ncells * bytes_per_cell;
-raw = fread(fid, nbytes_to_read, '*uint8');
-if numel(raw) < nbytes_to_read
-    error('Unexpected end of file reading cells from DataArray "%s".', a.Name);
-end
-end
-
-% Seek to each DataArray by offset and read only its bytes from the open file.
-function values = decode_appended_arrays_streaming(fid, payload_start, arrays)
-values = struct();
-for i = 1:numel(arrays)
-    a = arrays(i);
-    % Offsets in the VTU header are measured from the byte immediately after '_'.
-    if fseek(fid, payload_start + a.offset, 'bof') ~= 0
-        error('Seek failed for DataArray "%s".', a.Name);
-    end
-    nbytes = double(read_uint64_le_from_fid(fid));
-    raw = fread(fid, nbytes, '*uint8');
-    if numel(raw) < nbytes
-        error('Unexpected end of file reading DataArray "%s".', a.Name);
-    end
-    values.(a.Name) = cast_appended(raw, a.type, a.num_components);
 end
 end
 
@@ -404,48 +322,6 @@ end
 
 if ncomp > 1
     out = reshape(out, ncomp, []);
-end
-end
-
-% Build connected components of cells that share vertices.
-function labels = connected_cell_components(connectivity, npoints)
-ncells = size(connectivity, 2);
-parent = 1:ncells;
-owner = zeros(npoints, 1);
-
-for c = 1:ncells
-    verts = connectivity(:, c);
-    for iv = 1:numel(verts)
-        v = verts(iv);
-        if owner(v) == 0
-            owner(v) = c;
-        else
-            % Union-Find merge when two cells touch the same point.
-            parent = unite(parent, c, owner(v));
-        end
-    end
-end
-
-labels = zeros(ncells,1);
-for c = 1:ncells
-    labels(c) = find_root(parent, c);
-end
-end
-
-% Union operation for cell component labels.
-function parent = unite(parent, a, b)
-ra = find_root(parent, a);
-rb = find_root(parent, b);
-if ra ~= rb
-    parent(rb) = ra;
-end
-end
-
-% Find operation for cell component labels.
-function r = find_root(parent, x)
-r = x;
-while parent(r) ~= r
-    r = parent(r);
 end
 end
 
@@ -643,48 +519,6 @@ if ~isempty(fd_content)
 end
 
 vtk.AppendedData = tag_attrs(header_text, 'AppendedData');
-end
-
-% Collect all DataArrays with format="appended" from a VTKFile struct.
-% Returns a struct array with fields Name, type, offset, num_components
-% compatible with decode_specific_arrays and find_array.
-function arrays = collect_appended_arrays(vtk)
-arrays = struct('Name', {}, 'type', {}, 'offset', {}, 'num_components', {});
-section_names = {'Points', 'Cells', 'CellData', 'PointData'};
-piece = vtk.UnstructuredGrid.Piece;
-for k = 1:numel(section_names)
-    sname = section_names{k};
-    if ~isfield(piece, sname) || ~isfield(piece.(sname), 'DataArray')
-        continue;
-    end
-    for i = 1:numel(piece.(sname).DataArray)
-        da = piece.(sname).DataArray(i);
-        if ~strcmp(da.format, 'appended')
-            continue;
-        end
-        a.Name           = da.Name;
-        a.type           = da.type;
-        a.offset         = da.offset;
-        a.num_components = da.NumberOfComponents;
-        arrays(end+1) = a; %#ok<AGROW>
-    end
-end
-
-% FieldData lives at UnstructuredGrid level, not inside Piece.
-if isfield(vtk.UnstructuredGrid, 'FieldData') && ...
-        isfield(vtk.UnstructuredGrid.FieldData, 'DataArray')
-    for i = 1:numel(vtk.UnstructuredGrid.FieldData.DataArray)
-        da = vtk.UnstructuredGrid.FieldData.DataArray(i);
-        if ~strcmp(da.format, 'appended')
-            continue;
-        end
-        a.Name           = da.Name;
-        a.type           = da.type;
-        a.offset         = da.offset;
-        a.num_components = da.NumberOfComponents;
-        arrays(end+1) = a; %#ok<AGROW>
-    end
-end
 end
 
 % Extract all XML attributes from the first <tagname ...> tag as a struct.

--- a/matlab/readamrdata_forestclaw_vtu.m
+++ b/matlab/readamrdata_forestclaw_vtu.m
@@ -54,7 +54,9 @@ piece = parse_piece_counts(header_text);
 arrays = parse_data_arrays(header_text);
 
 % Phase 1: read only topology arrays (geometry + metadata, not field data).
-topo_names = {'Position', 'connectivity', 'types', 'mpirank', 'blockno', 'patchno'};
+% Include explicit metadata arrays written by newer versions of the VTU writer.
+topo_names = {'Position', 'connectivity', 'types', 'mpirank', 'blockno', 'patchno', ...
+              'mx_my_mz', 'level', 'xyz_low', 'dx_dy_dz'};
 topo = decode_specific_arrays(fid, payload_start, arrays, topo_names);
 
 required_fields = {'Position','connectivity','types','mpirank','blockno','patchno'};
@@ -141,17 +143,60 @@ for ng = 1:num_patches
     patch_pts_ids = unique(patch_conn(:));
     patch_pts = points(patch_pts_ids, :);
 
-    if dim == 2
-        [mx,my] = infer_2d_shape(patch_conn, points);
-        mz = [];
+    % Patch shape (mx, my, mz): prefer explicit FieldData metadata; fall back to inference.
+    if isfield(topo, 'mx_my_mz')
+        mxmymz = reshape(double(topo.mx_my_mz), 3, []);
+        mx = mxmymz(1, ng);
+        my = mxmymz(2, ng);
+        if dim > 2
+            mz = mxmymz(3, ng);
+        else
+            mz = [];
+        end
     else
-        [mx,my,mz] = infer_3d_shape(patch_conn, points);
+        if dim == 2
+            [mx,my] = infer_2d_shape(patch_conn, points);
+            mz = [];
+        else
+            [mx,my,mz] = infer_3d_shape(patch_conn, points);
+        end
     end
 
-    [xlow,dx] = infer_axis_spacing(patch_pts(:,1));
-    [ylow,dy] = infer_axis_spacing(patch_pts(:,2));
-    if dim > 2
-        [zlow,dz] = infer_axis_spacing(patch_pts(:,3));
+    % Patch origin and spacing: prefer explicit FieldData; fall back to inference.
+    if isfield(topo, 'xyz_low')
+        xyz_low_arr = reshape(double(topo.xyz_low), 3, []);
+        xlow = xyz_low_arr(1, ng);
+        ylow = xyz_low_arr(2, ng);
+        if dim > 2
+            zlow = xyz_low_arr(3, ng);
+        else
+            zlow = [];
+        end
+    else
+        [xlow,~] = infer_axis_spacing(patch_pts(:,1));
+        [ylow,~] = infer_axis_spacing(patch_pts(:,2));
+        if dim > 2
+            [zlow,~] = infer_axis_spacing(patch_pts(:,3));
+        end
+    end
+    
+    if isfield(topo, 'dx_dy_dz')
+        dxdydz_arr = reshape(double(topo.dx_dy_dz), 3, []);
+        dx = dxdydz_arr(1, ng);
+        dy = dxdydz_arr(2, ng);
+        if dim > 2
+            dz = dxdydz_arr(3, ng);
+        else
+            dz = [];
+        end
+    else
+        [~,dx] = infer_axis_spacing(patch_pts(:,1));
+        [~,dy] = infer_axis_spacing(patch_pts(:,2));
+        if dim > 2
+            [~,dz] = infer_axis_spacing(patch_pts(:,3));
+        else
+            dz = [];
+        end
     end
 
     % Fill legacy AMR metadata expected by plotting/post-processing scripts.
@@ -198,7 +243,29 @@ for ng = 1:num_patches
     amr(ng) = amrdata; %#ok<AGROW>
 end
 
-amr = assign_levels_from_spacing(amr, dim);
+% If explicit level data was written by the VTU writer, use it directly;
+% otherwise infer AMR levels from relative cell spacing (legacy files).
+if ~isfield(topo, 'level')
+    amr = assign_levels_from_spacing(amr, dim);
+else
+    for ng = 1:numel(amr)
+        amr(ng).level = double(topo.level(ng));
+    end
+end
+
+if dim == 2
+    for ng = 1:numel(amr)
+        if ~isfield(amr(ng), 'mz')
+            amr(ng).mz   = [];
+        end
+        if ~isfield(amr(ng), 'zlow')
+            amr(ng).zlow = [];
+        end
+        if ~isfield(amr(ng), 'dz')
+            amr(ng).dz   = [];
+        end
+    end
+end
 
 end
 
@@ -569,4 +636,6 @@ for i = 1:numel(dx)
     levels(i) = idx;
 end
 end
+
+
 

--- a/matlab/readamrdata_forestclaw_vtu.m
+++ b/matlab/readamrdata_forestclaw_vtu.m
@@ -44,20 +44,27 @@ end
 
 disp(['Reading data from ',filename]);
 
-% Use frame number for time
-t = Frame;
+h = parse_vtu_header(filename);
+fid_cleanup = onCleanup(@() fclose(h.fid)); %#ok<NASGU>
 
-[fid, header_text, payload_start] = open_vtu_header(filename);
-fid_cleanup = onCleanup(@() fclose(fid)); %#ok<NASGU>
+have_field_data = isfield(h.VTKFile.UnstructuredGrid, 'FieldData');
 
-piece = parse_piece_counts(header_text);
-arrays = parse_data_arrays(header_text);
+% Set time
+if have_field_data
+    t = find_by_name(h.VTKFile.UnstructuredGrid.FieldData.DataArray, 'TimeValue').data;
+else
+    t = Frame;
+end
+
+num_points = h.VTKFile.UnstructuredGrid.Piece.NumberOfPoints;
+num_cells  = h.VTKFile.UnstructuredGrid.Piece.NumberOfCells;
+arrays = collect_appended_arrays(h.VTKFile);
 
 % Phase 1: read only topology arrays (geometry + metadata, not field data).
 % Include explicit metadata arrays written by newer versions of the VTU writer.
 topo_names = {'Position', 'connectivity', 'types', 'mpirank', 'blockno', 'patchno', ...
               'patch_dimension', 'levels', 'patch_starts', 'patch_spacings', 'TimeValue'};
-topo = decode_specific_arrays(fid, payload_start, arrays, topo_names);
+topo = decode_specific_arrays(h.fid, h.payload_start, arrays, topo_names);
 
 required_fields = {'Position','connectivity','types','mpirank','blockno','patchno'};
 for ireq = 1:numel(required_fields)
@@ -69,7 +76,7 @@ end
 % Convert VTK connectivity to 1-based indexing for MATLAB array access.
 points = reshape(topo.Position, 3, []).';
 connectivity = double(topo.connectivity) + 1;
-connectivity = reshape(connectivity, [], piece.num_cells);
+connectivity = reshape(connectivity, [], num_cells);
 types = double(topo.types(:));
 
 if dim == 2
@@ -240,7 +247,7 @@ for ng = 1:num_patches
         fname_k = field_order{k};
         fa = find_array(arrays, fname_k);
         if ~isempty(fa)
-            raw = read_array_cells(fid, payload_start, fa, cell_ids(1)-1, numel(cell_ids));
+            raw = read_array_cells(h.fid, h.payload_start, fa, cell_ids(1)-1, numel(cell_ids));
             field_data = reshape(float_array(cast_appended(raw, fa.type, fa.num_components)), [], numel(cell_ids));
             patch_data = [patch_data; field_data]; %#ok<AGROW>
         end
@@ -260,11 +267,6 @@ else
     end
 end
 
-% Extract global time value if available.
-if isfield(topo, 'TimeValue')
-    t = double(topo.TimeValue(1));
-end
-
 if dim == 2
     for ng = 1:numel(amr)
         if ~isfield(amr(ng), 'mz')
@@ -281,91 +283,14 @@ end
 
 end
 
-% Open VTU file and read only the XML header, stopping at the binary payload.
-% Returns open file handle fid (caller must close), the XML header as a string,
-% and payload_start as the 0-based file offset of the first byte after '_'.
-function [fid, header_text, payload_start] = open_vtu_header(filename)
-fid = fopen(filename, 'r');
-if fid < 0
-    error('Unable to open %s', filename);
-end
-
-chunk_size = 65536;
-buf = uint8([]);
-needle = uint8('<AppendedData');
-
-while true
-    chunk = fread(fid, chunk_size, '*uint8');
-    buf = [buf; chunk]; %#ok<AGROW>
-
-    ad_idx = strfind(buf.', needle);
-    if ~isempty(ad_idx)
-        search_from = ad_idx(1) + numel(needle);
-        u_rel = find(buf(search_from:end) == uint8('_'), 1, 'first');
-        if ~isempty(u_rel)
-            % underscore_pos is the 1-based index of '_' in buf.
-            underscore_pos = search_from + u_rel - 1;
-            % payload_start is the 0-based file offset of the byte after '_'.
-            payload_start = underscore_pos;  % equals 0-based offset because MATLAB is 1-based
-            header_text = char(buf(1:underscore_pos-1)).';
-            return;
-        end
+% Return the DataArray struct whose Name matches, or [] if not found.
+function da = find_by_name(arrays, name)
+da = [];
+for i = 1:numel(arrays)
+    if strcmp(arrays(i).Name, name)
+        da = arrays(i);
+        return;
     end
-
-    if isempty(chunk)
-        fclose(fid);
-        error('No AppendedData payload marker "_" found in %s.', filename);
-    end
-end
-end
-
-% Parse global point/cell counts declared in the VTU Piece tag.
-function piece = parse_piece_counts(header_text)
-tok = regexp(header_text, '<Piece\s+[^>]*NumberOfPoints="(\d+)"\s+NumberOfCells="(\d+)"', 'tokens', 'once');
-if isempty(tok)
-    error('VTU Piece metadata is missing NumberOfPoints/NumberOfCells.');
-end
-piece.num_points = str2double(tok{1});
-piece.num_cells = str2double(tok{2});
-end
-
-% Parse appended DataArray metadata (name, type, offset, components).
-function arrays = parse_data_arrays(header_text)
-tags = regexp(header_text, '<DataArray\s+([^>]*)>', 'tokens');
-arrays = struct('Name', {}, 'type', {}, 'offset', {}, 'num_components', {});
-for i = 1:numel(tags)
-    attrs = tags{i}{1};
-    name = read_attr(attrs, 'Name');
-    if isempty(name)
-        continue;
-    end
-    fmt = read_attr(attrs, 'format');
-    if ~strcmp(fmt, 'appended')
-        continue;
-    end
-
-    a.Name = name;
-    a.type = read_attr(attrs, 'type');
-    a.offset = str2double(read_attr(attrs, 'offset'));
-
-    nc = read_attr(attrs, 'NumberOfComponents');
-    if isempty(nc)
-        a.num_components = 1;
-    else
-        a.num_components = str2double(nc);
-    end
-    arrays(end+1) = a; %#ok<AGROW>
-end
-end
-
-% Read one XML attribute value from an attribute string.
-function value = read_attr(attrs, key)
-pat = [key, '="([^"]+)"'];
-tok = regexp(attrs, pat, 'tokens', 'once');
-if isempty(tok)
-    value = '';
-else
-    value = tok{1};
 end
 end
 
@@ -587,22 +512,6 @@ else
 end
 end
 
-% Return mode for integer metadata that should be constant per patch.
-function m = int_mode(v)
-v = double(v(:));
-if isempty(v)
-    m = 0;
-    return
-end
-uv = unique(v);
-counts = zeros(size(uv));
-for i = 1:numel(uv)
-    counts(i) = sum(v == uv(i));
-end
-[~,idx] = max(counts);
-m = uv(idx);
-end
-
 % Convert numeric arrays to double and normalize orientation for reshape.
 function arr = float_array(v)
 arr = double(v);
@@ -646,6 +555,215 @@ levels = zeros(size(dx));
 for i = 1:numel(dx)
     [~,idx] = min(abs(udx - dx(i)));
     levels(i) = idx;
+end
+end
+
+% ============================ XML Header Parsing ============================
+
+% Parse a VTU file header into a struct h with fields:
+%   h.fid           - open file handle (caller must close)
+%   h.payload_start - 0-based file offset of the first payload byte
+%   h.VTKFile       - struct mirroring the XML header hierarchy:
+%       .type, .version, .byte_order, .header_type
+%       .UnstructuredGrid.Piece.NumberOfPoints  (numeric)
+%       .UnstructuredGrid.Piece.NumberOfCells   (numeric)
+%       .UnstructuredGrid.Piece.Points.DataArray(...)
+%       .UnstructuredGrid.Piece.Cells.DataArray(...)
+%       .UnstructuredGrid.Piece.CellData.DataArray(...)
+%       .UnstructuredGrid.FieldData.DataArray(...)  [if present]
+%       .AppendedData.encoding
+function h = parse_vtu_header(filename)
+fid = fopen(filename, 'r');
+if fid < 0
+    error('Unable to open %s', filename);
+end
+
+chunk_size = 65536;
+buf = uint8([]);
+needle = uint8('<AppendedData');
+
+while true
+    chunk = fread(fid, chunk_size, '*uint8');
+    buf = [buf; chunk]; %#ok<AGROW>
+
+    ad_idx = strfind(buf.', needle);
+    if ~isempty(ad_idx)
+        search_from = ad_idx(1) + numel(needle);
+        u_rel = find(buf(search_from:end) == uint8('_'), 1, 'first');
+        if ~isempty(u_rel)
+            % underscore_pos is the 1-based index of '_' in buf.
+            underscore_pos = search_from + u_rel - 1;
+            % h.payload_start is the 0-based file offset of the byte after '_'.
+            h.fid = fid;
+            h.payload_start = underscore_pos;  % equals 0-based offset because MATLAB is 1-based
+            h.VTKFile = build_vtu_struct(char(buf(1:underscore_pos-1)).');
+            return;
+        end
+    end
+
+    if isempty(chunk)
+        fclose(fid);
+        error('No AppendedData payload marker "_" found in %s.', filename);
+    end
+end
+end
+
+% Build a MATLAB struct mirroring the VTU XML header hierarchy.
+function vtk = build_vtu_struct(header_text)
+vtk = tag_attrs(header_text, 'VTKFile');
+
+piece = tag_attrs(header_text, 'Piece');
+piece.NumberOfPoints = str2double(piece.NumberOfPoints);
+piece.NumberOfCells  = str2double(piece.NumberOfCells);
+
+section_names = {'Points', 'Cells', 'CellData', 'PointData'};
+for k = 1:numel(section_names)
+    sname = section_names{k};
+    content = extract_between_tags(header_text, sname);
+    if ~isempty(content)
+        sect = tag_attrs(header_text, sname);
+        sect.DataArray = section_data_arrays(content);
+        piece.(sname) = sect;
+    end
+end
+
+vtk.UnstructuredGrid.Piece = piece;
+
+fd_content = extract_between_tags(header_text, 'FieldData');
+if ~isempty(fd_content)
+    fd = tag_attrs(header_text, 'FieldData');
+    fd.DataArray = section_data_arrays(fd_content);
+    % Read inline values for ASCII DataArrays immediately during header parse.
+    for i = 1:numel(fd.DataArray)
+        if strcmp(fd.DataArray(i).format, 'ascii')
+            fd.DataArray(i).data = read_ascii_da_content(fd_content, fd.DataArray(i).Name);
+        end
+    end
+    vtk.UnstructuredGrid.FieldData = fd;
+end
+
+vtk.AppendedData = tag_attrs(header_text, 'AppendedData');
+end
+
+% Collect all DataArrays with format="appended" from a VTKFile struct.
+% Returns a struct array with fields Name, type, offset, num_components
+% compatible with decode_specific_arrays and find_array.
+function arrays = collect_appended_arrays(vtk)
+arrays = struct('Name', {}, 'type', {}, 'offset', {}, 'num_components', {});
+section_names = {'Points', 'Cells', 'CellData', 'PointData'};
+piece = vtk.UnstructuredGrid.Piece;
+for k = 1:numel(section_names)
+    sname = section_names{k};
+    if ~isfield(piece, sname) || ~isfield(piece.(sname), 'DataArray')
+        continue;
+    end
+    for i = 1:numel(piece.(sname).DataArray)
+        da = piece.(sname).DataArray(i);
+        if ~strcmp(da.format, 'appended')
+            continue;
+        end
+        a.Name           = da.Name;
+        a.type           = da.type;
+        a.offset         = da.offset;
+        a.num_components = da.NumberOfComponents;
+        arrays(end+1) = a; %#ok<AGROW>
+    end
+end
+
+% FieldData lives at UnstructuredGrid level, not inside Piece.
+if isfield(vtk.UnstructuredGrid, 'FieldData') && ...
+        isfield(vtk.UnstructuredGrid.FieldData, 'DataArray')
+    for i = 1:numel(vtk.UnstructuredGrid.FieldData.DataArray)
+        da = vtk.UnstructuredGrid.FieldData.DataArray(i);
+        if ~strcmp(da.format, 'appended')
+            continue;
+        end
+        a.Name           = da.Name;
+        a.type           = da.type;
+        a.offset         = da.offset;
+        a.num_components = da.NumberOfComponents;
+        arrays(end+1) = a; %#ok<AGROW>
+    end
+end
+end
+
+% Extract all XML attributes from the first <tagname ...> tag as a struct.
+function s = tag_attrs(text, tagname)
+pat = ['<', tagname, '(?=[\s>\/])(\s[^>]*)?>'];
+tok = regexp(text, pat, 'tokens', 'once');
+if isempty(tok) || isempty(tok{1})
+    s = struct();
+    return;
+end
+kv = regexp(tok{1}, '(\w+)="([^"]*)"', 'tokens');
+s = struct();
+for i = 1:numel(kv)
+    s.(kv{i}{1}) = kv{i}{2};
+end
+end
+
+% Return the content between <tagname ...> and </tagname>, or '' if absent.
+function content = extract_between_tags(text, tagname)
+open_pat = ['<', tagname, '(?=[\s>])([^>]*)>'];
+[~, e] = regexp(text, open_pat, 'start', 'end', 'once');
+if isempty(e)
+    content = '';
+    return;
+end
+close_pat = ['</', tagname, '>'];
+c_rel = regexp(text(e+1:end), close_pat, 'start', 'once');
+if isempty(c_rel)
+    content = '';
+    return;
+end
+content = text(e+1 : e + c_rel - 1);
+end
+
+% Parse all <DataArray ...> elements in text into a struct array.
+% Fields: Name, type, NumberOfComponents (numeric), format, offset (numeric), data ([] or numeric).
+function das = section_data_arrays(text)
+das = struct('Name', {}, 'type', {}, 'NumberOfComponents', {}, 'format', {}, 'offset', {}, 'data', {});
+toks = regexp(text, '<DataArray\s+([^>]*)>', 'tokens');
+for i = 1:numel(toks)
+    attr_str = toks{i}{1};
+    da.Name               = read_attr(attr_str, 'Name');
+    da.type               = read_attr(attr_str, 'type');
+    da.NumberOfComponents = str2double_or(read_attr(attr_str, 'NumberOfComponents'), 1);
+    da.format             = read_attr(attr_str, 'format');
+    da.offset             = str2double_or(read_attr(attr_str, 'offset'), NaN);
+    da.data               = [];
+    das(end+1) = da; %#ok<AGROW>
+end
+end
+
+% Extract numeric values from an inline ASCII DataArray element, matched by Name.
+function vals = read_ascii_da_content(text, name)
+pat = ['<DataArray\s+[^>]*Name="', name, '"[^>]*>([\s\S]*?)<\/DataArray>'];
+tok = regexp(text, pat, 'tokens', 'once');
+if isempty(tok) || isempty(tok{1})
+    vals = [];
+    return;
+end
+vals = sscanf(strtrim(tok{1}), '%g');
+end
+
+% Return str2double(s) when s is non-empty, otherwise return default.
+function v = str2double_or(s, default)
+if isempty(s)
+    v = default;
+else
+    v = str2double(s);
+end
+end
+
+% Read one XML attribute value from an attribute string.
+function value = read_attr(attrs, key)
+pat = [key, '="([^"]+)"'];
+tok = regexp(attrs, pat, 'tokens', 'once');
+if isempty(tok)
+    value = '';
+else
+    value = tok{1};
 end
 end
 

--- a/matlab/readamrdata_forestclaw_vtu.m
+++ b/matlab/readamrdata_forestclaw_vtu.m
@@ -58,13 +58,13 @@ if exist(tname, 'file')
     end
 end
 
-bytes = read_file_bytes(filename);
-[header_text, appended_start] = split_vtu_header(bytes);
+[fid, header_text, payload_start] = open_vtu_header(filename);
+fid_cleanup = onCleanup(@() fclose(fid)); %#ok<NASGU>
 
 piece = parse_piece_counts(header_text);
 arrays = parse_data_arrays(header_text);
 
-values = decode_appended_arrays(bytes, appended_start, arrays);
+values = decode_appended_arrays_streaming(fid, payload_start, arrays);
 
 required_fields = {'Position','connectivity','types','mpirank','blockno','meqn'};
 for ireq = 1:numel(required_fields)
@@ -210,32 +210,42 @@ amr = assign_levels_from_spacing(amr, dim);
 
 end
 
-% Read complete file contents as raw bytes.
-function bytes = read_file_bytes(filename)
+% Open VTU file and read only the XML header, stopping at the binary payload.
+% Returns open file handle fid (caller must close), the XML header as a string,
+% and payload_start as the 0-based file offset of the first byte after '_'.
+function [fid, header_text, payload_start] = open_vtu_header(filename)
 fid = fopen(filename, 'r');
 if fid < 0
     error('Unable to open %s', filename);
 end
-bytes = fread(fid, inf, '*uint8');
-fclose(fid);
-end
 
-% Split XML header from raw appended payload location.
-function [header_text, appended_start] = split_vtu_header(bytes)
+chunk_size = 65536;
+buf = uint8([]);
 needle = uint8('<AppendedData');
-idx = strfind(bytes.', needle);
-if isempty(idx)
-    error('No AppendedData section found in VTU file.');
+
+while true
+    chunk = fread(fid, chunk_size, '*uint8');
+    buf = [buf; chunk]; %#ok<AGROW>
+
+    ad_idx = strfind(buf.', needle);
+    if ~isempty(ad_idx)
+        search_from = ad_idx(1) + numel(needle);
+        u_rel = find(buf(search_from:end) == uint8('_'), 1, 'first');
+        if ~isempty(u_rel)
+            % underscore_pos is the 1-based index of '_' in buf.
+            underscore_pos = search_from + u_rel - 1;
+            % payload_start is the 0-based file offset of the byte after '_'.
+            payload_start = underscore_pos;  % equals 0-based offset because MATLAB is 1-based
+            header_text = char(buf(1:underscore_pos-1)).';
+            return;
+        end
+    end
+
+    if isempty(chunk)
+        fclose(fid);
+        error('No AppendedData payload marker "_" found in %s.', filename);
+    end
 end
-start_idx = idx(1);
-tail = bytes(start_idx:min(numel(bytes), start_idx + 2048));
-u_idx = find(tail == uint8('_'), 1, 'first');
-if isempty(u_idx)
-    error('AppendedData payload marker "_" not found.');
-end
-% appended_start is the byte index of the '_' marker in AppendedData.
-appended_start = start_idx + u_idx - 1;
-header_text = char(bytes(1:appended_start-1)).';
 end
 
 % Parse global point/cell counts declared in the VTU Piece tag.
@@ -288,31 +298,33 @@ else
 end
 end
 
-% Decode all appended arrays using declared offsets and VTK data types.
-function values = decode_appended_arrays(bytes, appended_start, arrays)
+% Seek to each DataArray by offset and read only its bytes from the open file.
+function values = decode_appended_arrays_streaming(fid, payload_start, arrays)
 values = struct();
 for i = 1:numel(arrays)
     a = arrays(i);
-    % Offsets are measured from the byte immediately after '_'.
-    payload_pos = appended_start + 1 + a.offset;
-    nbytes = read_uint64_le(bytes, payload_pos);
-    data_start = payload_pos + 8;
-    data_end = data_start + double(nbytes) - 1;
-
-    if data_end > numel(bytes)
-        error('AppendedData offset/size exceeds file bounds for %s.', a.Name);
+    % Offsets in the VTU header are measured from the byte immediately after '_'.
+    if fseek(fid, payload_start + a.offset, 'bof') ~= 0
+        error('Seek failed for DataArray "%s".', a.Name);
     end
-
-    raw = bytes(data_start:data_end);
+    nbytes = double(read_uint64_le_from_fid(fid));
+    raw = fread(fid, nbytes, '*uint8');
+    if numel(raw) < nbytes
+        error('Unexpected end of file reading DataArray "%s".', a.Name);
+    end
     values.(a.Name) = cast_appended(raw, a.type, a.num_components);
 end
 end
 
-% Read little-endian UInt64 length prefix used by VTU AppendedData blocks.
-function u = read_uint64_le(bytes, pos)
+% Read a little-endian UInt64 length prefix from the current file position.
+function u = read_uint64_le_from_fid(fid)
+raw = fread(fid, 8, '*uint8');
+if numel(raw) < 8
+    error('Unexpected end of file reading 8-byte length prefix.');
+end
 u = uint64(0);
 for k = 0:7
-    u = bitor(u, bitshift(uint64(bytes(pos+k)), 8*k));
+    u = bitor(u, bitshift(uint64(raw(k+1)), 8*k));
 end
 end
 

--- a/matlab/readamrdata_forestclaw_vtu.m
+++ b/matlab/readamrdata_forestclaw_vtu.m
@@ -56,7 +56,7 @@ arrays = parse_data_arrays(header_text);
 % Phase 1: read only topology arrays (geometry + metadata, not field data).
 % Include explicit metadata arrays written by newer versions of the VTU writer.
 topo_names = {'Position', 'connectivity', 'types', 'mpirank', 'blockno', 'patchno', ...
-              'mx_my_mz', 'level', 'xyz_low', 'dx_dy_dz', 'TimeValue'};
+              'patch_dimension', 'levels', 'patch_starts', 'patch_spacings', 'TimeValue'};
 topo = decode_specific_arrays(fid, payload_start, arrays, topo_names);
 
 required_fields = {'Position','connectivity','types','mpirank','blockno','patchno'};
@@ -120,9 +120,9 @@ amr = struct('gridno', {}, ...
 
 field_order = {'meqn', 'aux', 'rhs', 'soln', 'error'};
 
-% Extract global mx_my_mz metadata (same for all patches)
-if isfield(topo, 'mx_my_mz')
-    mxmymz_global = reshape(double(topo.mx_my_mz), 3, []);
+% Extract global patch_dimension metadata (same for all patches)
+if isfield(topo, 'patch_dimension')
+    mxmymz_global = reshape(double(topo.patch_dimension), 3, []);
     mx_global = mxmymz_global(1, 1);
     my_global = mxmymz_global(2, 1);
     if dim > 2
@@ -156,7 +156,7 @@ for ng = 1:num_patches
     patch_pts = points(patch_pts_ids, :);
 
     % Patch shape (mx, my, mz): use global metadata (same for all patches) or fall back to inference.
-    if isfield(topo, 'mx_my_mz')
+    if isfield(topo, 'patch_dimension')
         mx = mx_global;
         my = my_global;
         mz = mz_global;
@@ -170,8 +170,8 @@ for ng = 1:num_patches
     end
 
     % Patch origin and spacing: prefer explicit FieldData; fall back to inference.
-    if isfield(topo, 'xyz_low')
-        xyz_low_arr = reshape(double(topo.xyz_low), 3, []);
+    if isfield(topo, 'patch_starts')
+        xyz_low_arr = reshape(double(topo.patch_starts), 3, []);
         xlow = xyz_low_arr(1, ng);
         ylow = xyz_low_arr(2, ng);
         if dim > 2
@@ -187,8 +187,8 @@ for ng = 1:num_patches
         end
     end
     
-    if isfield(topo, 'dx_dy_dz')
-        dxdydz_arr = reshape(double(topo.dx_dy_dz), 3, []);
+    if isfield(topo, 'patch_spacings')
+        dxdydz_arr = reshape(double(topo.patch_spacings), 3, []);
         dx = dxdydz_arr(1, ng);
         dy = dxdydz_arr(2, ng);
         if dim > 2
@@ -252,11 +252,11 @@ end
 
 % If explicit level data was written by the VTU writer, use it directly;
 % otherwise infer AMR levels from relative cell spacing (legacy files).
-if ~isfield(topo, 'level')
+if ~isfield(topo, 'levels')
     amr = assign_levels_from_spacing(amr, dim);
 else
     for ng = 1:numel(amr)
-        amr(ng).level = double(topo.level(ng));
+        amr(ng).level = double(topo.levels(ng));
     end
 end
 

--- a/matlab/readamrdata_forestclaw_vtu.m
+++ b/matlab/readamrdata_forestclaw_vtu.m
@@ -16,9 +16,7 @@ function [amr,t] = readamrdata_forestclaw_vtu(dim,Frame,dir)
 %     t     - Time from fort.t#### when available; otherwise Frame.
 %
 %   Notes:
-%     - VTU data is read from AppendedData encoding="raw" sections.
-%     - Data columns in amr(ng).data are patch cells; rows are concatenated
-%       in order: meqn, aux, rhs, soln, error (when present).
+%     - XML header is parsed into a struct.
 %     - Local helper read_by_name(h, arrays, name, startIdx, endIdx)
 %       accepts an optional 1-based inclusive tuple range.
 
@@ -50,25 +48,25 @@ h = parse_vtu_header(filename);
 fid_cleanup = onCleanup(@() fclose(h.fid));
 
 have_field_data = isfield(h.VTKFile.UnstructuredGrid, 'FieldData');
+if ~have_field_data
+    error('FieldData section not found in VTU file %s; unable to read time and patch metadata. Possible old Forestclaw VTU output.', filename);
+end
 
 % Global Variables
-num_points = h.VTKFile.UnstructuredGrid.Piece.NumberOfPoints;
 num_cells  = h.VTKFile.UnstructuredGrid.Piece.NumberOfCells;
-mx = 0;
-if have_field_data
-    t = find_by_name(h.VTKFile.UnstructuredGrid.FieldData.DataArray, 'TimeValue').data;
-    patch_dimension = find_by_name(h.VTKFile.UnstructuredGrid.FieldData.DataArray, 'patch_dimension').data;
-    mx = patch_dimension(1);
-    my = patch_dimension(2);
-    if dim == 3 
-        mz = patch_dimension(3);
-    end
-    patch_starts = read_by_name(h, h.VTKFile.UnstructuredGrid.FieldData.DataArray, 'patch_starts');
-    patch_spacings = read_by_name(h, h.VTKFile.UnstructuredGrid.FieldData.DataArray, 'patch_spacings');
-    levels = read_by_name(h, h.VTKFile.UnstructuredGrid.FieldData.DataArray, 'levels');
-    num_patches = numel(levels);
-else
-    t = Frame;
+
+t = find_by_name(h.VTKFile.UnstructuredGrid.FieldData.DataArray, 'TimeValue').data;
+patch_dimension = find_by_name(h.VTKFile.UnstructuredGrid.FieldData.DataArray, 'patch_dimension').data;
+
+patch_starts = read_by_name(h, h.VTKFile.UnstructuredGrid.FieldData.DataArray, 'patch_starts');
+patch_spacings = read_by_name(h, h.VTKFile.UnstructuredGrid.FieldData.DataArray, 'patch_spacings');
+levels = read_by_name(h, h.VTKFile.UnstructuredGrid.FieldData.DataArray, 'levels');
+
+num_patches = numel(levels);
+mx = patch_dimension(1);
+my = patch_dimension(2);
+if dim == 3 
+    mz = patch_dimension(3);
 end
 
 % All patches have the same number of cells; compute patch map by arithmetic.
@@ -322,115 +320,6 @@ end
 
 if ncomp > 1
     out = reshape(out, ncomp, []);
-end
-end
-
-% Infer (mx,my) assuming patch points lie on a Cartesian x/y grid.
-function [mx,my] = infer_2d_shape(patch_conn, points)
-patch_point_ids = unique(patch_conn(:));
-patch_xy = double(points(patch_point_ids, 1:2));
-
-nx = numel(unique(patch_xy(:,1)));
-ny = numel(unique(patch_xy(:,2)));
-
-if nx * ny ~= numel(patch_point_ids)
-    error('2D patch points do not form a rectangular Cartesian lattice.');
-end
-
-ncells = size(patch_conn, 2);
-mx = nx - 1;
-my = ny - 1;
-if mx * my ~= ncells
-    error('Cartesian-grid inference mismatch: mx*my does not equal cell count.');
-end
-end
-
-% Infer (mx,my,mz) assuming patch points lie on a Cartesian x/y/z grid.
-function [mx,my,mz] = infer_3d_shape(patch_conn, points)
-patch_point_ids = unique(patch_conn(:));
-patch_xyz = double(points(patch_point_ids, 1:3));
-
-nx = numel(unique(patch_xyz(:,1)));
-ny = numel(unique(patch_xyz(:,2)));
-nz = numel(unique(patch_xyz(:,3)));
-
-if nx * ny * nz ~= numel(patch_point_ids)
-    error('3D patch points do not form a rectangular Cartesian lattice.');
-end
-
-mx = nx - 1;
-my = ny - 1;
-mz = nz - 1;
-
-ncells = size(patch_conn, 2);
-if mx * my * mz ~= ncells
-    error('Cartesian-grid inference mismatch: mx*my*mz does not equal cell count.');
-end
-end
-
-% Estimate axis origin and spacing from unique coordinate values.
-function [x0,dx] = infer_axis_spacing(vals)
-u = unique(sort(double(vals(:))));
-if numel(u) < 2
-    x0 = u(1);
-    dx = 0;
-    return
-end
-d = diff(u);
-tol = max(1e-12, max(abs(u)) * 1e-10);
-d = d(d > tol);
-if isempty(d)
-    x0 = u(1);
-    dx = 0;
-else
-    x0 = u(1);
-    dx = min(d);
-end
-end
-
-% Convert numeric arrays to double and normalize orientation for reshape.
-function arr = float_array(v)
-arr = double(v);
-if isvector(arr)
-    arr = arr(:).';
-end
-end
-
-% Assign AMR levels from relative spacing tiers.
-function amr = assign_levels_from_spacing(amr, dim)
-if isempty(amr)
-    return
-end
-
-all_dx = zeros(numel(amr),1);
-for i = 1:numel(amr)
-    all_dx(i) = amr(i).dx;
-end
-
-levels = spacing_to_levels(all_dx);
-for i = 1:numel(amr)
-    amr(i).level = levels(i);
-    if dim == 2
-        if ~isfield(amr(i), 'mz')
-            amr(i).mz = [];
-        end
-        if ~isfield(amr(i), 'zlow')
-            amr(i).zlow = [];
-        end
-        if ~isfield(amr(i), 'dz')
-            amr(i).dz = [];
-        end
-    end
-end
-end
-
-% Convert unique spacing values to level indices (coarsest -> level 1).
-function levels = spacing_to_levels(dx)
-udx = unique(sort(dx, 'descend'));
-levels = zeros(size(dx));
-for i = 1:numel(dx)
-    [~,idx] = min(abs(udx - dx(i)));
-    levels(i) = idx;
 end
 end
 

--- a/matlab/readamrdata_forestclaw_vtu.m
+++ b/matlab/readamrdata_forestclaw_vtu.m
@@ -44,19 +44,8 @@ end
 
 disp(['Reading data from ',filename]);
 
-% Use legacy fort.tXXXX time if available, otherwise fall back to frame index.
+% Use frame number for time
 t = Frame;
-tname = [dir, sprintf('fort.t%04d', Frame)];
-if exist(tname, 'file')
-    tfid = fopen(tname, 'r');
-    if tfid >= 0
-        tval = fscanf(tfid, '%g', 1);
-        fclose(tfid);
-        if ~isempty(tval)
-            t = tval;
-        end
-    end
-end
 
 [fid, header_text, payload_start] = open_vtu_header(filename);
 fid_cleanup = onCleanup(@() fclose(fid)); %#ok<NASGU>

--- a/matlab/readamrdata_forestclaw_vtu.m
+++ b/matlab/readamrdata_forestclaw_vtu.m
@@ -56,7 +56,7 @@ arrays = parse_data_arrays(header_text);
 % Phase 1: read only topology arrays (geometry + metadata, not field data).
 % Include explicit metadata arrays written by newer versions of the VTU writer.
 topo_names = {'Position', 'connectivity', 'types', 'mpirank', 'blockno', 'patchno', ...
-              'mx_my_mz', 'level', 'xyz_low', 'dx_dy_dz'};
+              'mx_my_mz', 'level', 'xyz_low', 'dx_dy_dz', 'TimeValue'};
 topo = decode_specific_arrays(fid, payload_start, arrays, topo_names);
 
 required_fields = {'Position','connectivity','types','mpirank','blockno','patchno'};
@@ -120,6 +120,18 @@ amr = struct('gridno', {}, ...
 
 field_order = {'meqn', 'aux', 'rhs', 'soln', 'error'};
 
+% Extract global mx_my_mz metadata (same for all patches)
+if isfield(topo, 'mx_my_mz')
+    mxmymz_global = reshape(double(topo.mx_my_mz), 3, []);
+    mx_global = mxmymz_global(1, 1);
+    my_global = mxmymz_global(2, 1);
+    if dim > 2
+        mz_global = mxmymz_global(3, 1);
+    else
+        mz_global = [];
+    end
+end
+
 for ng = 1:num_patches
     amrdata = struct('gridno', [], ...
                      'level', [], ...
@@ -143,16 +155,11 @@ for ng = 1:num_patches
     patch_pts_ids = unique(patch_conn(:));
     patch_pts = points(patch_pts_ids, :);
 
-    % Patch shape (mx, my, mz): prefer explicit FieldData metadata; fall back to inference.
+    % Patch shape (mx, my, mz): use global metadata (same for all patches) or fall back to inference.
     if isfield(topo, 'mx_my_mz')
-        mxmymz = reshape(double(topo.mx_my_mz), 3, []);
-        mx = mxmymz(1, ng);
-        my = mxmymz(2, ng);
-        if dim > 2
-            mz = mxmymz(3, ng);
-        else
-            mz = [];
-        end
+        mx = mx_global;
+        my = my_global;
+        mz = mz_global;
     else
         if dim == 2
             [mx,my] = infer_2d_shape(patch_conn, points);
@@ -251,6 +258,11 @@ else
     for ng = 1:numel(amr)
         amr(ng).level = double(topo.level(ng));
     end
+end
+
+% Extract global time value if available.
+if isfield(topo, 'TimeValue')
+    t = double(topo.TimeValue(1));
 end
 
 if dim == 2

--- a/matlab/readamrdata_forestclaw_vtu.m
+++ b/matlab/readamrdata_forestclaw_vtu.m
@@ -64,20 +64,22 @@ fid_cleanup = onCleanup(@() fclose(fid)); %#ok<NASGU>
 piece = parse_piece_counts(header_text);
 arrays = parse_data_arrays(header_text);
 
-values = decode_appended_arrays_streaming(fid, payload_start, arrays);
+% Phase 1: read only topology arrays (geometry + metadata, not field data).
+topo_names = {'Position', 'connectivity', 'types', 'mpirank', 'blockno', 'patchno'};
+topo = decode_specific_arrays(fid, payload_start, arrays, topo_names);
 
-required_fields = {'Position','connectivity','types','mpirank','blockno','meqn'};
+required_fields = {'Position','connectivity','types','mpirank','blockno','patchno'};
 for ireq = 1:numel(required_fields)
-    if ~isfield(values, required_fields{ireq})
+    if ~isfield(topo, required_fields{ireq})
         error('Required VTU DataArray "%s" is missing in %s.', required_fields{ireq}, filename);
     end
 end
 
 % Convert VTK connectivity to 1-based indexing for MATLAB array access.
-points = reshape(values.Position, 3, []).';
-connectivity = double(values.connectivity) + 1;
+points = reshape(topo.Position, 3, []).';
+connectivity = double(topo.connectivity) + 1;
 connectivity = reshape(connectivity, [], piece.num_cells);
-types = double(values.types(:));
+types = double(topo.types(:));
 
 if dim == 2
     expected_type = 9;
@@ -103,10 +105,13 @@ if size(connectivity,2) ~= piece.num_cells
     error('Cell count mismatch while reading %s.', filename);
 end
 
-% ForestClaw VTU writes patches as disconnected connectivity components.
-component_labels = connected_cell_components(connectivity, size(points,1));
-roots = unique(component_labels, 'stable');
-num_patches = numel(roots);
+% All patches have the same number of cells; compute patch map by arithmetic.
+num_patches = numel(unique(double(topo.patchno(:)), 'sorted'));
+ncells_per_patch = piece.num_cells / num_patches;
+if ncells_per_patch ~= floor(ncells_per_patch)
+    error('num_cells (%d) is not evenly divisible by num_patches (%d) in %s.', ...
+          piece.num_cells, num_patches, filename);
+end
 amr = struct('gridno', {}, ...
              'level', {}, ...
              'blockno', {}, ...
@@ -139,8 +144,9 @@ for ng = 1:num_patches
                      'dy', [], ...
                      'dz', [], ...
                      'data', []);
-    comp_id = roots(ng);
-    cell_ids = find(component_labels == comp_id);
+    % Compute this patch's 1-based cell index range directly from uniform size.
+    cell_start_0 = (ng-1) * ncells_per_patch;  % 0-based offset into flat arrays
+    cell_ids = (cell_start_0+1 : cell_start_0+ncells_per_patch);  % 1-based MATLAB indices
 
     patch_conn = connectivity(:, cell_ids);
     patch_pts_ids = unique(patch_conn(:));
@@ -160,9 +166,9 @@ for ng = 1:num_patches
     end
 
     % Fill legacy AMR metadata expected by plotting/post-processing scripts.
-    amrdata.gridno = ng;
-    amrdata.blockno = int_mode(values.blockno(cell_ids));
-    amrdata.mpirank = int_mode(values.mpirank(cell_ids));
+    amrdata.gridno = double(topo.patchno(cell_ids(1))) + 1;
+    amrdata.blockno = double(topo.blockno(cell_ids(1)));
+    amrdata.mpirank = double(topo.mpirank(cell_ids(1)));
     amrdata.mx = mx;
     amrdata.my = my;
     if dim > 2
@@ -187,21 +193,18 @@ for ng = 1:num_patches
         amrdata.dz = [];
     end
 
+    % Phase 2: seek to this patch's cell slice in each field array and read it.
     patch_data = [];
     for k = 1:numel(field_order)
         fname_k = field_order{k};
-        if isfield(values, fname_k)
-            field_raw = values.(fname_k);
-            % Each field is stored as [ncomp x ncells] after reshape.
-            field_data = reshape(float_array(field_raw), [], piece.num_cells);
-            patch_data = [patch_data; field_data(:, cell_ids)]; %#ok<AGROW>
+        fa = find_array(arrays, fname_k);
+        if ~isempty(fa)
+            raw = read_array_cells(fid, payload_start, fa, cell_ids(1)-1, numel(cell_ids));
+            field_data = reshape(float_array(cast_appended(raw, fa.type, fa.num_components)), [], numel(cell_ids));
+            patch_data = [patch_data; field_data]; %#ok<AGROW>
         end
     end
     amrdata.data = patch_data;
-
-    if isfield(values, 'patchno')
-        amrdata.gridno = int_mode(values.patchno(cell_ids)) + 1;
-    end
 
     amr(ng) = amrdata; %#ok<AGROW>
 end
@@ -295,6 +298,67 @@ if isempty(tok)
     value = '';
 else
     value = tok{1};
+end
+end
+
+% Read only the named DataArrays from the appended section; skip all others.
+function values = decode_specific_arrays(fid, payload_start, arrays, names)
+values = struct();
+for i = 1:numel(arrays)
+    if any(strcmp(arrays(i).Name, names))
+        a = arrays(i);
+        if fseek(fid, payload_start + a.offset, 'bof') ~= 0
+            error('Seek failed for DataArray "%s".', a.Name);
+        end
+        nbytes = double(read_uint64_le_from_fid(fid));
+        raw = fread(fid, nbytes, '*uint8');
+        if numel(raw) < nbytes
+            error('Unexpected end of file reading DataArray "%s".', a.Name);
+        end
+        values.(a.Name) = cast_appended(raw, a.type, a.num_components);
+    end
+end
+end
+
+% Return the arrays entry whose Name matches, or [] if not found.
+function a = find_array(arrays, name)
+a = [];
+for i = 1:numel(arrays)
+    if strcmp(arrays(i).Name, name)
+        a = arrays(i);
+        return;
+    end
+end
+end
+
+% Return the byte width of one scalar element for a VTK type string.
+function n = vtk_type_size(vtk_type)
+switch vtk_type
+    case {'Float64', 'Int64'}
+        n = 8;
+    case {'Float32', 'Int32'}
+        n = 4;
+    case 'UInt8'
+        n = 1;
+    otherwise
+        error('Unknown VTK type "%s".', vtk_type);
+end
+end
+
+% Read a contiguous range of cells from a flat appended DataArray by seeking.
+% cell_start is 0-based; ncells is the count to read.
+function raw = read_array_cells(fid, payload_start, a, cell_start, ncells)
+elem_size = vtk_type_size(a.type);
+bytes_per_cell = a.num_components * elem_size;
+% Skip 8-byte length prefix then jump to cell_start within the data.
+data_offset = payload_start + a.offset + 8 + cell_start * bytes_per_cell;
+if fseek(fid, data_offset, 'bof') ~= 0
+    error('Seek failed reading cells from DataArray "%s".', a.Name);
+end
+nbytes_to_read = ncells * bytes_per_cell;
+raw = fread(fid, nbytes_to_read, '*uint8');
+if numel(raw) < nbytes_to_read
+    error('Unexpected end of file reading cells from DataArray "%s".', a.Name);
 end
 end
 

--- a/src/patches/clawpatch/fclaw_clawpatch_output_vtk.c
+++ b/src/patches/clawpatch/fclaw_clawpatch_output_vtk.c
@@ -62,6 +62,10 @@ typedef struct fclaw2d_vtk_state
     int64_t offset_mpirank, psize_mpirank;
     int64_t offset_blockno, psize_blockno;
     int64_t offset_patchno, psize_patchno;
+    int64_t offset_mxmymz, psize_mxmymz;
+    int64_t offset_level, psize_level;
+    int64_t offset_xyzlow, psize_xyzlow;
+    int64_t offset_dxdydz, psize_dxdydz;
     int64_t offset_meqn, psize_meqn;
     int64_t offset_aux, psize_aux;
     int64_t offset_rhs, psize_rhs;
@@ -152,6 +156,33 @@ fclaw2d_vtk_write_header (fclaw_domain_t * domain, fclaw2d_vtk_state_t * s)
                                 (long long) s->offset_types) < 0;
     retval = retval || fprintf (file, "    </DataArray>\n") < 0;
     retval = retval || fprintf (file, "   </Cells>\n") < 0;
+
+    retval = retval || fprintf (file, "   <FieldData>\n") < 0;
+    retval = retval || fprintf (file, "    <DataArray type=\"Int32\" "
+                                "Name=\"mx_my_mz\" NumberOfComponents=\"3\" NumberOfTuples=\"%lld\" format=\"appended\" "
+                                "offset=\"%lld\">\n",
+                                (long long) domain->global_num_patches,
+                                (long long) s->offset_mxmymz) < 0;
+    retval = retval || fprintf (file, "    </DataArray>\n") < 0;
+    retval = retval || fprintf (file, "    <DataArray type=\"Int32\" "
+                                "Name=\"level\" NumberOfTuples=\"%lld\" format=\"appended\" "
+                                "offset=\"%lld\">\n",
+                                (long long) domain->global_num_patches,
+                                (long long) s->offset_level) < 0;
+    retval = retval || fprintf (file, "    </DataArray>\n") < 0;
+    retval = retval || fprintf (file, "    <DataArray type=\"Float64\" "
+                                "Name=\"xyz_low\" NumberOfComponents=\"3\" NumberOfTuples=\"%lld\" format=\"appended\" "
+                                "offset=\"%lld\">\n",
+                                (long long) domain->global_num_patches,
+                                (long long) s->offset_xyzlow) < 0;
+    retval = retval || fprintf (file, "    </DataArray>\n") < 0;
+    retval = retval || fprintf (file, "    <DataArray type=\"Float64\" "
+                                "Name=\"dx_dy_dz\" NumberOfComponents=\"3\" NumberOfTuples=\"%lld\" format=\"appended\" "
+                                "offset=\"%lld\">\n",
+                                (long long) domain->global_num_patches,
+                                (long long) s->offset_dxdydz) < 0;
+    retval = retval || fprintf (file, "    </DataArray>\n") < 0;
+    retval = retval || fprintf (file, "   </FieldData>\n") < 0;
 
     char field_names[BUFSIZ];
     strncpy(field_names, "meqn", sizeof(field_names));
@@ -562,6 +593,88 @@ write_patchno_cb (fclaw_domain_t * domain, fclaw_patch_t * patch,
 }
 
 static void
+write_mxmymz_cb (fclaw_domain_t * domain, fclaw_patch_t * patch,
+                 int blockno, int patchno, void *user)
+{
+    fclaw_global_iterate_t *g = (fclaw_global_iterate_t *) user;
+    write_field_iter_user_t *iter = (write_field_iter_user_t *) g->user;
+    fclaw2d_vtk_state_t *s = iter->s;
+    int32_t *idata = (int32_t *) s->buf;
+    *idata++ = (int32_t) s->mx;
+    *idata++ = (int32_t) s->my;
+    *idata++ = (int32_t) s->mz;
+    add_to_buffer (s, s->psize_mxmymz);
+}
+
+/* Extract physical grid geometry for a patch; works for both 2D and 3D. */
+static void
+get_patch_geometry (fclaw_global_t * glob, fclaw_patch_t * patch, int dim,
+                    double *xlower, double *ylower, double *zlower,
+                    double *dx, double *dy, double *dz)
+{
+    if (dim == 2)
+    {
+        int mx, my, mbc;
+        fclaw_clawpatch_2d_grid_data (glob, patch, &mx, &my, &mbc,
+                                      xlower, ylower, dx, dy);
+        *zlower = 0.0;
+        *dz = 0.0;
+    }
+    else
+    {
+        int mx, my, mz, mbc;
+        fclaw_clawpatch_3d_grid_data (glob, patch, &mx, &my, &mz, &mbc,
+                                      xlower, ylower, zlower, dx, dy, dz);
+    }
+}
+
+static void
+write_level_cb (fclaw_domain_t * domain, fclaw_patch_t * patch,
+                int blockno, int patchno, void *user)
+{
+    fclaw_global_iterate_t *g = (fclaw_global_iterate_t *) user;
+    write_field_iter_user_t *iter = (write_field_iter_user_t *) g->user;
+    fclaw2d_vtk_state_t *s = iter->s;
+    int32_t *idata = (int32_t *) s->buf;
+    *idata = (int32_t) patch->level;
+    add_to_buffer (s, s->psize_level);
+}
+
+static void
+write_xyzlow_cb (fclaw_domain_t * domain, fclaw_patch_t * patch,
+                 int blockno, int patchno, void *user)
+{
+    fclaw_global_iterate_t *g = (fclaw_global_iterate_t *) user;
+    write_field_iter_user_t *iter = (write_field_iter_user_t *) g->user;
+    fclaw2d_vtk_state_t *s = iter->s;
+    double xlower, ylower, zlower, dx, dy, dz;
+    get_patch_geometry (g->glob, patch, s->dim,
+                        &xlower, &ylower, &zlower, &dx, &dy, &dz);
+    double *ddata = (double *) s->buf;
+    *ddata++ = xlower;
+    *ddata++ = ylower;
+    *ddata++ = zlower;
+    add_to_buffer (s, s->psize_xyzlow);
+}
+
+static void
+write_dxdydz_cb (fclaw_domain_t * domain, fclaw_patch_t * patch,
+                 int blockno, int patchno, void *user)
+{
+    fclaw_global_iterate_t *g = (fclaw_global_iterate_t *) user;
+    write_field_iter_user_t *iter = (write_field_iter_user_t *) g->user;
+    fclaw2d_vtk_state_t *s = iter->s;
+    double xlower, ylower, zlower, dx, dy, dz;
+    get_patch_geometry (g->glob, patch, s->dim,
+                        &xlower, &ylower, &zlower, &dx, &dy, &dz);
+    double *ddata = (double *) s->buf;
+    *ddata++ = dx;
+    *ddata++ = dy;
+    *ddata++ = dz;
+    add_to_buffer (s, s->psize_dxdydz);
+}
+
+static void
 fclaw2d_vtk_write_field (fclaw_global_t * glob, fclaw2d_vtk_state_t * s,
                          int64_t offset_field, int64_t psize_field,
                          fclaw_patch_callback_t cb, void* user)
@@ -727,6 +840,14 @@ fclaw2d_vtk_write_data (fclaw_global_t * glob, fclaw2d_vtk_state_t * s)
                              write_blockno_cb, NULL);
     fclaw2d_vtk_write_field (glob, s, s->offset_patchno, s->psize_patchno,
                              write_patchno_cb, NULL);
+    fclaw2d_vtk_write_field (glob, s, s->offset_mxmymz, s->psize_mxmymz,
+                             write_mxmymz_cb, NULL);
+    fclaw2d_vtk_write_field (glob, s, s->offset_level, s->psize_level,
+                             write_level_cb, NULL);
+    fclaw2d_vtk_write_field (glob, s, s->offset_xyzlow, s->psize_xyzlow,
+                             write_xyzlow_cb, NULL);
+    fclaw2d_vtk_write_field (glob, s, s->offset_dxdydz, s->psize_dxdydz,
+                             write_dxdydz_cb, NULL);
     fclaw2d_vtk_write_field (glob, s, s->offset_meqn, s->psize_meqn,
                              write_field_cb, (void*) s->value_cb);
     fclaw2d_vtk_write_field (glob, s, s->offset_aux, s->psize_aux,
@@ -838,6 +959,10 @@ fclaw_vtk_write_file (int dim, fclaw_global_t * glob, const char *basename,
     s->psize_mpirank = s->cells_per_patch * 4;
     s->psize_blockno = s->cells_per_patch * 4;
     s->psize_patchno = s->cells_per_patch * s->intsize;
+    s->psize_mxmymz = 3 * sizeof (int32_t);
+    s->psize_level = 1 * sizeof (int32_t);
+    s->psize_xyzlow = 3 * sizeof (double);
+    s->psize_dxdydz = 3 * sizeof (double);
     s->psize_meqn = s->cells_per_patch * s->meqn * sizeof (float);
     s->psize_aux = s->cells_per_patch * s->num_aux_fields * sizeof (float);
     s->psize_rhs = s->cells_per_patch * s->rhs_fields * sizeof (float);
@@ -872,7 +997,23 @@ fclaw_vtk_write_file (int dim, fclaw_global_t * glob, const char *basename,
     s->offset_patchno = curr_offset;
     curr_offset += s->ndsize +
         s->psize_patchno * domain->global_num_patches;
-    
+
+    s->offset_mxmymz = curr_offset;
+    curr_offset += s->ndsize +
+        s->psize_mxmymz * domain->global_num_patches;
+
+    s->offset_level = curr_offset;
+    curr_offset += s->ndsize +
+        s->psize_level * domain->global_num_patches;
+
+    s->offset_xyzlow = curr_offset;
+    curr_offset += s->ndsize +
+        s->psize_xyzlow * domain->global_num_patches;
+
+    s->offset_dxdydz = curr_offset;
+    curr_offset += s->ndsize +
+        s->psize_dxdydz * domain->global_num_patches;
+
     s->offset_meqn = curr_offset;
     curr_offset += s->ndsize +
         s->psize_meqn * domain->global_num_patches;

--- a/src/patches/clawpatch/fclaw_clawpatch_output_vtk.c
+++ b/src/patches/clawpatch/fclaw_clawpatch_output_vtk.c
@@ -130,23 +130,23 @@ fclaw2d_vtk_write_header (fclaw_domain_t * domain, fclaw2d_vtk_state_t * s)
     retval = retval || fprintf (file, " <UnstructuredGrid>\n") < 0;
     retval = retval || fprintf (file, "  <FieldData>\n") < 0;
     retval = retval || fprintf (file, "   <DataArray type=\"Int32\" "
-                                "Name=\"mx_my_mz\" NumberOfComponents=\"3\" NumberOfTuples=\"1\" format=\"ascii\">\n") < 0;
+                                "Name=\"patch_dimension\" NumberOfComponents=\"3\" NumberOfTuples=\"1\" format=\"ascii\">\n") < 0;
     retval = retval || fprintf (file, "    %d %d %d\n", s->mx, s->my, s->mz) < 0;
     retval = retval || fprintf (file, "   </DataArray>\n") < 0;
     retval = retval || fprintf (file, "   <DataArray type=\"Int32\" "
-                                "Name=\"level\" NumberOfTuples=\"%lld\" format=\"appended\" "
+                                "Name=\"levels\" NumberOfTuples=\"%lld\" format=\"appended\" "
                                 "offset=\"%lld\">\n",
                                 (long long) domain->global_num_patches,
                                 (long long) s->offset_level) < 0;
     retval = retval || fprintf (file, "   </DataArray>\n") < 0;
     retval = retval || fprintf (file, "   <DataArray type=\"Float64\" "
-                                "Name=\"xyz_low\" NumberOfComponents=\"3\" NumberOfTuples=\"%lld\" format=\"appended\" "
+                                "Name=\"patch_starts\" NumberOfComponents=\"3\" NumberOfTuples=\"%lld\" format=\"appended\" "
                                 "offset=\"%lld\">\n",
                                 (long long) domain->global_num_patches,
                                 (long long) s->offset_xyzlow) < 0;
     retval = retval || fprintf (file, "   </DataArray>\n") < 0;
     retval = retval || fprintf (file, "   <DataArray type=\"Float64\" "
-                                "Name=\"dx_dy_dz\" NumberOfComponents=\"3\" NumberOfTuples=\"%lld\" format=\"appended\" "
+                                "Name=\"patch_spacings\" NumberOfComponents=\"3\" NumberOfTuples=\"%lld\" format=\"appended\" "
                                 "offset=\"%lld\">\n",
                                 (long long) domain->global_num_patches,
                                 (long long) s->offset_dxdydz) < 0;

--- a/src/patches/clawpatch/fclaw_clawpatch_output_vtk.c
+++ b/src/patches/clawpatch/fclaw_clawpatch_output_vtk.c
@@ -62,10 +62,10 @@ typedef struct fclaw2d_vtk_state
     int64_t offset_mpirank, psize_mpirank;
     int64_t offset_blockno, psize_blockno;
     int64_t offset_patchno, psize_patchno;
-    int64_t offset_mxmymz, psize_mxmymz;
     int64_t offset_level, psize_level;
     int64_t offset_xyzlow, psize_xyzlow;
     int64_t offset_dxdydz, psize_dxdydz;
+    double time_value;
     int64_t offset_meqn, psize_meqn;
     int64_t offset_aux, psize_aux;
     int64_t offset_rhs, psize_rhs;
@@ -128,6 +128,34 @@ fclaw2d_vtk_write_header (fclaw_domain_t * domain, fclaw2d_vtk_state_t * s)
                                 "header_type=\"UInt64\" "
                                 ">\n") < 0;
     retval = retval || fprintf (file, " <UnstructuredGrid>\n") < 0;
+    retval = retval || fprintf (file, "  <FieldData>\n") < 0;
+    retval = retval || fprintf (file, "   <DataArray type=\"Int32\" "
+                                "Name=\"mx_my_mz\" NumberOfComponents=\"3\" NumberOfTuples=\"1\" format=\"ascii\">\n") < 0;
+    retval = retval || fprintf (file, "    %d %d %d\n", s->mx, s->my, s->mz) < 0;
+    retval = retval || fprintf (file, "   </DataArray>\n") < 0;
+    retval = retval || fprintf (file, "   <DataArray type=\"Int32\" "
+                                "Name=\"level\" NumberOfTuples=\"%lld\" format=\"appended\" "
+                                "offset=\"%lld\">\n",
+                                (long long) domain->global_num_patches,
+                                (long long) s->offset_level) < 0;
+    retval = retval || fprintf (file, "   </DataArray>\n") < 0;
+    retval = retval || fprintf (file, "   <DataArray type=\"Float64\" "
+                                "Name=\"xyz_low\" NumberOfComponents=\"3\" NumberOfTuples=\"%lld\" format=\"appended\" "
+                                "offset=\"%lld\">\n",
+                                (long long) domain->global_num_patches,
+                                (long long) s->offset_xyzlow) < 0;
+    retval = retval || fprintf (file, "   </DataArray>\n") < 0;
+    retval = retval || fprintf (file, "   <DataArray type=\"Float64\" "
+                                "Name=\"dx_dy_dz\" NumberOfComponents=\"3\" NumberOfTuples=\"%lld\" format=\"appended\" "
+                                "offset=\"%lld\">\n",
+                                (long long) domain->global_num_patches,
+                                (long long) s->offset_dxdydz) < 0;
+    retval = retval || fprintf (file, "   </DataArray>\n") < 0;
+    retval = retval || fprintf (file, "   <DataArray type=\"Float64\" "
+                                "Name=\"TimeValue\" NumberOfTuples=\"1\" format=\"ascii\">\n") < 0;
+    retval = retval || fprintf (file, "    %.*g\n", 17, s->time_value) < 0;
+    retval = retval || fprintf (file, "   </DataArray>\n") < 0;
+    retval = retval || fprintf (file, "  </FieldData>\n") < 0;
     retval = retval || fprintf (file, "  <Piece NumberOfPoints=\"%lld\" "
                                 "NumberOfCells=\"%lld\">\n",
                                 (long long) s->global_num_points,
@@ -156,33 +184,6 @@ fclaw2d_vtk_write_header (fclaw_domain_t * domain, fclaw2d_vtk_state_t * s)
                                 (long long) s->offset_types) < 0;
     retval = retval || fprintf (file, "    </DataArray>\n") < 0;
     retval = retval || fprintf (file, "   </Cells>\n") < 0;
-
-    retval = retval || fprintf (file, "   <FieldData>\n") < 0;
-    retval = retval || fprintf (file, "    <DataArray type=\"Int32\" "
-                                "Name=\"mx_my_mz\" NumberOfComponents=\"3\" NumberOfTuples=\"%lld\" format=\"appended\" "
-                                "offset=\"%lld\">\n",
-                                (long long) domain->global_num_patches,
-                                (long long) s->offset_mxmymz) < 0;
-    retval = retval || fprintf (file, "    </DataArray>\n") < 0;
-    retval = retval || fprintf (file, "    <DataArray type=\"Int32\" "
-                                "Name=\"level\" NumberOfTuples=\"%lld\" format=\"appended\" "
-                                "offset=\"%lld\">\n",
-                                (long long) domain->global_num_patches,
-                                (long long) s->offset_level) < 0;
-    retval = retval || fprintf (file, "    </DataArray>\n") < 0;
-    retval = retval || fprintf (file, "    <DataArray type=\"Float64\" "
-                                "Name=\"xyz_low\" NumberOfComponents=\"3\" NumberOfTuples=\"%lld\" format=\"appended\" "
-                                "offset=\"%lld\">\n",
-                                (long long) domain->global_num_patches,
-                                (long long) s->offset_xyzlow) < 0;
-    retval = retval || fprintf (file, "    </DataArray>\n") < 0;
-    retval = retval || fprintf (file, "    <DataArray type=\"Float64\" "
-                                "Name=\"dx_dy_dz\" NumberOfComponents=\"3\" NumberOfTuples=\"%lld\" format=\"appended\" "
-                                "offset=\"%lld\">\n",
-                                (long long) domain->global_num_patches,
-                                (long long) s->offset_dxdydz) < 0;
-    retval = retval || fprintf (file, "    </DataArray>\n") < 0;
-    retval = retval || fprintf (file, "   </FieldData>\n") < 0;
 
     char field_names[BUFSIZ];
     strncpy(field_names, "meqn", sizeof(field_names));
@@ -592,20 +593,6 @@ write_patchno_cb (fclaw_domain_t * domain, fclaw_patch_t * patch,
     add_to_buffer (s, s->psize_patchno);
 }
 
-static void
-write_mxmymz_cb (fclaw_domain_t * domain, fclaw_patch_t * patch,
-                 int blockno, int patchno, void *user)
-{
-    fclaw_global_iterate_t *g = (fclaw_global_iterate_t *) user;
-    write_field_iter_user_t *iter = (write_field_iter_user_t *) g->user;
-    fclaw2d_vtk_state_t *s = iter->s;
-    int32_t *idata = (int32_t *) s->buf;
-    *idata++ = (int32_t) s->mx;
-    *idata++ = (int32_t) s->my;
-    *idata++ = (int32_t) s->mz;
-    add_to_buffer (s, s->psize_mxmymz);
-}
-
 /* Extract physical grid geometry for a patch; works for both 2D and 3D. */
 static void
 get_patch_geometry (fclaw_global_t * glob, fclaw_patch_t * patch, int dim,
@@ -840,8 +827,6 @@ fclaw2d_vtk_write_data (fclaw_global_t * glob, fclaw2d_vtk_state_t * s)
                              write_blockno_cb, NULL);
     fclaw2d_vtk_write_field (glob, s, s->offset_patchno, s->psize_patchno,
                              write_patchno_cb, NULL);
-    fclaw2d_vtk_write_field (glob, s, s->offset_mxmymz, s->psize_mxmymz,
-                             write_mxmymz_cb, NULL);
     fclaw2d_vtk_write_field (glob, s, s->offset_level, s->psize_level,
                              write_level_cb, NULL);
     fclaw2d_vtk_write_field (glob, s, s->offset_xyzlow, s->psize_xyzlow,
@@ -944,6 +929,7 @@ fclaw_vtk_write_file (int dim, fclaw_global_t * glob, const char *basename,
     s->inttype = s->fits32 ? "Int32" : "Int64";
     s->intsize = s->fits32 ? sizeof (int32_t) : sizeof (int64_t);
     s->ndsize = 8;   /* uint64 */
+    s->time_value = glob->curr_time;
     s->coordinate_cb = coordinate_cb;
     s->value_cb = value_cb;
     s->aux_cb = aux_cb;
@@ -959,7 +945,6 @@ fclaw_vtk_write_file (int dim, fclaw_global_t * glob, const char *basename,
     s->psize_mpirank = s->cells_per_patch * 4;
     s->psize_blockno = s->cells_per_patch * 4;
     s->psize_patchno = s->cells_per_patch * s->intsize;
-    s->psize_mxmymz = 3 * sizeof (int32_t);
     s->psize_level = 1 * sizeof (int32_t);
     s->psize_xyzlow = 3 * sizeof (double);
     s->psize_dxdydz = 3 * sizeof (double);
@@ -997,10 +982,6 @@ fclaw_vtk_write_file (int dim, fclaw_global_t * glob, const char *basename,
     s->offset_patchno = curr_offset;
     curr_offset += s->ndsize +
         s->psize_patchno * domain->global_num_patches;
-
-    s->offset_mxmymz = curr_offset;
-    curr_offset += s->ndsize +
-        s->psize_mxmymz * domain->global_num_patches;
 
     s->offset_level = curr_offset;
     curr_offset += s->ndsize +


### PR DESCRIPTION
Adds `readamrdata_forestclaw_vtu.m` for reading VTU files, and modifies the VTU writer to add a `FieldData` section. This section adds some additional data useful in the Matlab scripts such as time, patch spacings, dimensions, etc.